### PR TITLE
Add opa-fmt rule

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,6 +16,7 @@ linters:
     - rowserrcheck
     - wastedassign
     # annoying
+    - goerr113
     - varnamelen
     - nonamedreturns
     - testpackage

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Regal is a linter for Rego, with the goal of making your Rego magnificent!
 
 \- [Merriam Webster](https://www.merriam-webster.com/dictionary/regal)
 
+## Goals
+
+- Identify common mistakes, bugs and inefficiencies in Rego policies, and suggest better approaches
+- Provide advice on best practices, coding style, and tooling
+- Allow users, teams and organizations to enforce custom rules on their policy code
+
 Regal rules are to as large extent as possible
 [written in Rego](https://www.styra.com/blog/linting-rego-with-rego/) themselves,
 using the JSON representation of the Rego abstract syntax tree (AST) as input, a

--- a/build/builtin_metadata.rego
+++ b/build/builtin_metadata.rego
@@ -5,23 +5,23 @@
 #   data available in Regal policies under `data.builtins`
 package build.metadata
 
-import future.keywords.in
 import future.keywords.if
+import future.keywords.in
 
 response := http.send({
-    "method": "get",
-    "url": "https://raw.githubusercontent.com/open-policy-agent/opa/main/builtin_metadata.json",
-    "force_json_decode": true,
-    "raise_error": false,
+	"method": "get",
+	"url": "https://raw.githubusercontent.com/open-policy-agent/opa/main/builtin_metadata.json",
+	"force_json_decode": true,
+	"raise_error": false,
 })
 
 something_wrong if {
-    response.status_code != 200
-    print("error in response")
-    print(response)
+	response.status_code != 200
+	print("error in response")
+	print(response)
 }
 
 builtin_metadata[builtin] := object.filter(attributes, ["args", "result"]) if {
-    not something_wrong
-    some builtin, attributes in object.remove(response.body, ["_categories"])
+	not something_wrong
+	some builtin, attributes in object.remove(response.body, ["_categories"])
 }

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -19,6 +19,8 @@ rules:
   style:
     prefer-snake-case:
       enabled: true
+    opa-fmt:
+      enabled: true
   testing:
     test-outside-test-package:
       enabled: true

--- a/bundle/regal/main.rego
+++ b/bundle/regal/main.rego
@@ -10,7 +10,7 @@ report contains violation if {
 	violation := {
 		"category": "error",
 		"title": "invalid-input",
-		"description": "provided input must be a JSON AST"
+		"description": "provided input must be a JSON AST",
 	}
 }
 
@@ -20,7 +20,7 @@ report contains violation if {
 	violation := {
 		"category": "error",
 		"title": "invalid-input",
-		"description": "provided input must be a JSON AST"
+		"description": "provided input must be a JSON AST",
 	}
 }
 

--- a/bundle/regal/rules/assignment/assignment.rego
+++ b/bundle/regal/rules/assignment/assignment.rego
@@ -16,7 +16,7 @@ import data.regal.result
 # custom:
 #   category: assignment
 report contains violation if {
-    config.for_rule(rego.metadata.rule()).enabled == true
+	config.for_rule(rego.metadata.rule()).enabled == true
 
 	some rule in input.rules
 	rule["default"] == true

--- a/bundle/regal/rules/comments/comments.rego
+++ b/bundle/regal/rules/comments/comments.rego
@@ -10,6 +10,7 @@ import data.regal.result
 # TODO: Normalize Text and Location -> text and location
 
 todo_identifiers := ["todo", "TODO", "fixme", "FIXME"]
+
 todo_pattern := sprintf("(%s)", [concat("|", todo_identifiers)])
 
 # METADATA
@@ -23,9 +24,9 @@ todo_pattern := sprintf("(%s)", [concat("|", todo_identifiers)])
 report contains violation if {
 	config.for_rule(rego.metadata.rule()).enabled == true
 
-    some comment in input.comments
-    text := base64.decode(comment.Text)
-    regex.match(todo_pattern, text)
+	some comment in input.comments
+	text := base64.decode(comment.Text)
+	regex.match(todo_pattern, text)
 
-    violation := result.fail(rego.metadata.rule(), result.location(comment))
+	violation := result.fail(rego.metadata.rule(), result.location(comment))
 }

--- a/bundle/regal/rules/comments/comments_test.rego
+++ b/bundle/regal/rules/comments/comments_test.rego
@@ -12,10 +12,10 @@ test_fail_todo_comment if {
 		"description": "Avoid TODO comments",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": "https://docs.styra.com/regal/rules/todo-comment"
+			"ref": "https://docs.styra.com/regal/rules/todo-comment",
 		}],
 		"title": "todo-comment",
-        "location": {"col": 1, "file": "policy.rego", "row": 8},
+		"location": {"col": 1, "file": "policy.rego", "row": 8},
 	}}
 }
 
