### PR TITLE
Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,24 +45,26 @@ Regal comes with a set of built-in rules. The following rules are currently avai
 
 <!-- RULES_TABLE_START -->
 
-|  Category  |                                           Title                                           |                      Description                      |
-|------------|-------------------------------------------------------------------------------------------|-------------------------------------------------------|
-| assignment | [use-assignment-operator](https://docs.styra.com/regal/rules/use-assignment-operator)     | Prefer := over = for assignment                       |
-| assignment | [assignment-operator](https://docs.styra.com/regal/rules/use-assignment-operator)         | Prefer := over = for assignment                       |
-| comments   | [todo-comment](https://docs.styra.com/regal/rules/todo-comment)                           | Avoid TODO comments                                   |
-| functions  | [input-or-data-reference](https://docs.styra.com/regal/rules/input-or-data-reference)     | Reference to input, data or rule ref in function body |
-| imports    | [implicit-future-keywords](https://docs.styra.com/regal/rules/implicit-future-keywords)   | Use explicit future keyword imports                   |
-| imports    | [avoid-importing-input](https://docs.styra.com/regal/rules/avoid-importing-input)         | Avoid importing input                                 |
-| imports    | [redundant-data-import](https://docs.styra.com/regal/rules/redundant-data-import)         | Redundant import of data                              |
-| imports    | [import-shadows-import](https://docs.styra.com/regal/rules/import-shadows-import)         | Import shadows another import                         |
-| rules      | [rule-shadows-builtin](https://docs.styra.com/regal/rules/rule-shadows-builtin)           | Rule name shadows built-in                            |
-| style      | [prefer-snake-case](https://docs.styra.com/regal/rules/prefer-snake-case)                 | Prefer snake_case for names                           |
-| style      | [use-in-operator](https://docs.styra.com/regal/rules/use-in-operator)                     | Use in to check for membership                        |
-| style      | [line-length](https://docs.styra.com/regal/rules/line-length)                             | Line too long                                         |
-| testing    | [test-outside-test-package](https://docs.styra.com/regal/rules/test-outside-test-package) | Test outside of test package                          |
-| testing    | [identically-named-tests](https://docs.styra.com/regal/rules/identically-named-tests)     | Multiple tests with same name                         |
-| testing    | [todo-test](https://docs.styra.com/regal/rules/todo-test)                                 | TODO test encountered                                 |
-| variables  | [unconditional-assignment](https://docs.styra.com/regal/rules/unconditional-assignment)   | Unconditional assignment in rule body                 |
+|  Category  |                                           Title                                           |                      Description                       |
+|------------|-------------------------------------------------------------------------------------------|--------------------------------------------------------|
+| assignment | [use-assignment-operator](https://docs.styra.com/regal/rules/use-assignment-operator)     | Prefer := over = for assignment                        |
+| comments   | [todo-comment](https://docs.styra.com/regal/rules/todo-comment)                           | Avoid TODO comments                                    |
+| functions  | [external-reference](https://docs.styra.com/regal/rules/external-reference)               | Reference to input, data or rule ref in function body  |
+| imports    | [implicit-future-keywords](https://docs.styra.com/regal/rules/implicit-future-keywords)   | Use explicit future keyword imports                    |
+| imports    | [avoid-importing-input](https://docs.styra.com/regal/rules/avoid-importing-input)         | Avoid importing input                                  |
+| imports    | [redundant-data-import](https://docs.styra.com/regal/rules/redundant-data-import)         | Redundant import of data                               |
+| imports    | [import-shadows-import](https://docs.styra.com/regal/rules/import-shadows-import)         | Import shadows another import                          |
+| rules      | [avoid-get-and-list-prefix](https://docs.styra.com/regal/rules/avoid-get-and-list-prefix) | Avoid get_ and list_ prefix for rules and functions    |
+| rules      | [rule-shadows-builtin](https://docs.styra.com/regal/rules/rule-shadows-builtin)           | Rule name shadows built-in                             |
+| style      | [prefer-snake-case](https://docs.styra.com/regal/rules/prefer-snake-case)                 | Prefer snake_case for names                            |
+| style      | [use-in-operator](https://docs.styra.com/regal/rules/use-in-operator)                     | Use in to check for membership                         |
+| style      | [line-length](https://docs.styra.com/regal/rules/line-length)                             | Line too long                                          |
+| style      | [opa-fmt](https://docs.styra.com/regal/rules/opa-fmt)                                     | File should be formatted with `opa fmt`                |
+| testing    | [test-outside-test-package](https://docs.styra.com/regal/rules/test-outside-test-package) | Test outside of test package                           |
+| testing    | [file-missing-test-suffix](https://docs.styra.com/regal/rules/file-missing-test-suffix)   | Files containing tests should have a _test.rego suffix |
+| testing    | [identically-named-tests](https://docs.styra.com/regal/rules/identically-named-tests)     | Multiple tests with same name                          |
+| testing    | [todo-test](https://docs.styra.com/regal/rules/todo-test)                                 | TODO test encountered                                  |
+| variables  | [unconditional-assignment](https://docs.styra.com/regal/rules/unconditional-assignment)   | Unconditional assignment in rule body                  |
 
 <!-- RULES_TABLE_END -->
 

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -6,14 +6,16 @@ rules:
     todo-comment:
       enabled: true
   functions:
-    input-or-data-reference:
+    external-reference:
       enabled: true
   imports:
-    implicit-future-keywords:
-      enabled: true
     avoid-importing-input:
       enabled: true
+    implicit-future-keywords:
+      enabled: true
     import-shadows-import:
+      enabled: true
+    redundant-data-import:
       enabled: true
   rules:
     rule-shadows-builtin:
@@ -29,6 +31,8 @@ rules:
     use-in-operator:
       enabled: true
   testing:
+    file-missing-test-suffix:
+      enabled: true
     identically-named-tests:
       enabled: true
     test-outside-test-package:

--- a/bundle/regal/rules/assignment/assignment.rego
+++ b/bundle/regal/rules/assignment/assignment.rego
@@ -26,7 +26,7 @@ report contains violation if {
 }
 
 # METADATA
-# title: assignment-operator
+# title: use-assignment-operator
 # description: Prefer := over = for assignment
 # related_resources:
 # - description: documentation

--- a/bundle/regal/rules/assignment/assignment_test.rego
+++ b/bundle/regal/rules/assignment/assignment_test.rego
@@ -31,7 +31,7 @@ test_fail_unification_in_object_rule_assignment if {
 			"description": "documentation",
 			"ref": "https://docs.styra.com/regal/rules/use-assignment-operator",
 		}],
-		"title": "assignment-operator",
+		"title": "use-assignment-operator",
 		"location": {"col": 1, "file": "policy.rego", "row": 8, "text": `x["a"] = 1`},
 	}}
 }
@@ -41,7 +41,7 @@ test_success_assignment_in_object_rule_assignment if {
 }
 
 report(snippet) := report if {
-	# regal ignore:input-or-data-reference
+	# regal ignore:external-reference
 	report := assignment.report with input as ast.with_future_keywords(snippet)
 		with config.for_rule as {"enabled": true}
 }

--- a/bundle/regal/rules/comments/comments_test.rego
+++ b/bundle/regal/rules/comments/comments_test.rego
@@ -37,7 +37,7 @@ test_success_no_todo_comment if {
 }
 
 report(snippet) := report if {
-	# regal ignore:input-or-data-reference
+	# regal ignore:external-reference
 	report := comments.report with input as ast.with_future_keywords(snippet)
 		with config.for_rule as {"enabled": true}
 }

--- a/bundle/regal/rules/functions/functions.rego
+++ b/bundle/regal/rules/functions/functions.rego
@@ -9,11 +9,11 @@ import data.regal.config
 import data.regal.result
 
 # METADATA
-# title: input-or-data-reference
+# title: external-reference
 # description: Reference to input, data or rule ref in function body
 # related_resources:
 # - description: documentation
-#   ref: https://docs.styra.com/regal/rules/input-or-data-reference
+#   ref: https://docs.styra.com/regal/rules/external-reference
 # custom:
 #   category: functions
 report contains violation if {
@@ -40,11 +40,11 @@ report contains violation if {
 }
 
 # METADATA
-# title: input-or-data-reference
+# title: external-reference
 # description: Reference to input, data or rule ref in function body
 # related_resources:
 # - description: documentation
-#   ref: https://docs.styra.com/regal/rules/input-or-data-reference
+#   ref: https://docs.styra.com/regal/rules/external-reference
 # custom:
 #   category: functions
 report contains violation if {

--- a/bundle/regal/rules/functions/functions_test.rego
+++ b/bundle/regal/rules/functions/functions_test.rego
@@ -13,9 +13,9 @@ test_fail_function_references_input if {
 		"location": {"col": 8, "file": "policy.rego", "row": 8, "text": `f(_) { input.foo }`},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": "https://docs.styra.com/regal/rules/input-or-data-reference",
+			"ref": "https://docs.styra.com/regal/rules/external-reference",
 		}],
-		"title": "input-or-data-reference",
+		"title": "external-reference",
 	}}
 }
 
@@ -25,9 +25,9 @@ test_fail_function_references_data if {
 		"description": "Reference to input, data or rule ref in function body",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": "https://docs.styra.com/regal/rules/input-or-data-reference",
+			"ref": "https://docs.styra.com/regal/rules/external-reference",
 		}],
-		"title": "input-or-data-reference",
+		"title": "external-reference",
 		"location": {"col": 8, "file": "policy.rego", "row": 8, "text": `f(_) { data.foo }`},
 	}}
 }
@@ -47,9 +47,9 @@ f(x, y) {
 		"location": {"col": 7, "file": "policy.rego", "row": 13, "text": `	y == foo`},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": "https://docs.styra.com/regal/rules/input-or-data-reference",
+			"ref": "https://docs.styra.com/regal/rules/external-reference",
 		}],
-		"title": "input-or-data-reference",
+		"title": "external-reference",
 	}}
 }
 
@@ -70,7 +70,7 @@ test_success_function_references_only_own_vars_nested if {
 }
 
 report(snippet) := report if {
-	# regal ignore:input-or-data-reference
+	# regal ignore:external-reference
 	report := functions.report with input as ast.with_future_keywords(snippet)
 		with config.for_rule as {"enabled": true}
 }

--- a/bundle/regal/rules/imports/imports_test.rego
+++ b/bundle/regal/rules/imports/imports_test.rego
@@ -108,7 +108,7 @@ import data.bar as foo
 }
 
 report(snippet) := report if {
-	# regal ignore:input-or-data-reference
+	# regal ignore:external-reference
 	report := imports.report with input as ast.policy(snippet)
 		with config.for_rule as {"enabled": true}
 }

--- a/bundle/regal/rules/rules/rules.rego
+++ b/bundle/regal/rules/rules/rules.rego
@@ -26,3 +26,20 @@ report contains violation if {
 
 	violation := result.fail(rego.metadata.rule(), result.location(rule.head))
 }
+
+# METADATA
+# title: avoid-get-and-list-prefix
+# description: Avoid get_ and list_ prefix for rules and functions
+# related_resources:
+# - description: documentation
+#   ref: https://docs.styra.com/regal/rules/avoid-get-and-list-prefix
+# custom:
+#   category: rules
+report contains violation if {
+	config.for_rule(rego.metadata.rule()).enabled == true
+
+	some rule in input.rules
+	strings.any_prefix_match(rule.head.name, {"get_", "list_"})
+
+	violation := result.fail(rego.metadata.rule(), result.location(rule.head))
+}

--- a/bundle/regal/rules/rules/rules_test.rego
+++ b/bundle/regal/rules/rules/rules_test.rego
@@ -7,7 +7,8 @@ import data.regal.config
 import data.regal.rules.rules
 
 test_fail_rule_name_shadows_builtin if {
-	report(`or := 1`) == {{
+	r := report(`or := 1`)
+	r == {{
 		"category": "rules",
 		"description": "Rule name shadows built-in",
 		"related_resources": [{
@@ -19,11 +20,42 @@ test_fail_rule_name_shadows_builtin if {
 	}}
 }
 
+test_fail_rule_name_starts_with_get if {
+	r := report(`get_foo := 1`)
+	r == {{
+		"category": "rules",
+		"description": "Avoid get_ and list_ prefix for rules and functions",
+		"related_resources": [{
+			"description": "documentation",
+			"ref": "https://docs.styra.com/regal/rules/avoid-get-and-list-prefix",
+		}],
+		"title": "avoid-get-and-list-prefix",
+		"location": {"col": 1, "file": "policy.rego", "row": 8, "text": "get_foo := 1"},
+	}}
+}
+
+test_fail_function_name_starts_with_list if {
+	r := report(`list_users(datasource) := ["we", "have", "no", "users"]`)
+	r == {{
+		"category": "rules",
+		"description": "Avoid get_ and list_ prefix for rules and functions",
+		"related_resources": [{
+			"description": "documentation",
+			"ref": "https://docs.styra.com/regal/rules/avoid-get-and-list-prefix",
+		}],
+		"title": "avoid-get-and-list-prefix",
+		"location": {
+			"col": 1, "file": "policy.rego", "row": 8,
+			"text": `list_users(datasource) := ["we", "have", "no", "users"]`,
+		},
+	}}
+}
+
 test_success_rule_name_does_not_shadows_builtin if {
 	report(`foo := 1`) == set()
 }
 
 report(snippet) := report if {
-	# regal ignore:input-or-data-reference
+	# regal ignore:external-reference
 	report := rules.report with input as ast.with_future_keywords(snippet) with config.for_rule as {"enabled": true}
 }

--- a/bundle/regal/rules/style/style_test.rego
+++ b/bundle/regal/rules/style/style_test.rego
@@ -312,7 +312,7 @@ test_success_line_not_too_long if {
 }
 
 report(snippet) := report if {
-	# regal ignore:input-or-data-reference
+	# regal ignore:external-reference
 	report := style.report with input as ast.with_future_keywords(snippet)
 		with config.for_rule as {"enabled": true, "max-line-length": 80}
 }

--- a/bundle/regal/rules/testing/testing.rego
+++ b/bundle/regal/rules/testing/testing.rego
@@ -7,8 +7,6 @@ import future.keywords.in
 import data.regal.config
 import data.regal.result
 
-# Test that rules named test_* does not exist outside of _test packages
-
 package_name := concat(".", [path.value | some path in input["package"].path])
 
 tests := [rule |
@@ -32,6 +30,24 @@ report contains violation if {
 	some rule in tests
 
 	violation := result.fail(rego.metadata.rule(), result.location(rule.head))
+}
+
+# METADATA
+# title: file-missing-test-suffix
+# description: Files containing tests should have a _test.rego suffix
+# related_resources:
+# - description: documentation
+#   ref: https://docs.styra.com/regal/rules/file-missing-test-suffix
+# custom:
+#   category: testing
+report contains violation if {
+	config.for_rule(rego.metadata.rule()).enabled == true
+
+	count(tests) > 0
+
+	not endswith(input.regal.file.name, "_test.rego")
+
+	violation := result.fail(rego.metadata.rule(), {"location": {"file": input.regal.file.name}})
 }
 
 # METADATA

--- a/bundle/regal/rules/variables/variables_test.rego
+++ b/bundle/regal/rules/variables/variables_test.rego
@@ -41,7 +41,7 @@ test_success_unconditional_assignment_but_with_in_body if {
 }
 
 report(snippet) := report if {
-	# regal ignore:input-or-data-reference
+	# regal ignore:external-reference
 	report := variables.report with input as ast.with_future_keywords(snippet)
 		with config.for_rule as {"enabled": true}
 }

--- a/cmd/table.go
+++ b/cmd/table.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"log"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
@@ -16,6 +17,7 @@ import (
 	"github.com/open-policy-agent/opa/loader"
 
 	"github.com/styrainc/regal/internal/compile"
+	"github.com/styrainc/regal/pkg/rules"
 )
 
 type tableCommandParams struct {
@@ -70,9 +72,7 @@ func createTable(args []string, params tableCommandParams) error {
 		return compiler.Errors
 	}
 
-	as := compiler.GetAnnotationSet()
-	flattened := as.Flatten()
-
+	flattened := compiler.GetAnnotationSet().Flatten()
 	tableData := make([][]string, 0, len(flattened))
 
 	traversedTitles := map[string]struct{}{}
@@ -98,6 +98,18 @@ func createTable(args []string, params tableCommandParams) error {
 			annotations.Description,
 		})
 	}
+
+	for _, rule := range rules.AllGoRules() {
+		tableData = append(tableData, []string{
+			rule.Category(),
+			"[" + rule.Name() + "](" + rule.Documentation() + ")",
+			rule.Description(),
+		})
+	}
+
+	sort.Slice(tableData, func(i, j int) bool {
+		return tableData[i][0] < tableData[j][0]
+	})
 
 	return writeTable(tableData, params)
 }

--- a/docs/rego-style-guide.md
+++ b/docs/rego-style-guide.md
@@ -9,7 +9,7 @@ for Regal to check, and should be targeted by other means.
 ## General Advice
 
 - [x] ~~Optimize for readability, not performance~~
-- [ ] Use `opa fmt`
+- [x] Use `opa fmt`
 - [ ] Use strict mode
 - [ ] Use metadata annotations
 - [x] ~~Get to know the built-in functions~~
@@ -30,17 +30,14 @@ certainly have to be configurable to be usable. Same goes for JSON schemas.
 ## Style
 
 - [x] Prefer snake_case for rule names and variables
-- [ ] Keep line length <= 120 characters
-
-### Notes
-Line length check easiest done in Go, but ideally via a custom built-in function.
+- [x] Keep line length <= 120 characters
 
 ## Rules
 
 - [ ] Use helper rules and functions
 - [ ] Use negation to handle undefined
 - [x] ~~Consider partial helper rules over comprehensions in rule bodies~~
-- [ ] Avoid prefixing rules and functions with get_ or list_
+- [x] Avoid prefixing rules and functions with get_ or list_
 - [x] Prefer unconditional assignment in rule head over rule body
 
 ### Notes
@@ -54,7 +51,7 @@ determine whether the author has done, and both have valid use cases.
 
 ## Variables and Data Types
 
-- [ ] Use `in` to check for membership
+- [x] Use `in` to check for membership
 - [ ] Prefer some .. in for iteration
 - [ ] Use every to express FOR ALL
 - [ ] Don't use unification operator for assignment or comparison

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -39,6 +39,7 @@ func MustParseModule(policy string) *ast.Module {
 	return ast.MustParseModuleWithOpts(policy, ParserOptions())
 }
 
+// EnhanceAST TODO rename with https://github.com/StyraInc/regal/issues/86.
 func EnhanceAST(name string, content string, module *ast.Module) (map[string]any, error) {
 	var enhancedAst map[string]any
 

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -230,10 +230,6 @@ func (l Linter) mergedConfig() (config.Config, error) {
 }
 
 func (l Linter) enabledGoRules() ([]rules.Rule, error) {
-	allGoRules := []rules.Rule{
-		rules.NewOpaFmtRule(),
-	}
-
 	conf, err := l.mergedConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create merged config: %w", err)
@@ -241,7 +237,7 @@ func (l Linter) enabledGoRules() ([]rules.Rule, error) {
 
 	var enabledGoRules []rules.Rule
 
-	for _, rule := range allGoRules {
+	for _, rule := range rules.AllGoRules() {
 		ruleConf, ok := conf.Rules[rule.Category()][rule.Name()]
 		if ok && ruleConf.Enabled {
 			enabledGoRules = append(enabledGoRules, rule)

--- a/pkg/rules/fmt.go
+++ b/pkg/rules/fmt.go
@@ -68,3 +68,11 @@ func (f *OpaFmtRule) Name() string {
 func (f *OpaFmtRule) Category() string {
 	return category
 }
+
+func (f *OpaFmtRule) Description() string {
+	return description
+}
+
+func (f *OpaFmtRule) Documentation() string {
+	return relatedResourcesRef
+}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -34,6 +34,10 @@ type Rule interface {
 	Name() string
 	// Category returns the category of the rule.
 	Category() string
+	// Description returns the description of the rule.
+	Description() string
+	// Documentation returns the documentation URL for the rule.
+	Documentation() string
 }
 
 // NewInput creates a new Input from a set of modules.
@@ -73,4 +77,10 @@ func InputFromPaths(paths []string) (Input, error) {
 	}
 
 	return NewInput(fileContent, modules), nil
+}
+
+func AllGoRules() []Rule {
+	return []Rule{
+		NewOpaFmtRule(),
+	}
 }


### PR DESCRIPTION
- Fix naming in `use-assignment` rule -> `use-assignment-operator`
- Rename `input-or-data-reference` rule -> `external-reference`
- `redundant-data-import` rule missing from provided config, added
- Add new `file-missing-test-suffix` rule
- Include Go rules in markdown table generation
- Include Go rules in markdown table generation
- Update Rego Style Guide doc