### PR TITLE
Add parsing of ignore directives

### DIFF
--- a/bundle/regal/main.rego
+++ b/bundle/regal/main.rego
@@ -26,8 +26,32 @@ report contains violation if {
 
 report contains violation if {
 	violation := data.regal.rules[_].report[_]
+
+	not ignored(violation, ignore_directives)
 }
 
 report contains violation if {
 	violation := data.custom.regal.rules[_].report[_]
+
+	not ignored(violation, ignore_directives)
+}
+
+ignored(violation, directives) if {
+	ignored_rules := directives[violation.location.row]
+	violation.title in ignored_rules
+}
+
+ignore_directives[row] := rules if {
+	some comment in input.comments
+	text := trim_space(base64.decode(comment.Text))
+
+	startswith(text, "regal")
+
+	i := indexof(text, "ignore:")
+	i != -1
+
+	list := regex.replace(substring(text, i + 7, -1), `\s`, "")
+
+	row := comment.Location.row + 1
+	rules := split(list, ",")
 }

--- a/bundle/regal/main_test.rego
+++ b/bundle/regal/main_test.rego
@@ -1,0 +1,61 @@
+package regal.main_test
+
+test_main_basic_input_success {
+	report := data.regal.main.report with input as regal.parse_module("p.rego", `package p`)
+	report == set()
+}
+
+test_main_multiple_failues {
+	policy := `package p
+
+	# both camel case and unification operator
+	default camelCase = "yes"
+	`
+	report := data.regal.main.report with input as regal.parse_module("p.rego", policy)
+
+	count(report) == 2
+}
+
+test_main_ignore_directive_failure {
+	policy := `package p
+
+	# regal ignore:todo-comment
+	camelCase := "yes"
+	`
+	report := data.regal.main.report with input as regal.parse_module("p.rego", policy)
+
+	count(report) == 1
+}
+
+test_main_ignore_directive_success {
+	policy := `package p
+
+	# regal ignore:prefer-snake-case
+	camelCase := "yes"
+	`
+	report := data.regal.main.report with input as regal.parse_module("p.rego", policy)
+
+	count(report) == 0
+}
+
+test_main_ignore_directive_multiple_success {
+	policy := `package p
+
+	# regal ignore:prefer-snake-case,use-assignment-operator
+	default camelCase = "yes"
+	`
+	report := data.regal.main.report with input as regal.parse_module("p.rego", policy)
+
+	count(report) == 0
+}
+
+test_main_ignore_directive_multiple_mixed_success {
+	policy := `package p
+
+	# regal ignore:prefer-snake-case,todo-comment
+	default camelCase = "yes"
+	`
+	report := data.regal.main.report with input as regal.parse_module("p.rego", policy)
+
+	count(report) == 1
+}

--- a/bundle/regal/rules/assignment/assignment_test.rego
+++ b/bundle/regal/rules/assignment/assignment_test.rego
@@ -41,6 +41,7 @@ test_success_assignment_in_object_rule_assignment if {
 }
 
 report(snippet) := report if {
+	# regal ignore:input-or-data-reference
 	report := assignment.report with input as ast.with_future_keywords(snippet)
 		with config.for_rule as {"enabled": true}
 }

--- a/bundle/regal/rules/comments/comments.rego
+++ b/bundle/regal/rules/comments/comments.rego
@@ -11,7 +11,7 @@ import data.regal.result
 
 todo_identifiers := ["todo", "TODO", "fixme", "FIXME"]
 
-todo_pattern := sprintf("(%s)", [concat("|", todo_identifiers)])
+todo_pattern := sprintf(`^\s*(%s)`, [concat("|", todo_identifiers)])
 
 # METADATA
 # title: todo-comment

--- a/bundle/regal/rules/comments/comments_test.rego
+++ b/bundle/regal/rules/comments/comments_test.rego
@@ -37,6 +37,7 @@ test_success_no_todo_comment if {
 }
 
 report(snippet) := report if {
+	# regal ignore:input-or-data-reference
 	report := comments.report with input as ast.with_future_keywords(snippet)
 		with config.for_rule as {"enabled": true}
 }

--- a/bundle/regal/rules/functions/functions_test.rego
+++ b/bundle/regal/rules/functions/functions_test.rego
@@ -60,7 +60,7 @@ test_success_function_references_no_input_or_data_reverse if {
 }
 
 report(snippet) := report if {
+	# regal ignore:input-or-data-reference
 	report := functions.report with input as ast.with_future_keywords(snippet)
 		with config.for_rule as {"enabled": true}
-	print(report)
 }

--- a/bundle/regal/rules/imports/imports_test.rego
+++ b/bundle/regal/rules/imports/imports_test.rego
@@ -75,6 +75,7 @@ test_success_import_data_path if {
 }
 
 report(snippet) := report if {
+	# regal ignore:input-or-data-reference
 	report := imports.report with input as ast.with_future_keywords(snippet)
 		with config.for_rule as {"enabled": true}
 }

--- a/bundle/regal/rules/rules/rules_test.rego
+++ b/bundle/regal/rules/rules/rules_test.rego
@@ -24,5 +24,6 @@ test_success_rule_name_does_not_shadows_builtin if {
 }
 
 report(snippet) := report if {
+	# regal ignore:input-or-data-reference
 	report := rules.report with input as ast.with_future_keywords(snippet) with config.for_rule as {"enabled": true}
 }

--- a/bundle/regal/rules/style/style.rego
+++ b/bundle/regal/rules/style/style.rego
@@ -37,6 +37,24 @@ report contains violation if {
 	config.for_rule(rego.metadata.rule()).enabled == true
 
 	some rule in input.rules
+	rule["default"] == true
+	not util.is_snake_case(rule.head.name)
+
+	violation := result.fail(rego.metadata.rule(), result.location(rule.head))
+}
+
+# METADATA
+# title: prefer-snake-case
+# description: Prefer snake_case for names
+# related_resources:
+# - description: documentation
+#   ref: https://docs.styra.com/regal/rules/prefer-snake-case
+# custom:
+#   category: style
+report contains violation if {
+	config.for_rule(rego.metadata.rule()).enabled == true
+
+	some rule in input.rules
 	some expr in rule.body
 	some symbol in expr.terms.symbols
 

--- a/bundle/regal/rules/style/style_test.rego
+++ b/bundle/regal/rules/style/style_test.rego
@@ -81,5 +81,6 @@ test_success_snake_cased_every if {
 }
 
 report(snippet) := report if {
+	# regal ignore:input-or-data-reference
 	report := style.report with input as ast.with_future_keywords(snippet) with config.for_rule as {"enabled": true}
 }

--- a/bundle/regal/rules/testing/testing_test.rego
+++ b/bundle/regal/rules/testing/testing_test.rego
@@ -30,5 +30,6 @@ test_success_test_inside_test_package if {
 }
 
 report(snippet) := report if {
+	# regal ignore:input-or-data-reference
 	report := testing.report with input as ast.with_future_keywords(snippet) with config.for_rule as {"enabled": true}
 }

--- a/bundle/regal/rules/variables/variables_test.rego
+++ b/bundle/regal/rules/variables/variables_test.rego
@@ -41,6 +41,7 @@ test_success_unconditional_assignment_but_with_in_body if {
 }
 
 report(snippet) := report if {
+	# regal ignore:input-or-data-reference
 	report := variables.report with input as ast.with_future_keywords(snippet)
 		with config.for_rule as {"enabled": true}
 }


### PR DESCRIPTION
It is now possible to add an "ignore directive" above any line of Rego, to have Regal ignore the next line given that the
rule(s) named in the directive match that of the linter being executed. Example:

```rego
# regal ignore:prefer-snake-case,use-assignment-operator
default fooBar = "baz"
```

Note that this only works for the next _line_, and does not take into account concepts like packages, functions or rules. But this should be good enough for most use cases, I think.

Resolves #39