@@ -25,10 +25,10 @@ test_fail_fixme_comment if {
 		"description": "Avoid TODO comments",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": "https://docs.styra.com/regal/rules/todo-comment"
+			"ref": "https://docs.styra.com/regal/rules/todo-comment",
 		}],
 		"title": "todo-comment",
-        "location": {"col": 1, "file": "policy.rego", "row": 8},
+		"location": {"col": 1, "file": "policy.rego", "row": 8},
 	}}
 }
 
@@ -36,7 +36,7 @@ test_success_no_todo_comment if {
 	report(`# This code is great`) == set()
 }
 
-report(snippet) := report {
+report(snippet) := report if {
 	report := comments.report with input as ast.with_future_keywords(snippet)
 		with config.for_rule as {"enabled": true}
 }

--- a/bundle/regal/rules/functions/functions_test.rego
+++ b/bundle/regal/rules/functions/functions_test.rego
@@ -36,7 +36,7 @@ test_success_function_references_no_input_or_data if {
 	report(`f(x) { x == true }`) == set()
 }
 
-report(snippet) := report {
+report(snippet) := report if {
 	report := functions.report with input as ast.with_future_keywords(snippet)
 		with config.for_rule as {"enabled": true}
 }

--- a/bundle/regal/rules/imports/imports.rego
+++ b/bundle/regal/rules/imports/imports.rego
@@ -27,7 +27,7 @@ report contains violation if {
 	imported.path.value[0].type == "var"
 	imported.path.value[0].value == "future"
 	imported.path.value[1].type == "string"
-    imported.path.value[1].value == "keywords"
+	imported.path.value[1].value == "keywords"
 
 	violation := result.fail(rego.metadata.rule(), {"location": imported.path.value[0].location})
 }
@@ -49,7 +49,7 @@ report contains violation if {
 
 	# If we want to allow aliasing input, eg `import input as tfplan`:
 	# count(imported.path.value) == 1
-    # imported.alias
+	# imported.alias
 
 	violation := result.fail(rego.metadata.rule(), {"location": imported.path.value[0].location})
 }

--- a/bundle/regal/rules/imports/imports_test.rego
+++ b/bundle/regal/rules/imports/imports_test.rego
@@ -12,7 +12,7 @@ test_fail_future_keywords_import_wildcard if {
 		"description": "Use explicit future keyword imports",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": "https://docs.styra.com/regal/rules/implicit-future-keywords"
+			"ref": "https://docs.styra.com/regal/rules/implicit-future-keywords",
 		}],
 		"title": "implicit-future-keywords",
 		"location": {"col": 8, "file": "policy.rego", "row": 8},
@@ -37,7 +37,7 @@ test_fail_import_input if {
 		"description": "Avoid importing input",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": "https://docs.styra.com/regal/rules/avoid-importing-input"
+			"ref": "https://docs.styra.com/regal/rules/avoid-importing-input",
 		}],
 		"title": "avoid-importing-input",
 		"location": {"col": 8, "file": "policy.rego", "row": 8},
@@ -50,7 +50,7 @@ test_fail_import_data if {
 		"description": "Redundant import of data",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": "https://docs.styra.com/regal/rules/redundant-data-import"
+			"ref": "https://docs.styra.com/regal/rules/redundant-data-import",
 		}],
 		"title": "redundant-data-import",
 		"location": {"col": 8, "file": "policy.rego", "row": 8},
@@ -63,7 +63,7 @@ test_fail_import_data_aliased if {
 		"description": "Redundant import of data",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": "https://docs.styra.com/regal/rules/redundant-data-import"
+			"ref": "https://docs.styra.com/regal/rules/redundant-data-import",
 		}],
 		"title": "redundant-data-import",
 		"location": {"col": 8, "file": "policy.rego", "row": 8},
@@ -74,7 +74,7 @@ test_success_import_data_path if {
 	report(`import data.something`) == set()
 }
 
