### PR TITLE
Allow custom rules

### DIFF
--- a/bundle/regal/main.rego
+++ b/bundle/regal/main.rego
@@ -27,3 +27,7 @@ report contains violation if {
 report contains violation if {
 	violation := data.regal.rules[_].report[_]
 }
+
+report contains violation if {
+	violation := data.custom.regal.rules[_].report[_]
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,11 +1,45 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/open-policy-agent/opa/util/test"
+	rio "github.com/styrainc/regal/internal/io"
 )
+
+func TestFindRegalDirectory(t *testing.T) {
+	t.Parallel()
+
+	fs := map[string]string{"/foo/bar/baz/p.rego": ""}
+
+	test.WithTempFS(fs, func(root string) {
+		if err := os.Mkdir(filepath.Join(root, rio.PathSeparator, ".regal"), os.ModePerm); err != nil {
+			t.Fatal(err)
+		}
+
+		path := filepath.Join(root, "/foo/bar/baz")
+
+		_, err := FindRegalDirectory(path)
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	fs = map[string]string{
+		"/foo/bar/baz/p.rego": "",
+		"/foo/bar/bax.json":   "",
+	}
+
+	test.WithTempFS(fs, func(root string) {
+		path := filepath.Join(root, "/foo/bar/baz")
+		_, err := FindRegalDirectory(path)
+		if err == nil {
+			t.Errorf("expected no config file to be found")
+		}
+	})
+}
 
 func TestFindConfig(t *testing.T) {
 	t.Parallel()

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -2,6 +2,7 @@ package linter
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -73,6 +74,31 @@ func TestLintWithUserConfig(t *testing.T) {
 
 	if result.Violations[0].Title != "prefer-snake-case" {
 		t.Errorf("excpected first violation to be 'prefer-snake-case', got %s", result.Violations[0].Title)
+	}
+}
+
+func TestLintWithCustomRule(t *testing.T) {
+	t.Parallel()
+
+	policy := `package p`
+
+	userBundle := LoaderResultFromString(policy)
+
+	linter := NewLinter().
+		WithAddedBundle(test.GetRegalBundle(t)).
+		WithCustomRules([]string{filepath.Join("testdata", "custom.rego")})
+
+	result, err := linter.Lint(context.Background(), userBundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Violations) != 1 {
+		t.Errorf("expected 1 violation, got %d", len(result.Violations))
+	}
+
+	if result.Violations[0].Title != "acme-corp-package" {
+		t.Errorf("excpected first violation to be 'acme-corp-package', got %s", result.Violations[0].Title)
 	}
 }
 

--- a/pkg/linter/testdata/custom.rego
+++ b/pkg/linter/testdata/custom.rego
@@ -1,0 +1,31 @@
+package custom.regal.rules.naming
+
+import future.keywords.contains
+import future.keywords.if
+
+import data.regal
+
+# METADATA
+# title: acme-corp-package
+# description: All packages must use "acme.corp" base name
+# related_resources:
+# - description: documentation
+#   ref: https://www.acmecorp.example.org/docs/regal/package
+# custom:
+#   category: naming
+report contains violation if {
+	not acme_corp_package
+	not system_log_package
+
+	violation := regal.fail(rego.metadata.rule(), {})
+}
+
+acme_corp_package if {
+	input["package"].path[1].value == "acme"
+	input["package"].path[2].value == "corp"
+}
+
+system_log_package if {
+	input["package"].path[1].value == "system"
+	input["package"].path[2].value == "log"
+}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -20,7 +20,7 @@ type Violation struct {
 	Title            string            `json:"title"`
 	Description      string            `json:"description"`
 	Category         string            `json:"category"`
-	RelatedResources []RelatedResource `json:"related_resources"`
+	RelatedResources []RelatedResource `json:"related_resources,omitempty"`
 	Location         Location          `json:"location,omitempty"`
 }
 


### PR DESCRIPTION
Custom rules may now be provided either in `.regal/rules` or explicitly using the `--rules` option for `regal lint`.

Resolves #21