### PR TITLE
Warn on identically named tests

### DIFF
--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -26,7 +26,11 @@ rules:
     use-in-operator:
       enabled: true
   testing:
+    identically-named-tests:
+      enabled: true
     test-outside-test-package:
+      enabled: true
+    todo-test:
       enabled: true
   variables:
     unconditional-assignment:

--- a/bundle/regal/rules/testing/testing.rego
+++ b/bundle/regal/rules/testing/testing.rego
@@ -11,6 +11,11 @@ import data.regal.result
 
 package_name := concat(".", [path.value | some path in input["package"].path])
 
+tests := [rule |
+	some rule in input.rules
+	startswith(rule.head.name, "test_")
+]
+
 # METADATA
 # title: test-outside-test-package
 # description: Test outside of test package
@@ -24,8 +29,49 @@ report contains violation if {
 
 	not endswith(package_name, "_test")
 
-	some rule in input.rules
-	startswith(rule.head.name, "test_")
+	some rule in tests
 
 	violation := result.fail(rego.metadata.rule(), result.location(rule.head))
+}
+
+# METADATA
+# title: identically-named-tests
+# description: Multiple tests with same name
+# related_resources:
+# - description: documentation
+#   ref: https://docs.styra.com/regal/rules/identically-named-tests
+# custom:
+#   category: testing
+report contains violation if {
+	config.for_rule(rego.metadata.rule()).enabled == true
+
+	test_names := [rule.head.name | some rule in tests]
+
+	some i, name in test_names
+
+	name in array.slice(test_names, 0, i)
+
+	# We don't currently have location for rule heads, but this should
+	# change soon: https://github.com/open-policy-agent/opa/pull/5811
+	violation := result.fail(rego.metadata.rule(), {})
+}
+
+# METADATA
+# title: todo-test
+# description: TODO test encountered
+# related_resources:
+# - description: documentation
+#   ref: https://docs.styra.com/regal/rules/todo-test
+# custom:
+#   category: testing
+report contains violation if {
+	config.for_rule(rego.metadata.rule()).enabled == true
+
+	some rule in input.rules
+
+	startswith(rule.head.name, "todo_")
+
+	# We don't currently have location for rule heads, but this should
+	# change soon: https://github.com/open-policy-agent/opa/pull/5811
+	violation := result.fail(rego.metadata.rule(), {})
 }

--- a/bundle/regal/rules/testing/testing_test.rego
+++ b/bundle/regal/rules/testing/testing_test.rego
@@ -21,12 +21,63 @@ test_fail_test_outside_test_package if {
 
 test_success_test_inside_test_package if {
 	ast := rego.parse_module("foo_test.rego", `
-        package foo_test
+	package foo_test
 
-        test_foo { false }
-    `)
+	test_foo { false }
+	`)
 	result := testing.report with input as ast
 	result == set()
+}
+
+test_fail_identically_named_tests if {
+	ast := rego.parse_module("foo_test.rego", `
+	package foo_test
+
+	test_foo { false }
+	test_foo { true }
+	`)
+	result := testing.report with input as ast
+	result == {{
+		"category": "testing",
+		"description": "Multiple tests with same name",
+		"related_resources": [{
+			"description": "documentation",
+			"ref": "https://docs.styra.com/regal/rules/identically-named-tests",
+		}],
+		"title": "identically-named-tests",
+	}}
+}
+
+test_success_differently_named_tests if {
+	ast := rego.parse_module("foo_test.rego", `
+	package foo_test
+
+	test_foo { false }
+	test_bar { true }
+	test_baz { 1 == 1 }
+	`)
+	result := testing.report with input as ast
+	result == set()
+}
+
+test_fail_todo_test if {
+	ast := rego.parse_module("foo_test.rego", `
+	package foo_test
+
+	todo_test_foo { false }
+
+	test_bar { true }
+	`)
+	result := testing.report with input as ast
+	result == {{
+		"category": "testing",
+		"description": "TODO test encountered",
+		"related_resources": [{
+			"description": "documentation",
+			"ref": "https://docs.styra.com/regal/rules/todo-test",
+		}],
+		"title": "todo-test",
+	}}
 }
 
 report(snippet) := report if {


### PR DESCRIPTION
Bonus: add rule to flag todo_ tests

Fixes #46