-report(snippet) := report {
+report(snippet) := report if {
 	report := imports.report with input as ast.with_future_keywords(snippet)
 		with config.for_rule as {"enabled": true}
 }

--- a/bundle/regal/rules/rules/rules.rego
+++ b/bundle/regal/rules/rules/rules.rego
@@ -5,10 +5,10 @@ import future.keywords.if
 import future.keywords.in
 
 import data.regal.config
-import data.regal.result
 import data.regal.opa.builtins
+import data.regal.result
 
-builtin_names := {builtin | some builtin, _  in builtins}
+builtin_names := {builtin | some builtin, _ in builtins}
 
 # METADATA
 # title: rule-shadows-builtin

--- a/bundle/regal/rules/rules/rules_test.rego
+++ b/bundle/regal/rules/rules/rules_test.rego
@@ -6,23 +6,23 @@ import data.regal.ast
 import data.regal.config
 import data.regal.rules.rules
 
-test_fail_rule_name_shadows_builtin {
+test_fail_rule_name_shadows_builtin if {
 	report(`or := 1`) == {{
 		"category": "rules",
 		"description": "Rule name shadows built-in",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": "https://docs.styra.com/regal/rules/rule-shadows-builtin"
+			"ref": "https://docs.styra.com/regal/rules/rule-shadows-builtin",
 		}],
 		"title": "rule-shadows-builtin",
 		"location": {"col": 1, "file": "policy.rego", "row": 8},
 	}}
 }
 
