### PR TITLE
Add bugs category, and two new rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,21 @@ $ opa parse p.rego --format json --json-include locations | opa eval -f pretty -
 ]
 ```
 
+### Built-in Functions
+
+Regal provides a few custom built-in functions tailor-made for linter policies. 
+
+#### `regal.parse_module(filename, policy)`
+
+Works just like `rego.parse_module`, but provides an AST including location information, and custom additions added
+by Regal, like the text representation of each line in the original policy.
+
+#### `regal.json_pretty(data)`
+
+Printing nested objects and arrays is quite helpful for debugging AST nodes, but the standard representation — where
+everything is displayed on a single line — not so much. This built-in allows marshalling JSON similar to `json.marshal`,
+but with newlines and spaces added for a more pleasant experience.
+
 ## Community
 
 For questions, discussions and announcements related to Styra products, services and open source projects, please join the Styra community on [Slack](https://join.slack.com/t/styracommunity/shared_invite/zt-1p81qz8g4-t2OLKbvw0J5ibdcNc62~6Q)!

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -2,6 +2,11 @@ rules:
   assignment:
     use-assignment-operator:
       enabled: true
+  bugs:
+    constant-condition:
+      enabled: true
+    top-level-iteration:
+      enabled: true
   comments:
     todo-comment:
       enabled: true

--- a/bundle/regal/rules/bugs/bugs.rego
+++ b/bundle/regal/rules/bugs/bugs.rego
@@ -1,0 +1,102 @@
+package regal.rules.bugs
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.config
+import data.regal.result
+
+# We could probably include arrays and objects too, as a single compound value
+# is not very useful, but it's not as clear cut as scalars, as you could have
+# something like {"a": foo(input.x) == "bar"} which is not a constant condition,
+# however meaningless it may be. Maybe consider for another rule?
+_scalars := {"boolean", "null", "number", "string"}
+
+_operators := {"equal", "gt", "gte", "lt", "lte", "neq"}
+
+_rule_names := {name | name := input.rules[_].head.name}
+
+_rules_with_bodies := [rule |
+	some rule in input.rules
+	not probably_no_body(rule)
+]
+
+# NOTE: The constant condition checks currently don't do nesting!
+# Additionally, there are several other conditions that could be considered
+# constant, or if not, redundant... so this rule should be expanded in time
+
+# METADATA
+# title: constant-condition
+# description: Constant condition
+# related_resources:
+# - description: documentation
+#   ref: https://docs.styra.com/regal/rules/constant-condition
+# custom:
+#   category: bugs
+report contains violation if {
+	config.for_rule(rego.metadata.rule()).enabled == true
+
+	some rule in _rules_with_bodies
+	some expr in rule.body
+
+	expr.terms.type in _scalars
+
+	violation := result.fail(rego.metadata.rule(), result.location(expr))
+}
+
+# METADATA
+# title: constant-condition
+# description: Constant condition
+# related_resources:
+# - description: documentation
+#   ref: https://docs.styra.com/regal/rules/constant-condition
+# custom:
+#   category: bugs
+report contains violation if {
+	config.for_rule(rego.metadata.rule()).enabled == true
+
+	some rule in _rules_with_bodies
+	some expr in rule.body
+
+	expr.terms[0].value[0].type == "var"
+	expr.terms[0].value[0].value in _operators
+
+	expr.terms[1].type in _scalars
+	expr.terms[2].type in _scalars
+
+	violation := result.fail(rego.metadata.rule(), result.location(expr))
+}
+
+# METADATA
+# title: top-level-iteration
+# description: Iteration in top-level assignment
+# related_resources:
+# - description: documentation
+#   ref: https://docs.styra.com/regal/rules/top-level-iteration
+# custom:
+#   category: bugs
+report contains violation if {
+	config.for_rule(rego.metadata.rule()).enabled == true
+
+	some rule in input.rules
+
+	rule.head.value.type == "ref"
+
+	last := rule.head.value.value[count(rule.head.value.value) - 1]
+	last.type == "var"
+
+	illegal_value_ref(last.value)
+
+	violation := result.fail(rego.metadata.rule(), result.location(rule.head))
+}
+
+illegal_value_ref(value) if not value in _rule_names
+
+# i.e. allow {..}, or allow := true, which expands to allow = true { true }
+probably_no_body(rule) if {
+	count(rule.body) == 1
+	rule.body[0].terms.type == "boolean"
+	rule.body[0].terms.value == true
+}

--- a/bundle/regal/rules/bugs/bugs_test.rego
+++ b/bundle/regal/rules/bugs/bugs_test.rego
@@ -1,0 +1,91 @@
+package regal.rules.bugs_test
+
+import future.keywords.if
+
+import data.regal.ast
+import data.regal.config
+import data.regal.rules.bugs
+
+test_fail_simple_constant_condition if {
+	r := report(`allow {
+	1
+	}`)
+	r == {{
+		"category": "bugs",
+		"description": "Constant condition",
+		"location": {"col": 2, "file": "policy.rego", "row": 9, "text": "\t1"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": "https://docs.styra.com/regal/rules/constant-condition",
+		}],
+		"title": "constant-condition",
+	}}
+}
+
+test_success_static_condition_probably_generated if {
+	report(`allow { true }`) == set()
+}
+
+test_fail_operator_constant_condition if {
+	r := report(`allow {
+	1 == 1
+	}`)
+	r == {{
+		"category": "bugs",
+		"description": "Constant condition",
+		"location": {"col": 2, "file": "policy.rego", "row": 9, "text": "\t1 == 1"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": "https://docs.styra.com/regal/rules/constant-condition",
+		}],
+		"title": "constant-condition",
+	}}
+}
+
+test_success_non_constant_condition if {
+	report(`allow { 1 == input.one }`) == set()
+}
+
+test_fail_top_level_iteration_wildcard if {
+	r := report(`x := input.foo.bar[_]`)
+	r == {{
+		"category": "bugs",
+		"description": "Iteration in top-level assignment",
+		"location": {"col": 1, "file": "policy.rego", "row": 8, "text": "x := input.foo.bar[_]"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": "https://docs.styra.com/regal/rules/top-level-iteration",
+		}],
+		"title": "top-level-iteration",
+	}}
+}
+
+test_fail_top_level_iteration_named_var if {
+	r := report(`x := input.foo.bar[i]`)
+	r == {{
+		"category": "bugs",
+		"description": "Iteration in top-level assignment",
+		"location": {"col": 1, "file": "policy.rego", "row": 8, "text": "x := input.foo.bar[i]"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": "https://docs.styra.com/regal/rules/top-level-iteration",
+		}],
+		"title": "top-level-iteration",
+	}}
+}
+
+test_success_top_level_known_var_ref if {
+	report(`
+	i := "foo"
+	x := input.foo.bar[i]`) == set()
+}
+
+test_success_top_level_input_ref if {
+	report(`x := input.foo.bar[input.y]`) == set()
+}
+
+report(snippet) := report if {
+	# regal ignore:external-reference
+	report := bugs.report with input as ast.with_future_keywords(snippet)
+		with config.for_rule as {"enabled": true}
+}

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -12,6 +12,10 @@ func NewCompilerWithRegalBuiltins() *ast.Compiler {
 		Name: builtins.RegalParseModuleMeta.Name,
 		Decl: builtins.RegalParseModuleMeta.Decl,
 	})
+	caps.Builtins = append(caps.Builtins, &ast.Builtin{
+		Name: builtins.RegalJSONPrettyMeta.Name,
+		Decl: builtins.RegalJSONPrettyMeta.Decl,
+	})
 
 	return ast.NewCompiler().WithCapabilities(caps)
 }

--- a/internal/test/rego_test.go
+++ b/internal/test/rego_test.go
@@ -71,5 +71,12 @@ func customBuiltins() []*tester.Builtin {
 			},
 			Func: rego.Function2(builtins.RegalParseModuleMeta, builtins.RegalParseModule),
 		},
+		{
+			Decl: &ast.Builtin{
+				Name: builtins.RegalJSONPrettyMeta.Name,
+				Decl: builtins.RegalJSONPrettyMeta.Decl,
+			},
+			Func: rego.Function1(builtins.RegalJSONPrettyMeta, builtins.RegalJSONPretty),
+		},
 	}
 }

--- a/pkg/builtins/builtins.go
+++ b/pkg/builtins/builtins.go
@@ -25,6 +25,17 @@ var RegalParseModuleMeta = &rego.Function{
 	),
 }
 
+// RegalJSONPrettyMeta metadata for regal.json_pretty.
+var RegalJSONPrettyMeta = &rego.Function{
+	Name: "regal.json_pretty",
+	Decl: types.NewFunction(
+		types.Args(
+			types.Named("data", types.A).Description("data to marshal to JSON in a pretty format"),
+		),
+		types.Named("output", types.S),
+	),
+}
+
 // RegalParseModule regal.parse_module, like rego.parse_module but with location data included in AST.
 func RegalParseModule(_ rego.BuiltinContext, filename *ast.Term, policy *ast.Term) (*ast.Term, error) {
 	policyStr, err := builtins.StringOperand(policy.Value, 1)
@@ -58,4 +69,14 @@ func RegalParseModule(_ rego.BuiltinContext, filename *ast.Term, policy *ast.Ter
 	}
 
 	return term, nil
+}
+
+// RegalJSONPretty regal.json_pretty, like json.marshal but with pretty formatting.
+func RegalJSONPretty(_ rego.BuiltinContext, data *ast.Term) (*ast.Term, error) {
+	encoded, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+
+	return ast.StringTerm(string(encoded)), nil
 }

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -123,6 +123,7 @@ func (l Linter) prepareRegoArgs() []func(*rego.Rego) {
 		rego.EnablePrintStatements(true),
 		rego.PrintHook(topdown.NewPrintHook(os.Stderr)),
 		rego.Function2(builtins.RegalParseModuleMeta, builtins.RegalParseModule),
+		rego.Function1(builtins.RegalJSONPrettyMeta, builtins.RegalJSONPretty),
 	)
 
 	if l.configBundle != nil {

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -17,7 +17,7 @@ func TestLintBasic(t *testing.T) {
 
 # TODO: fix this
 camelCase {
-	1 == 1
+	1 == input.one
 }
 `
 
@@ -72,7 +72,7 @@ func TestLintWithUserConfig(t *testing.T) {
 
 # TODO: fix this
 camelCase {
-	1 == 1
+	1 == input.one
 }
 `
 


### PR DESCRIPTION
Two new linter rules in a new "bugs" category:

- constant-conditions
- top-level-iteration

I found that I also wanted a way to use `print` for nested objects, but the default serialization is really compact. Added a `regal.json_pretty` to help with that.