### PR TITLE
Add reporter interface and implementations

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,6 +25,7 @@ linters:
     - godox
     - exhaustruct
     - cyclop
+    - ireturn
 linters-settings:
   tagliatelle:
     case:

--- a/bundle/regal/result.rego
+++ b/bundle/regal/result.rego
@@ -29,4 +29,5 @@ location(x) := {"location": location} {
 location(x) := {} {
 	not x.location
 	not x.Location
+	count(x.ref) != 1
 }

--- a/bundle/regal/rules/style/style_test.rego
+++ b/bundle/regal/rules/style/style_test.rego
@@ -17,7 +17,7 @@ snake_case_violation := {
 }
 
 test_fail_camel_cased_rule_name if {
-	report(`camelCase := 5`) == {object.union(snake_case_violation, {"location": {"col": 0, "file": "policy.rego", "row": 8}})}
+	report(`camelCase := 5`) == {object.union(snake_case_violation, {"location": {"col": 1, "file": "policy.rego", "row": 8}})}
 }
 
 test_success_snake_cased_rule_name if {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/styrainc/regal
 go 1.20
 
 require (
+	github.com/gosuri/uitable v0.0.4
+	github.com/imdario/mergo v0.3.15
 	github.com/open-policy-agent/opa v0.50.2
 	github.com/spf13/cobra v1.6.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -11,15 +13,20 @@ require (
 require (
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/agnivade/levenshtein v1.1.1 // indirect
+	github.com/fatih/color v1.15.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
-	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.18 // indirect
+	github.com/mattn/go-runewidth v0.0.14 // indirect
+	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
+	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/yashtewari/glob-intersection v0.1.0 // indirect
+	golang.org/x/sys v0.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/dgraph-io/ristretto v0.1.1 h1:6CWw5tJNgpegArSHpNHJKldNeq03FQCwYvfMVWa
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
+github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/foxcpp/go-mockdns v1.0.0 h1:7jBqxd3WDWwi/6WhDvacvH1XsN3rOLXyHM1uhvIx6FI=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -27,6 +29,8 @@ github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/google/flatbuffers v1.12.1 h1:MVlul7pQNoDzWRLTw5imwYsl+usrS1TXG2H4jg6ImGw=
+github.com/gosuri/uitable v0.0.4 h1:IG2xLKRvErL3uhY6e1BylFzG+aJiwQviDDTfOKeKTpY=
+github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
 github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
@@ -35,6 +39,13 @@ github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.18 h1:DOKFKCQ7FNG2L1rbrmstDN4QVRdS89Nkh85u68Uwp98=
+github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
+github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/miekg/dns v1.1.43 h1:JKfpVSCB84vrAmHzyrsxB5NAr5kLoMXZArPSw7Qlgyg=
 github.com/open-policy-agent/opa v0.50.2 h1:iD2kKLFkflgSCTMtrC/3jLmOQ7IWyDXMg6+VQA0tSC0=
@@ -45,8 +56,11 @@ github.com/prometheus/client_golang v1.14.0 h1:nJdhIvne2eSX/XRAFV9PcvFFRbrjbcTUj
 github.com/prometheus/client_model v0.3.0 h1:UBgGFHqYdG/TPFD1B1ogZywDqEkwp3fBMvqdiQ7Xew4=
 github.com/prometheus/common v0.37.0 h1:ccBbHCgIiT9uSoFY0vX8H3zsNR5eLt17/RQLUvn8pXE=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
-github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 h1:MkV+77GLUNo5oJ0jf870itWm3D0Sjh7+Za9gazKc5LQ=
-github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
+github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
+github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
@@ -64,7 +78,9 @@ github.com/yashtewari/glob-intersection v0.1.0 h1:6gJvMYQlTDOL3dMsPF6J0+26vwX9MB
 github.com/yashtewari/glob-intersection v0.1.0/go.mod h1:LK7pIC3piUjovexikBbJ26Yml7g8xa5bsjfx2v1fwok=
 go.opencensus.io v0.23.0 h1:gqCw0LfLxScz8irSi8exQc7fyQ0fKQU/qnC/X8+V/1M=
 golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -1,6 +1,7 @@
 package io
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -99,4 +100,18 @@ func ExcludeTestFilter() filter.LoaderFilter {
 	return func(abspath string, info files.FileInfo, depth int) bool {
 		return strings.HasSuffix(info.Name(), "_test.rego")
 	}
+}
+
+func ReadRow(reader io.Reader, row int) ([]byte, error) {
+	scanner := bufio.NewScanner(reader)
+
+	r := 0
+	for scanner.Scan() {
+		r++
+		if r == row {
+			return scanner.Bytes(), scanner.Err()
+		}
+	}
+
+	return nil, scanner.Err() //nolint:wrapcheck
 }

--- a/internal/io/io_test.go
+++ b/internal/io/io_test.go
@@ -1,6 +1,7 @@
 package io
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -20,5 +21,23 @@ func TestJSONRoundTrip(t *testing.T) {
 
 	if f.Bar != "foo" {
 		t.Errorf("expected JSON roundtrip to set struct value")
+	}
+}
+
+func TestReadRow(t *testing.T) {
+	t.Parallel()
+
+	text := `a b c
+d e f
+g h i
+j k l`
+
+	bs, err := ReadRow(strings.NewReader(text), 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(bs) != "g h i" {
+		t.Errorf("expected row 3 to be 'g h i'")
 	}
 }

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -39,8 +39,8 @@ func GetRegalBundle(t *testing.T) bundle.Bundle {
 }
 
 func InputPolicy(filename string, policy string) rules.Input {
-	filebytes := map[string][]byte{filename: []byte(policy)}
+	content := map[string]string{filename: policy}
 	modules := map[string]*ast.Module{filename: parse.MustParseModule(policy)}
 
-	return rules.NewInput(filebytes, modules)
+	return rules.NewInput(content, modules)
 }

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -36,8 +36,32 @@ camelCase {
 		t.Errorf("excpected first violation to be 'todo-comments', got %s", result.Violations[0].Title)
 	}
 
+	if result.Violations[0].Location.Row != 3 {
+		t.Errorf("excpected first violation to be on line 3, got %d", result.Violations[0].Location.Row)
+	}
+
+	if result.Violations[0].Location.Column != 1 {
+		t.Errorf("excpected first violation to be on column 1, got %d", result.Violations[0].Location.Column)
+	}
+
+	if string(result.Violations[0].Location.Text) != "# TODO: fix this" {
+		t.Errorf("excpected first violation to be on '# TODO: fix this', got %s", result.Violations[0].Location.Text)
+	}
+
 	if result.Violations[1].Title != "prefer-snake-case" {
 		t.Errorf("excpected second violation to be 'prefer-snake-case', got %s", result.Violations[1].Title)
+	}
+
+	if result.Violations[1].Location.Row != 4 {
+		t.Errorf("excpected second violation to be on line 4, got %d", result.Violations[1].Location.Row)
+	}
+
+	if result.Violations[1].Location.Column != 1 {
+		t.Errorf("excpected second violation to be on column 1, got %d", result.Violations[1].Location.Column)
+	}
+
+	if string(result.Violations[1].Location.Text) != "camelCase {" {
+		t.Errorf("excpected second violation to be on 'camelCase {', got %s", result.Violations[1].Location.Text)
 	}
 }
 

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -1,5 +1,7 @@
 package report
 
+import "fmt"
+
 // RelatedResource provides documentation on a violation.
 type RelatedResource struct {
 	Description string `json:"description"`
@@ -26,5 +28,23 @@ type Violation struct {
 
 // Report aggregate of Violation as returned by a linter run.
 type Report struct {
-	Violations []Violation `json:"report"`
+	Violations []Violation `json:"violations"`
+}
+
+func (r Report) FileCount() map[string]int {
+	fc := map[string]int{}
+	for _, violation := range r.Violations {
+		fc[violation.Location.File]++
+	}
+
+	return fc
+}
+
+// String shorthand form for a Location.
+func (l Location) String() string {
+	if l.Row == 0 && l.Column == 0 {
+		return l.File
+	}
+
+	return fmt.Sprintf("%s:%d:%d", l.File, l.Row, l.Column)
 }

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -1,0 +1,122 @@
+package reporter
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/gosuri/uitable"
+	"github.com/styrainc/regal/pkg/report"
+)
+
+// Reporter releases linter reports in a format decided by the implementation.
+type Reporter interface {
+	// Publish releases a report to any appropriate target
+	Publish(report.Report) error
+}
+
+// PrettyReporter is a Reporter for representing reports as tables.
+type PrettyReporter struct {
+	out io.Writer
+}
+
+type CompactReporter struct {
+	out io.Writer
+}
+
+type JSONReporter struct {
+	out io.Writer
+}
+
+func NewPrettyReporter(out io.Writer) PrettyReporter {
+	return PrettyReporter{out: out}
+}
+
+func NewCompactReporter(out io.Writer) CompactReporter {
+	return CompactReporter{out: out}
+}
+
+func NewJSONReporter(out io.Writer) JSONReporter {
+	return JSONReporter{out: out}
+}
+
+func (tr PrettyReporter) Publish(r report.Report) error {
+	table := uitable.New()
+	table.MaxColWidth = 80
+	table.Wrap = true
+	numFiles := len(r.FileCount())
+
+	plural := ""
+	if numFiles == 0 || numFiles > 1 {
+		plural = "s"
+	}
+
+	heading := fmt.Sprintf("Found %d violations in %d file%s\n\n", len(r.Violations), numFiles, plural)
+
+	numViolations := len(r.Violations)
+
+	for i, violation := range r.Violations {
+		table.AddRow("Rule:", violation.Title)
+		table.AddRow("Description:", violation.Description)
+		table.AddRow("Category:", violation.Category)
+		table.AddRow("Location:", violation.Location.String())
+
+		if violation.Location.Text != nil {
+			table.AddRow("Text:", string(violation.Location.Text))
+		}
+
+		table.AddRow("Documentation:", getDocumentationURL(violation))
+
+		if i+1 < numViolations {
+			table.AddRow("")
+		}
+	}
+
+	end := ""
+	if numViolations > 0 {
+		end = "\n"
+	}
+
+	_, err := fmt.Fprint(tr.out, heading+table.String()+end)
+
+	return err //nolint:wrapcheck
+}
+
+func (tr CompactReporter) Publish(r report.Report) error {
+	table := uitable.New()
+	table.MaxColWidth = 80
+	table.Wrap = true
+
+	for _, violation := range r.Violations {
+		table.AddRow(violation.Location.String(), violation.Description)
+	}
+
+	_, err := fmt.Fprintln(tr.out, table)
+
+	return err //nolint:wrapcheck
+}
+
+func (tr JSONReporter) Publish(r report.Report) error {
+	if r.Violations == nil {
+		r.Violations = []report.Violation{}
+	}
+
+	bs, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return fmt.Errorf("json marshalling of report failed: %w", err)
+	}
+
+	_, err = fmt.Fprintln(tr.out, string(bs))
+
+	return err //nolint:wrapcheck
+}
+
+func getDocumentationURL(violation report.Violation) string {
+	for _, resource := range violation.RelatedResources {
+		if resource.Description == "documentation" {
+			return resource.Reference
+		}
+	}
+
+	return ""
+}

--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -1,0 +1,213 @@
+package reporter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/styrainc/regal/pkg/report"
+)
+
+//nolint:gochecknoglobals
+var rep = report.Report{
+	Violations: []report.Violation{
+		{
+			Title:       "breaking-the-law",
+			Description: "Rego must not break the law!",
+			Category:    "legal",
+			Location: report.Location{
+				File:   "a.rego",
+				Row:    1,
+				Column: 1,
+				Text:   []byte("package illegal"),
+			},
+			RelatedResources: []report.RelatedResource{
+				{
+					Description: "documentation",
+					Reference:   "https://example.com/illegal",
+				},
+			},
+		},
+		{
+			Title:       "questionable-decision",
+			Description: "Questionable decision found",
+			Category:    "really?",
+			Location: report.Location{
+				File:   "b.rego",
+				Row:    22,
+				Column: 18,
+				Text:   []byte("default allow = true"),
+			},
+			RelatedResources: []report.RelatedResource{
+				{
+					Description: "documentation",
+					Reference:   "https://example.com/questionable",
+				},
+			},
+		},
+	},
+}
+
+func TestPrettyReporterPublish(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	pr := NewPrettyReporter(&buf)
+
+	err := pr.Publish(rep)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := `Found 2 violations in 2 files
+
+Rule:         	breaking-the-law                
+Description:  	Rego must not break the law!    
+Category:     	legal                           
+Location:     	a.rego:1:1                      
+Text:         	package illegal                 
+Documentation:	https://example.com/illegal     
+              
+Rule:         	questionable-decision           
+Description:  	Questionable decision found     
+Category:     	really?                         
+Location:     	b.rego:22:18                    
+Text:         	default allow = true            
+Documentation:	https://example.com/questionable
+`
+
+	if buf.String() != expect {
+		t.Errorf("expected %q, got %q", expect, buf.String())
+	}
+}
+
+func TestPrettyReporterPublishNoViolations(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	pr := NewPrettyReporter(&buf)
+
+	err := pr.Publish(report.Report{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if buf.String() != "Found 0 violations in 0 files\n\n" {
+		t.Errorf("expected %q, got %q", "Found 0 violations in 0 files\n\n", buf.String())
+	}
+}
+
+func TestCompactReporterPublish(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	cr := NewCompactReporter(&buf)
+
+	err := cr.Publish(rep)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := `a.rego:1:1  	Rego must not break the law!
+b.rego:22:18	Questionable decision found 
+`
+
+	if buf.String() != expect {
+		t.Errorf("expected %q, got %q", expect, buf.String())
+	}
+}
+
+func TestCompactReporterPublishNoViolations(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	cr := NewCompactReporter(&buf)
+
+	err := cr.Publish(report.Report{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if buf.String() != "\n" {
+		t.Errorf("expected %q, got %q", "", buf.String())
+	}
+}
+
+func TestJSONReporterPublish(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	jr := NewJSONReporter(&buf)
+
+	err := jr.Publish(rep)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := `{
+  "violations": [
+    {
+      "title": "breaking-the-law",
+      "description": "Rego must not break the law!",
+      "category": "legal",
+      "related_resources": [
+        {
+          "description": "documentation",
+          "ref": "https://example.com/illegal"
+        }
+      ],
+      "location": {
+        "col": 1,
+        "row": 1,
+        "file": "a.rego",
+        "text": "cGFja2FnZSBpbGxlZ2Fs"
+      }
+    },
+    {
+      "title": "questionable-decision",
+      "description": "Questionable decision found",
+      "category": "really?",
+      "related_resources": [
+        {
+          "description": "documentation",
+          "ref": "https://example.com/questionable"
+        }
+      ],
+      "location": {
+        "col": 18,
+        "row": 22,
+        "file": "b.rego",
+        "text": "ZGVmYXVsdCBhbGxvdyA9IHRydWU="
+      }
+    }
+  ]
+}
+`
+	if buf.String() != expect {
+		t.Errorf("expected %q, got %q", expect, buf.String())
+	}
+}
+
+func TestJSONReporterPublishNoViolations(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	jr := NewJSONReporter(&buf)
+
+	err := jr.Publish(report.Report{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if buf.String() != `{
+  "violations": []
+}
+` {
+		t.Errorf("expected %q, got %q", `{"violations":[]}`, buf.String())
+	}
+}

--- a/pkg/rules/fmt.go
+++ b/pkg/rules/fmt.go
@@ -32,7 +32,7 @@ func (f *OpaFmtRule) Run(ctx context.Context, input Input) (*report.Report, erro
 			return nil, fmt.Errorf("timeout when running %s rule: %w", title, ctx.Err())
 		default:
 			module := input.Modules[filename]
-			unformatted := input.FileBytes[filename]
+			unformatted := []byte(input.FileContent[filename])
 
 			formatted, err := format.Ast(module)
 			if err != nil {

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -19,8 +19,8 @@ import (
 type Input struct {
 	// FileNames is used to maintain consistent order between runs.
 	FileNames []string
-	// FileBytes carries the raw bytes of each file
-	FileBytes map[string][]byte
+	// FileContent carries the string contents of each file
+	FileContent map[string]string
 	// Modules is the set of modules to lint.
 	Modules map[string]*ast.Module
 }
@@ -36,15 +36,15 @@ type Rule interface {
 }
 
 // NewInput creates a new Input from a set of modules.
-func NewInput(fileBytes map[string][]byte, modules map[string]*ast.Module) Input {
+func NewInput(fileContent map[string]string, modules map[string]*ast.Module) Input {
 	// Maintain order across runs
 	filenames := util.Keys(modules)
 	sort.Strings(filenames)
 
 	return Input{
-		FileBytes: fileBytes,
-		FileNames: filenames,
-		Modules:   modules,
+		FileContent: fileContent,
+		FileNames:   filenames,
+		Modules:     modules,
 	}
 }
 
@@ -57,7 +57,7 @@ func InputFromPaths(paths []string) (Input, error) {
 		return Input{}, fmt.Errorf("failed to load policy from provided args: %w", err)
 	}
 
-	filebytes := make(map[string][]byte, len(policyPaths))
+	fileContent := make(map[string]string, len(policyPaths))
 	modules := make(map[string]*ast.Module, len(policyPaths))
 
 	for _, path := range policyPaths {
@@ -67,9 +67,9 @@ func InputFromPaths(paths []string) (Input, error) {
 			return Input{}, err //nolint:wrapcheck
 		}
 
-		filebytes[result.Name] = result.Raw
+		fileContent[result.Name] = string(result.Raw)
 		modules[result.Name] = result.Parsed
 	}
 
-	return NewInput(filebytes, modules), nil
+	return NewInput(fileContent, modules), nil
 }


### PR DESCRIPTION
Some colors would be nice, but this is a good start. This PR adds three reporter formats, which can be set via the CLI.

- pretty (default)
- compact
- json

![Screenshot 2023-03-30 at 11 15 54](https://user-images.githubusercontent.com/510711/228793549-cb760e92-6f68-46b6-975e-3e51c28b0243.png)
![Screenshot 2023-03-30 at 11 23 56](https://user-images.githubusercontent.com/510711/228793557-5419a89f-183d-44b4-a181-bf4c3822ca10.png)
![Screenshot 2023-03-30 at 11 24 25](https://user-images.githubusercontent.com/510711/228793562-d7bf6c33-51e2-43cb-af24-4819fd7dc52e.png)

Resolves #24 
