### PR TITLE
Add command for generating markdown table from rule annotations

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,3 +31,11 @@ linters-settings:
     case:
       rules:
         json: snake
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/open-policy-agent/opa)
+      - prefix(github.com/styrainc/regal)
+      - blank
+      - dot

--- a/README.md
+++ b/README.md
@@ -41,13 +41,34 @@ regal lint policy/
 
 ## Rules
 
-This table should be generated from metadata annotations, and inserted here as part of the build process.
-See: https://github.com/StyraInc/regal/issues/36
+Regal comes with a set of built-in rules. The following rules are currently available:
 
-| Category   | Rule                                                                                  | Description                     | Enabled |
-|------------|---------------------------------------------------------------------------------------|---------------------------------|---------|
-| Assignment | [use-assignment-operator](https://docs.styra.com/regal/rules/use-assignment-operator) | Prefer := over = for assignment | true    |
-| Comments   | [todo-comment](https://docs.styra.com/regal/rules/todo-comment)                       | Avoid TODO comments             | true    |
+<!-- RULES_TABLE_START -->
+
+|  Category  |                                           Title                                           |                      Description                      |
+|------------|-------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| assignment | [use-assignment-operator](https://docs.styra.com/regal/rules/use-assignment-operator)     | Prefer := over = for assignment                       |
+| assignment | [assignment-operator](https://docs.styra.com/regal/rules/use-assignment-operator)         | Prefer := over = for assignment                       |
+| comments   | [todo-comment](https://docs.styra.com/regal/rules/todo-comment)                           | Avoid TODO comments                                   |
+| functions  | [input-or-data-reference](https://docs.styra.com/regal/rules/input-or-data-reference)     | Reference to input, data or rule ref in function body |
+| imports    | [implicit-future-keywords](https://docs.styra.com/regal/rules/implicit-future-keywords)   | Use explicit future keyword imports                   |
+| imports    | [avoid-importing-input](https://docs.styra.com/regal/rules/avoid-importing-input)         | Avoid importing input                                 |
+| imports    | [redundant-data-import](https://docs.styra.com/regal/rules/redundant-data-import)         | Redundant import of data                              |
+| imports    | [import-shadows-import](https://docs.styra.com/regal/rules/import-shadows-import)         | Import shadows another import                         |
+| rules      | [rule-shadows-builtin](https://docs.styra.com/regal/rules/rule-shadows-builtin)           | Rule name shadows built-in                            |
+| style      | [prefer-snake-case](https://docs.styra.com/regal/rules/prefer-snake-case)                 | Prefer snake_case for names                           |
+| style      | [use-in-operator](https://docs.styra.com/regal/rules/use-in-operator)                     | Use in to check for membership                        |
+| style      | [line-length](https://docs.styra.com/regal/rules/line-length)                             | Line too long                                         |
+| testing    | [test-outside-test-package](https://docs.styra.com/regal/rules/test-outside-test-package) | Test outside of test package                          |
+| testing    | [identically-named-tests](https://docs.styra.com/regal/rules/identically-named-tests)     | Multiple tests with same name                         |
+| testing    | [todo-test](https://docs.styra.com/regal/rules/todo-test)                                 | TODO test encountered                                 |
+| variables  | [unconditional-assignment](https://docs.styra.com/regal/rules/unconditional-assignment)   | Unconditional assignment in rule body                 |
+
+<!-- RULES_TABLE_END -->
+
+If you'd like to see more rules, please [open an issue](https://github.com/StyraInc/regal/issues) for your feature
+request, or better yet, submit a PR! See the [custom rules](#custom-rules) section for more information on how to
+develop your own rules, for yourself or for inclusion in Regal.
 
 ## Configuration
 
@@ -211,6 +232,18 @@ Regal uses [golangci-lint](https://golangci-lint.run/) with most linters enabled
 golangci-lint run ./...
 ```
 
+In order to satisfy the [gci](https://github.com/daixiang0/gci) linter, you may either manually order imports, or have
+them automatically ordered and grouped by the tool:
+
+```shell
+gci write \
+  -s standard \
+  -s default \
+  -s "prefix(github.com/open-policy-agent/opa)" \
+  -s "prefix(github.com/styrainc/regal)" \
+  -s blank \
+  -s dot .
+```
 ### Authoring Rules
 
 During development of Rego-based rules, you may want to test the policies in isolation — i.e. without running Regal.

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+
 	rio "github.com/styrainc/regal/internal/io"
 	"github.com/styrainc/regal/pkg/config"
 	"github.com/styrainc/regal/pkg/linter"

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -7,8 +7,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/open-policy-agent/opa/ast"
 	"github.com/spf13/cobra"
+
+	"github.com/open-policy-agent/opa/ast"
+
 	rp "github.com/styrainc/regal/internal/parse"
 )
 

--- a/cmd/table.go
+++ b/cmd/table.go
@@ -1,0 +1,134 @@
+//nolint:wrapcheck
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"io/fs"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/loader"
+
+	"github.com/styrainc/regal/internal/compile"
+)
+
+type tableCommandParams struct {
+	writeToReadme bool
+}
+
+func init() {
+	params := tableCommandParams{}
+	parseCommand := &cobra.Command{
+		Hidden: true,
+		Use:    "table <path> [path [...]]",
+		Long:   "Create a markdown table from rule annotations found in provided modules",
+
+		PreRunE: func(_ *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return errors.New("no files to parse for annotations provided")
+			}
+
+			return nil
+		},
+
+		Run: func(_ *cobra.Command, args []string) {
+			if err := createTable(args, params); err != nil {
+				log.SetOutput(os.Stderr)
+				log.Println(err)
+				os.Exit(1)
+			}
+		},
+	}
+	parseCommand.Flags().BoolVar(&params.writeToReadme, "write-to-readme", false, "Write table to README.md")
+	RootCommand.AddCommand(parseCommand)
+}
+
+func createTable(args []string, params tableCommandParams) error {
+	result, err := loader.NewFileLoader().Filtered(args, func(abspath string, info fs.FileInfo, depth int) bool {
+		return strings.HasSuffix(abspath, "_test.rego")
+	})
+	if err != nil {
+		return err
+	}
+
+	modules := map[string]*ast.Module{}
+
+	for path, file := range result.Modules {
+		modules[path] = file.Parsed
+	}
+
+	compiler := compile.NewCompilerWithRegalBuiltins()
+	compiler.Compile(modules)
+
+	if compiler.Failed() {
+		return compiler.Errors
+	}
+
+	as := compiler.GetAnnotationSet()
+	flattened := as.Flatten()
+
+	tableData := make([][]string, 0, len(flattened))
+
+	traversedTitles := map[string]struct{}{}
+
+	for _, entry := range flattened {
+		annotations := entry.Annotations
+
+		_, ok := annotations.Custom["category"]
+		if !ok {
+			continue
+		}
+
+		if _, ok = traversedTitles[annotations.Title]; ok {
+			continue
+		}
+
+		traversedTitles[annotations.Title] = struct{}{}
+
+		//nolint:forcetypeassert
+		tableData = append(tableData, []string{
+			annotations.Custom["category"].(string),
+			"[" + annotations.Title + "](" + annotations.RelatedResources[0].Ref.String() + ")",
+			annotations.Description,
+		})
+	}
+
+	return writeTable(tableData, params)
+}
+
+func writeTable(tableData [][]string, params tableCommandParams) error {
+	var buf bytes.Buffer
+
+	table := tablewriter.NewWriter(&buf)
+	table.SetHeader([]string{"Category", "Title", "Description"})
+	table.SetAutoFormatHeaders(false)
+	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+	table.SetCenterSeparator("|")
+	table.SetAutoWrapText(false)
+	table.AppendBulk(tableData)
+	table.Render()
+
+	if !params.writeToReadme {
+		_, err := os.Stdout.Write(buf.Bytes())
+
+		return err
+	}
+
+	file, err := os.ReadFile("README.md")
+	if err != nil {
+		return err
+	}
+
+	first := strings.Split(string(file), "<!-- RULES_TABLE_START -->")[0]
+	last := strings.Split(string(file), "<!-- RULES_TABLE_END -->")[1]
+
+	newReadme := first + "<!-- RULES_TABLE_START -->\n\n" + buf.String() + "\n<!-- RULES_TABLE_END -->" + last
+
+	return os.WriteFile("README.md", []byte(newReadme), 0o600)
+}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,10 +42,13 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.18 h1:DOKFKCQ7FNG2L1rbrmstDN4QVRdS89Nkh85u68Uwp98=
 github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/miekg/dns v1.1.43 h1:JKfpVSCB84vrAmHzyrsxB5NAr5kLoMXZArPSw7Qlgyg=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/open-policy-agent/opa v0.51.0 h1:2hS5xhos8HtkN+mgpqMhNJSFtn/1n/h3wh+AeTPJg6Q=
 github.com/open-policy-agent/opa v0.51.0/go.mod h1:OjmwLfXdeR7skSxrt8Yd3ScXTqPxyJn7GeTRJrcEerU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -1,0 +1,17 @@
+package compile
+
+import (
+	"github.com/open-policy-agent/opa/ast"
+
+	"github.com/styrainc/regal/pkg/builtins"
+)
+
+func NewCompilerWithRegalBuiltins() *ast.Compiler {
+	caps := ast.CapabilitiesForThisVersion()
+	caps.Builtins = append(caps.Builtins, &ast.Builtin{
+		Name: builtins.RegalParseModuleMeta.Name,
+		Decl: builtins.RegalParseModuleMeta.Decl,
+	})
+
+	return ast.NewCompiler().WithCapabilities(caps)
+}

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -9,9 +9,10 @@ import (
 	"os"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/loader/filter"
-	"gopkg.in/yaml.v3"
 )
 
 const PathSeparator = string(os.PathSeparator)

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/open-policy-agent/opa/ast"
+
 	rio "github.com/styrainc/regal/internal/io"
 )
 

--- a/internal/test/rego_test.go
+++ b/internal/test/rego_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/tester"
+
 	"github.com/styrainc/regal/pkg/builtins"
 )
 

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
+
 	rio "github.com/styrainc/regal/internal/io"
 	"github.com/styrainc/regal/internal/parse"
 	"github.com/styrainc/regal/pkg/rules"

--- a/pkg/builtins/builtins.go
+++ b/pkg/builtins/builtins.go
@@ -9,6 +9,7 @@ import (
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/topdown/builtins"
 	"github.com/open-policy-agent/opa/types"
+
 	"github.com/styrainc/regal/internal/parse"
 )
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/opa/util/test"
+
 	rio "github.com/styrainc/regal/internal/io"
 )
 

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -8,10 +8,12 @@ import (
 	"strings"
 
 	"github.com/imdario/mergo"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/topdown"
+
 	rio "github.com/styrainc/regal/internal/io"
 	"github.com/styrainc/regal/internal/parse"
 	"github.com/styrainc/regal/internal/util"

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/gosuri/uitable"
+
 	"github.com/styrainc/regal/pkg/report"
 )
 

--- a/pkg/rules/fmt.go
+++ b/pkg/rules/fmt.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/open-policy-agent/opa/format"
+
 	"github.com/styrainc/regal/pkg/report"
 )
 

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -10,6 +10,7 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/loader"
+
 	"github.com/styrainc/regal/internal/parse"
 	"github.com/styrainc/regal/internal/util"
 	"github.com/styrainc/regal/pkg/report"


### PR DESCRIPTION
And generate a table for our README :)

NOTE: This should be integrated in the build, so that whenever a built-in is added or updated, a new table is generated. I plan to look into build-related improvements later, so doing this manually for now.

Fixes #36