-test_success_rule_name_does_not_shadows_builtin {
+test_success_rule_name_does_not_shadows_builtin if {
 	report(`foo := 1`) == set()
 }
 
-report(snippet) := report {
+report(snippet) := report if {
 	report := rules.report with input as ast.with_future_keywords(snippet) with config.for_rule as {"enabled": true}
 }

--- a/bundle/regal/rules/style/style_test.rego
+++ b/bundle/regal/rules/style/style_test.rego
@@ -11,15 +11,13 @@ snake_case_violation := {
 	"description": "Prefer snake_case for names",
 	"related_resources": [{
 		"description": "documentation",
-		"ref": "https://docs.styra.com/regal/rules/prefer-snake-case"
+		"ref": "https://docs.styra.com/regal/rules/prefer-snake-case",
 	}],
 	"title": "prefer-snake-case",
 }
 
 test_fail_camel_cased_rule_name if {
-	report(`camelCase := 5`) == {
-		object.union(snake_case_violation, {"location": {"col": 0, "file": "policy.rego", "row": 8}})
-	}
+	report(`camelCase := 5`) == {object.union(snake_case_violation, {"location": {"col": 0, "file": "policy.rego", "row": 8}})}
 }
 
 test_success_snake_cased_rule_name if {
@@ -27,9 +25,7 @@ test_success_snake_cased_rule_name if {
 }
 
 test_fail_camel_cased_some_declaration if {
-	report(`p {some fooBar; input[fooBar]}`) == {
-		object.union(snake_case_violation, {"location": {"col": 9, "file": "policy.rego", "row": 8}})
-	}
+	report(`p {some fooBar; input[fooBar]}`) == {object.union(snake_case_violation, {"location": {"col": 9, "file": "policy.rego", "row": 8}})}
 }
 
 test_success_snake_cased_some_declaration if {
@@ -37,9 +33,7 @@ test_success_snake_cased_some_declaration if {
 }
 
 test_fail_camel_cased_multiple_some_declaration if {
-	report(`p {some x, foo_bar, fooBar; x = 1; foo_bar = 2; input[fooBar]}`) == {
-		object.union(snake_case_violation, {"location": {"col": 21, "file": "policy.rego", "row": 8}})
-	}
+	report(`p {some x, foo_bar, fooBar; x = 1; foo_bar = 2; input[fooBar]}`) == {object.union(snake_case_violation, {"location": {"col": 21, "file": "policy.rego", "row": 8}})}
 }
 
 test_success_snake_cased_multiple_some_declaration if {
@@ -47,15 +41,11 @@ test_success_snake_cased_multiple_some_declaration if {
 }
 
 test_fail_camel_cased_var_assignment if {
-	report(`allow { camelCase := 5 }`) == {
-		object.union(snake_case_violation, {"location": {"col": 9, "file": "policy.rego", "row": 8}})
-	}
+	report(`allow { camelCase := 5 }`) == {object.union(snake_case_violation, {"location": {"col": 9, "file": "policy.rego", "row": 8}})}
 }
 
 test_fail_camel_cased_multiple_var_assignment if {
-	report(`allow { snake_case := "foo"; camelCase := 5 }`) == {
-		object.union(snake_case_violation, {"location": {"col": 30, "file": "policy.rego", "row": 8}})
-	}
+	report(`allow { snake_case := "foo"; camelCase := 5 }`) == {object.union(snake_case_violation, {"location": {"col": 30, "file": "policy.rego", "row": 8}})}
 }
 
 test_success_snake_cased_var_assignment if {
@@ -63,21 +53,15 @@ test_success_snake_cased_var_assignment if {
 }
 
 test_fail_camel_cased_some_in_value if {
-	report(`allow { some cC in input }`) == {
-		object.union(snake_case_violation, {"location": {"col": 14, "file": "policy.rego", "row": 8}})
-	}
+	report(`allow { some cC in input }`) == {object.union(snake_case_violation, {"location": {"col": 14, "file": "policy.rego", "row": 8}})}
 }
 
 test_fail_camel_cased_some_in_key_value if {
-	report(`allow { some cC, sc in input }`) == {
-		object.union(snake_case_violation, {"location": {"col": 14, "file": "policy.rego", "row": 8}})
-	}
+	report(`allow { some cC, sc in input }`) == {object.union(snake_case_violation, {"location": {"col": 14, "file": "policy.rego", "row": 8}})}
 }
 
 test_fail_camel_cased_some_in_key_value_2 if {
-	report(`allow { some sc, cC in input }`) == {
-		object.union(snake_case_violation, {"location": {"col": 18, "file": "policy.rego", "row": 8}})
-	}
+	report(`allow { some sc, cC in input }`) == {object.union(snake_case_violation, {"location": {"col": 18, "file": "policy.rego", "row": 8}})}
 }
 
 test_success_snake_cased_some_in if {
@@ -85,21 +69,17 @@ test_success_snake_cased_some_in if {
 }
 
 test_fail_camel_cased_every_value if {
-	report(`allow { every cC in input { cC == 1 } }`) == {
-		object.union(snake_case_violation, {"location": {"col": 15, "file": "policy.rego", "row": 8}})
-	}
+	report(`allow { every cC in input { cC == 1 } }`) == {object.union(snake_case_violation, {"location": {"col": 15, "file": "policy.rego", "row": 8}})}
 }
 
 test_fail_camel_cased_every_key if {
-	report(`allow { every cC, sc in input { cC == 1; print(sc) } }`) == {
-		object.union(snake_case_violation, {"location": {"col": 15, "file": "policy.rego", "row": 8}})
-	}
+	report(`allow { every cC, sc in input { cC == 1; print(sc) } }`) == {object.union(snake_case_violation, {"location": {"col": 15, "file": "policy.rego", "row": 8}})}
 }
 
 test_success_snake_cased_every if {
 	report(`allow { every sc in input { sc == 1 } }`) == set()
 }
 
-report(snippet) := report {
+report(snippet) := report if {
 	report := style.report with input as ast.with_future_keywords(snippet) with config.for_rule as {"enabled": true}
 }

--- a/bundle/regal/rules/testing/testing.rego
+++ b/bundle/regal/rules/testing/testing.rego
@@ -24,8 +24,8 @@ report contains violation if {
 
 	not endswith(package_name, "_test")
 
-    some rule in input.rules
-    startswith(rule.head.name, "test_")
+	some rule in input.rules
+	startswith(rule.head.name, "test_")
 
 	violation := result.fail(rego.metadata.rule(), result.location(rule.head))
 }

--- a/bundle/regal/rules/testing/testing_test.rego
+++ b/bundle/regal/rules/testing/testing_test.rego
@@ -12,7 +12,7 @@ test_fail_test_outside_test_package if {
 		"description": "Test outside of test package",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": "https://docs.styra.com/regal/rules/test-outside-test-package"
+			"ref": "https://docs.styra.com/regal/rules/test-outside-test-package",
 		}],
 		"title": "test-outside-test-package",
 		"location": {"col": 1, "file": "policy.rego", "row": 8},
@@ -29,6 +29,6 @@ test_success_test_inside_test_package if {
 	result == set()
 }
 
-report(snippet) := report {
+report(snippet) := report if {
 	report := testing.report with input as ast.with_future_keywords(snippet) with config.for_rule as {"enabled": true}
 }

--- a/bundle/regal/rules/variables/variables.rego
+++ b/bundle/regal/rules/variables/variables.rego
@@ -20,13 +20,13 @@ report contains violation if {
 
 	some rule in input.rules
 
-    # Single expression in rule body
-    # There's going to be a few cases where more expressions
-    # are in the body and it still "unconditional", like e.g
-    # a `print` call.. but let's keep it simple for now
+	# Single expression in rule body
+	# There's going to be a few cases where more expressions
+	# are in the body and it still "unconditional", like e.g
+	# a `print` call.. but let's keep it simple for now
 	count(rule.body) == 1
 
-    # Var assignment in rule head
+	# Var assignment in rule head
 	rule.head.value.type == "var"
 	rule_head_var := rule.head.value.value
 
@@ -35,14 +35,14 @@ report contains violation if {
 	not rule.body[0]["with"]
 
 	# Which is an assignment (= or :=)
-    terms := rule.body[0].terms
+	terms := rule.body[0].terms
 	terms[0].type == "ref"
 	terms[0].value[0].type == "var"
 	terms[0].value[0].value in {"eq", "assign"}
 
-    # Of var declared in rule head
+	# Of var declared in rule head
 	terms[1].type == "var"
-    terms[1].value == rule_head_var
+	terms[1].value == rule_head_var
 
-    violation := result.fail(rego.metadata.rule(), {"location": rule.head.value.location})
+	violation := result.fail(rego.metadata.rule(), {"location": rule.head.value.location})
 }

--- a/bundle/regal/rules/variables/variables_test.rego
+++ b/bundle/regal/rules/variables/variables_test.rego
@@ -40,7 +40,7 @@ test_success_unconditional_assignment_but_with_in_body if {
 	report(`x := y { y := 5 with input as 1 }`) == set()
 }
 
-report(snippet) := report {
+report(snippet) := report if {
 	report := variables.report with input as ast.with_future_keywords(snippet)
 		with config.for_rule as {"enabled": true}
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/google/flatbuffers v1.12.1 h1:MVlul7pQNoDzWRLTw5imwYsl+usrS1TXG2H4jg6ImGw=
+github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
+github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -61,6 +61,16 @@ func MustLoadRegalBundlePath(path string) bundle.Bundle {
 	return regalBundle
 }
 
+// MustJSON parses JSON from reader, exit on failure.
+func MustJSON(from any) []byte {
+	bs, err := json.MarshalIndent(from, "", "   ")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return bs
+}
+
 // JSONRoundTrip convert any value to JSON and back again.
 func JSONRoundTrip(from any, to any) error {
 	bs, err := json.Marshal(from)
@@ -68,8 +78,7 @@ func JSONRoundTrip(from any, to any) error {
 		return fmt.Errorf("failed JSON marshalling %w", err)
 	}
 
-	//nolint:wrapcheck
-	return json.Unmarshal(bs, to)
+	return json.Unmarshal(bs, to) //nolint:wrapcheck
 }
 
 // MustYAMLToMap creates a map from reader, expecting YAML content, or fail.

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -6,8 +6,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
 	rio "github.com/styrainc/regal/internal/io"
+	"github.com/styrainc/regal/internal/parse"
+	"github.com/styrainc/regal/pkg/rules"
 )
 
 const regalBundleDir = "../../bundle"
@@ -33,4 +36,11 @@ func GetRegalBundle(t *testing.T) bundle.Bundle {
 	})
 
 	return *regalBundle
+}
+
+func InputPolicy(filename string, policy string) rules.Input {
+	filebytes := map[string][]byte{filename: []byte(policy)}
+	modules := map[string]*ast.Module{filename: parse.MustParseModule(policy)}
+
+	return rules.NewInput(filebytes, modules)
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,5 +1,10 @@
 package util
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Keys returns slice of keys from map.
 func Keys[K comparable, V any](m map[K]V) []K {
 	ks := make([]K, len(m))
@@ -11,4 +16,30 @@ func Keys[K comparable, V any](m map[K]V) []K {
 	}
 
 	return ks
+}
+
+// SearchMap searches map for value at provided path.
+func SearchMap(object map[string]any, path []string) (any, error) {
+	current := object
+	traversed := make([]string, 0, len(path))
+
+	for i, p := range path {
+		var ok bool
+		if i == len(path)-1 {
+			value, ok := current[p]
+			if ok {
+				return value, nil
+			}
+
+			return nil, fmt.Errorf("no '%v' attribute at path '%v'", p, strings.Join(traversed, "."))
+		}
+
+		if current, ok = current[p].(map[string]any); !ok {
+			return nil, fmt.Errorf("no '%v' attribute at path '%v'", p, strings.Join(traversed, "."))
+		}
+
+		traversed = append(traversed, p)
+	}
+
+	return current, nil
 }

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -6,26 +6,24 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/open-policy-agent/opa/ast"
 	rio "github.com/styrainc/regal/internal/io"
-	"github.com/styrainc/regal/internal/parse"
 	"github.com/styrainc/regal/internal/test"
 )
 
 func TestLintBasic(t *testing.T) {
 	t.Parallel()
 
-	policy := parse.MustParseModule(`package p
-	# TODO: fix this
-	camelCase {
-		true
-	}`)
+	policy := `package p
+
+# TODO: fix this
+camelCase {
+	1 == 1
+}
+`
 
 	linter := NewLinter().WithAddedBundle(test.GetRegalBundle(t))
 
-	result, err := linter.Lint(context.Background(), map[string]*ast.Module{
-		"p.rego": policy,
-	})
+	result, err := linter.Lint(context.Background(), test.InputPolicy("p.rego", policy))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,11 +44,13 @@ func TestLintBasic(t *testing.T) {
 func TestLintWithUserConfig(t *testing.T) {
 	t.Parallel()
 
-	policy := parse.MustParseModule(`package p
-	# TODO: fix this
-	camelCase {
-		true
-	}`)
+	policy := `package p
+
+# TODO: fix this
+camelCase {
+	1 == 1
+}
+`
 
 	configRaw := `rules:
   comments:
@@ -63,9 +63,7 @@ func TestLintWithUserConfig(t *testing.T) {
 		WithUserConfig(config).
 		WithAddedBundle(test.GetRegalBundle(t))
 
-	result, err := linter.Lint(context.Background(), map[string]*ast.Module{
-		"p.rego": policy,
-	})
+	result, err := linter.Lint(context.Background(), test.InputPolicy("p.rego", policy))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,15 +80,13 @@ func TestLintWithUserConfig(t *testing.T) {
 func TestLintWithCustomRule(t *testing.T) {
 	t.Parallel()
 
-	policy := parse.MustParseModule(`package p`)
+	policy := "package p\n"
 
 	linter := NewLinter().
 		WithAddedBundle(test.GetRegalBundle(t)).
 		WithCustomRules([]string{filepath.Join("testdata", "custom.rego")})
 
-	result, err := linter.Lint(context.Background(), map[string]*ast.Module{
-		"p.rego": policy,
-	})
+	result, err := linter.Lint(context.Background(), test.InputPolicy("p.rego", policy))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/rules/fmt.go
+++ b/pkg/rules/fmt.go
@@ -1,0 +1,69 @@
+package rules
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/open-policy-agent/opa/format"
+	"github.com/styrainc/regal/pkg/report"
+)
+
+type OpaFmtRule struct{}
+
+const (
+	title                       = "opa-fmt"
+	description                 = "File should be formatted with `opa fmt`"
+	category                    = "style"
+	relatedResourcesDescription = "documentation"
+	relatedResourcesRef         = "https://docs.styra.com/regal/rules/opa-fmt"
+)
+
+func NewOpaFmtRule() *OpaFmtRule {
+	return &OpaFmtRule{}
+}
+
+func (f *OpaFmtRule) Run(ctx context.Context, input Input) (*report.Report, error) {
+	result := &report.Report{}
+
+	for _, filename := range input.FileNames {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("timeout when running %s rule: %w", title, ctx.Err())
+		default:
+			module := input.Modules[filename]
+			unformatted := input.FileBytes[filename]
+
+			formatted, err := format.Ast(module)
+			if err != nil {
+				return nil, fmt.Errorf("failed to format module %s: %w", filename, err)
+			}
+
+			if !bytes.Equal(formatted, unformatted) {
+				violation := report.Violation{
+					Title:       title,
+					Description: description,
+					Category:    category,
+					RelatedResources: []report.RelatedResource{{
+						Description: relatedResourcesDescription,
+						Reference:   relatedResourcesRef,
+					}},
+					Location: report.Location{
+						File: filename,
+					},
+				}
+				result.Violations = append(result.Violations, violation)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func (f *OpaFmtRule) Name() string {
+	return title
+}
+
+func (f *OpaFmtRule) Category() string {
+	return category
+}

--- a/pkg/rules/fmt_test.go
+++ b/pkg/rules/fmt_test.go
@@ -1,0 +1,55 @@
+package rules_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/styrainc/regal/internal/test"
+	"github.com/styrainc/regal/pkg/rules"
+)
+
+func TestFmtRuleFail(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	policy := "  package p "
+
+	result, err := rules.NewOpaFmtRule().Run(ctx, test.InputPolicy("p.rego", policy))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Violations) != 1 {
+		t.Errorf("expected 1 violation, got %d", len(result.Violations))
+	}
+
+	if result.Violations[0].Title != "opa-fmt" {
+		t.Errorf("expected violation title to be 'opa-fmt', got %s", result.Violations[0].Title)
+	}
+
+	if result.Violations[0].Category != "style" {
+		t.Errorf("expected violation category to be 'style', got %s", result.Violations[0].Category)
+	}
+
+	if result.Violations[0].Location.File != "p.rego" {
+		t.Errorf("expected violation location file to be 'p.rego', got %s", result.Violations[0].Location.File)
+	}
+}
+
+func TestFmtRuleSuccess(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	policy := "package p\n"
+
+	result, err := rules.NewOpaFmtRule().Run(ctx, test.InputPolicy("p.rego", policy))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Violations) != 0 {
+		t.Errorf("expected 0 violation, got %d", len(result.Violations))
+	}
+}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -1,0 +1,75 @@
+package rules
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/bundle"
+	"github.com/open-policy-agent/opa/loader"
+	"github.com/styrainc/regal/internal/parse"
+	"github.com/styrainc/regal/internal/util"
+	"github.com/styrainc/regal/pkg/report"
+)
+
+// Input represents the input for a linter evaluation.
+type Input struct {
+	// FileNames is used to maintain consistent order between runs.
+	FileNames []string
+	// FileBytes carries the raw bytes of each file
+	FileBytes map[string][]byte
+	// Modules is the set of modules to lint.
+	Modules map[string]*ast.Module
+}
+
+// Rule represents a linter rule.
+type Rule interface {
+	// Run runs the rule on the provided input.
+	Run(context.Context, Input) (*report.Report, error)
+	// Name returns the name of the rule.
+	Name() string
+	// Category returns the category of the rule.
+	Category() string
+}
+
+// NewInput creates a new Input from a set of modules.
+func NewInput(fileBytes map[string][]byte, modules map[string]*ast.Module) Input {
+	// Maintain order across runs
+	filenames := util.Keys(modules)
+	sort.Strings(filenames)
+
+	return Input{
+		FileBytes: fileBytes,
+		FileNames: filenames,
+		Modules:   modules,
+	}
+}
+
+// InputFromPaths creates a new Input from a set of file or directory paths.
+func InputFromPaths(paths []string) (Input, error) {
+	policyPaths, err := loader.FilteredPaths(paths, func(_ string, info os.FileInfo, depth int) bool {
+		return !info.IsDir() && !strings.HasSuffix(info.Name(), bundle.RegoExt)
+	})
+	if err != nil {
+		return Input{}, fmt.Errorf("failed to load policy from provided args: %w", err)
+	}
+
+	filebytes := make(map[string][]byte, len(policyPaths))
+	modules := make(map[string]*ast.Module, len(policyPaths))
+
+	for _, path := range policyPaths {
+		result, err := loader.RegoWithOpts(path, parse.ParserOptions())
+		if err != nil {
+			// TODO: Keep running and collect errors instead?
+			return Input{}, err //nolint:wrapcheck
+		}
+
+		filebytes[result.Name] = result.Raw
+		modules[result.Name] = result.Parsed
+	}
+
+	return NewInput(filebytes, modules), nil
+}


### PR DESCRIPTION
As this was the first linter rule in Go, it took quite some plumbing to get right. I'd expect (and hope!) future Go rules will be less demanding.

I've also refactored the input passed to the various linting functions so that it now includes the raw data from the original file as well. This was needed for comparison for `opa fmt`, but will also be useful later for linter rules that need to work on data not found in the AST.

The .rego file changes here can largely be ignored, as the only change is running the formatter on them.

Resolves #40