### PR TITLE
Add `regal test` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Regal comes with a set of built-in rules. The following rules are currently avai
 |  Category  |                                           Title                                           |                      Description                       |
 |------------|-------------------------------------------------------------------------------------------|--------------------------------------------------------|
 | assignment | [use-assignment-operator](https://docs.styra.com/regal/rules/use-assignment-operator)     | Prefer := over = for assignment                        |
+| bugs       | [constant-condition](https://docs.styra.com/regal/rules/constant-condition)               | Constant condition                                     |
+| bugs       | [top-level-iteration](https://docs.styra.com/regal/rules/top-level-iteration)             | Iteration in top-level assignment                      |
 | comments   | [todo-comment](https://docs.styra.com/regal/rules/todo-comment)                           | Avoid TODO comments                                    |
 | functions  | [external-reference](https://docs.styra.com/regal/rules/external-reference)               | Reference to input, data or rule ref in function body  |
 | imports    | [implicit-future-keywords](https://docs.styra.com/regal/rules/implicit-future-keywords)   | Use explicit future keyword imports                    |
@@ -74,8 +76,8 @@ develop your own rules, for yourself or for inclusion in Regal.
 
 ## Configuration
 
-A custom configuration file may be used to override the [default configuration](bundle/regal/config/data.yaml) options
-provided by Regal. This is particularly useful for e.g. enabling/disabling certain rules, or to provide more
+A custom configuration file may be used to override the [default configuration](bundle/regal/config/provided/data.yaml)
+options provided by Regal. This is particularly useful for e.g. enabling/disabling certain rules, or to provide more
 fine-grained options for the linter rules that support it.
 
 **.regal/config.yaml**
@@ -95,197 +97,13 @@ provided will be used to override the default configuration.
 
 ## Custom Rules
 
-Regal is built to be easily extended. Creating custom rules is a great way to enforce naming conventions, best practices
-or more opinionated rules across teams and organizations. If you'd like to provide your own linter rules for a project,
-you may do so by placing them in a `rules` directory inside the `.regal` directory preferably placed in the root of your
-project (which is also where [custom configuration](#configuration) resides).
-
-If you so prefer, custom rules may also be provided using the `--rules` option for `regal lint`, which may point either
-to a Rego file, or a directory containing Rego files and potentially data (JSON or YAML).
-
-### Developing Rules
-
-Regal rules works primarily on the abstract syntax tree (AST) as parsed by OPA. The AST of each policy scanned will be
-provided as input to the linter policies, and additional data useful in the context of linting, as well as some
-purpose-built custom functions are made available in any Regal policy.
-
-If we were to write the simplest policy possible, it would contain nothing but a package declaration:
-
-**policy.rego**
-```rego
-package policy
-```
-
-Using `opa parse --format json --json-include locations policy.rego`, we're provided with the AST of the above policy:
-
-```json
-{
-  "package": {
-    "location": {
-      "file": "policy.rego",
-      "row": 1,
-      "col": 1
-    },
-    "path": [
-      {
-        "location": {
-          "file": "policy.rego",
-          "row": 1,
-          "col": 9
-        },
-        "type": "var",
-        "value": "data"
-      },
-      {
-        "location": {
-          "file": "policy.rego",
-          "row": 1,
-          "col": 9
-        },
-        "type": "string",
-        "value": "policy"
-      }
-    ]
-  }
-}
-```
-
-As trivial as may be, it's enough to build our first linter rule! Let's say we'd like to enforce a uniform naming
-convention on any policy in a repository. Packages may be named anything, but must start with the name of the
-organization (Acme Corp). So `package acme.corp.policy` should be allowed, but not `package policy` or
-`package policy.acme.corp`. One exception: policy authors should be allowed to write policy for the `system.log` package
-provided by OPA to allow
-[masking](https://www.openpolicyagent.org/docs/latest/management-decision-logs/#masking-sensitive-data) sensitive data
-from decision logs.
-
-An example policy to implement this requirement might look something like this:
-
-```rego
-package custom.regal.rules.naming
-
-import future.keywords.contains
-import future.keywords.if
-
-import data.regal.result
-
-# METADATA
-# title: acme-corp-package
-# description: All packages must use "acme.corp" base name
-# related_resources:
-# - description: documentation
-#   ref: https://www.acmecorp.example.org/docs/regal/package
-# custom:
-#   category: naming
-report contains violation if {
-	not acme_corp_package
-	not system_log_package
-
-	violation := result.fail(rego.metadata.rule(), result.location(input["package"].path[1]))
-}
-
-acme_corp_package if {
-	input["package"].path[1].value == "acme"
-	input["package"].path[2].value == "corp"
-}
-
-system_log_package if {
-	input["package"].path[1].value == "system"
-	input["package"].path[2].value == "log"
-}
-```
-
-Starting from top to bottom, these are the components comprising our custom rule:
-
-1. The package of custom rules **must** start with `custom.regal.rules`, followed by the category of the rule.
-2. Importing `data.regal` provides policy authors with custom built-in functions to help author rules, but is optional.
-3. Regal rules make heavy use of [metadata annotations](https://www.openpolicyagent.org/docs/latest/annotations/) in
-   order to document the purpose of the rule, along with any other information that could potentially be useful.
-   All rules **must** have a `title`, a `description`, and a `category` (placed under the `custom` object). Providing
-   links to additional documentation under `related_resources` is recommended, but not required.
-4. Regal will evaluate any rule named `report` in each linter policy, so at least one `report` rule **must** be present.
-5. In our example `report` rule, we evaluate another rule (`acme_corp_package`) in order to know if the package name
-   starts with `acme.corp`, and another rule (`system_log_package`) to know if it starts with `system.log`. If neither
-   of the conditions are true, the rule fails and violation is created.
-6. The violation is created by calling `result.fail`, which takes the metadata from the rule and returns it, which will
-   later be included in the final report provided by Regal.
-7. The `result.location` helps extract the location from the element failing the test. Make sure to use it!
+See the docs on [custom rules](/docs/custom-rules) for more information on how to develop your own rules.
 
 ## Development
 
-### Building
-
-1. Run the `build.sh` script to populate the `data` directory with any data necessary for
-   linting (such as the built-in function metadata from OPA).
-2. Build the `regal` executable by running `go build`.
-
-### Testing
-
-To run all tests, including the Rego rules unit tests:
-
-```shell
-go test ./...
-```
-
-### Linting
-
-Regal uses [golangci-lint](https://golangci-lint.run/) with most linters enabled. In order to check your code, run:
-
-```shell
-golangci-lint run ./...
-```
-
-In order to satisfy the [gci](https://github.com/daixiang0/gci) linter, you may either manually order imports, or have
-them automatically ordered and grouped by the tool:
-
-```shell
-gci write \
-  -s standard \
-  -s default \
-  -s "prefix(github.com/open-policy-agent/opa)" \
-  -s "prefix(github.com/styrainc/regal)" \
-  -s blank \
-  -s dot .
-```
-### Authoring Rules
-
-During development of Rego-based rules, you may want to test the policies in isolation — i.e. without running Regal.
-Since Regal policies and data are kept in a regular
-[bundle](https://www.openpolicyagent.org/docs/latest/management-bundles/) structure, this is simple. Given we want to
-test `p.rego` against the available set of rules, we can have OPA parse it and pipe the output to `opa eval` for
-evaluation:
-
-```shell
-$ opa parse p.rego --format json --json-include locations | opa eval -f pretty -b bundle -I data.regal.main.report
-[
-  {
-    "category": "variables",
-    "description": "Unconditional assignment in rule body",
-    "related_resources": [
-      {
-        "description": "documentation",
-        "ref": "https://docs.styra.com/regal/rules/unconditional-assignment"
-      }
-    ],
-    "title": "unconditional-assignment"
-  }
-]
-```
-
-### Built-in Functions
-
-Regal provides a few custom built-in functions tailor-made for linter policies. 
-
-#### `regal.parse_module(filename, policy)`
-
-Works just like `rego.parse_module`, but provides an AST including location information, and custom additions added
-by Regal, like the text representation of each line in the original policy.
-
-#### `regal.json_pretty(data)`
-
-Printing nested objects and arrays is quite helpful for debugging AST nodes, but the standard representation — where
-everything is displayed on a single line — not so much. This built-in allows marshalling JSON similar to `json.marshal`,
-but with newlines and spaces added for a more pleasant experience.
+See the [development](/docs/development) docs if you'd like to hack on Regal itself.
 
 ## Community
 
-For questions, discussions and announcements related to Styra products, services and open source projects, please join the Styra community on [Slack](https://join.slack.com/t/styracommunity/shared_invite/zt-1p81qz8g4-t2OLKbvw0J5ibdcNc62~6Q)!
+For questions, discussions and announcements related to Styra products, services and open source projects, please join 
+the Styra community on [Slack](https://join.slack.com/t/styracommunity/shared_invite/zt-1p81qz8g4-t2OLKbvw0J5ibdcNc62~6Q)!

--- a/cmd/filter.go
+++ b/cmd/filter.go
@@ -1,0 +1,25 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/open-policy-agent/opa/loader"
+)
+
+type loaderFilter struct {
+	Ignore []string
+}
+
+func (f loaderFilter) Apply(abspath string, info os.FileInfo, depth int) bool {
+	for _, s := range f.Ignore {
+		if loader.GlobExcludeName(s, 1)(abspath, info, depth) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,0 +1,353 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/bundle"
+	"github.com/open-policy-agent/opa/cover"
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/storage/inmem"
+	"github.com/open-policy-agent/opa/tester"
+	"github.com/open-policy-agent/opa/topdown"
+	"github.com/open-policy-agent/opa/util"
+	"github.com/open-policy-agent/opa/version"
+
+	"github.com/styrainc/regal/internal/compile"
+	"github.com/styrainc/regal/pkg/builtins"
+)
+
+const (
+	testPrettyOutput       = "pretty"
+	testJSONOutput         = "json"
+	benchmarkGoBenchOutput = "gobench"
+)
+
+type testCommandParams struct {
+	verbose      bool
+	outputFormat *util.EnumFlag
+	coverage     bool
+	threshold    float64
+	timeout      time.Duration
+	ignore       []string
+	bundleMode   bool
+	benchmark    bool
+	benchMem     bool
+	runRegex     string
+	count        int
+	skipExitZero bool
+}
+
+func newTestCommandParams() *testCommandParams {
+	return &testCommandParams{
+		outputFormat: util.NewEnumFlag(testPrettyOutput, []string{
+			testPrettyOutput,
+			testJSONOutput,
+			benchmarkGoBenchOutput,
+		}),
+	}
+}
+
+var testParams = newTestCommandParams() //nolint: gochecknoglobals
+
+var testCommand = &cobra.Command{ //nolint: gochecknoglobals
+	Hidden: true,
+	Use:    "test <path> [path [...]]",
+	Short:  "Execute Rego test cases for Regal",
+	Long: `Execute Rego test cases for Regal rules.
+
+The 'test' command works mostly like OPA's test command, but with all Regal-specific built-ins included. Note that this
+command is only meant to be used for testing of Regal rules, and should only be relevant to users authoring their own
+rules.
+
+`,
+	PreRunE: func(Cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return fmt.Errorf("specify at least one file")
+		}
+
+		return nil
+	},
+
+	Run: func(cmd *cobra.Command, args []string) {
+		os.Exit(opaTest(args))
+	},
+}
+
+func opaTest(args []string) int { //nolint: funlen
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if testParams.outputFormat.String() == benchmarkGoBenchOutput && !testParams.benchmark {
+		fmt.Fprintf(
+			os.Stderr,
+			"cannot use output format %s without running benchmarks (--bench)\n",
+			benchmarkGoBenchOutput,
+		)
+
+		return 0
+	}
+
+	if !isThresholdValid(testParams.threshold) {
+		fmt.Fprintln(os.Stderr, "Code coverage threshold must be between 0 and 100")
+
+		return 1
+	}
+
+	filter := loaderFilter{
+		Ignore: testParams.ignore,
+	}
+
+	var modules map[string]*ast.Module
+
+	var bundles map[string]*bundle.Bundle
+
+	var store storage.Store
+
+	var err error
+
+	if testParams.bundleMode {
+		bundles, err = tester.LoadBundles(args, filter.Apply)
+		store = inmem.NewWithOpts(inmem.OptRoundTripOnWrite(false))
+	} else {
+		modules, store, err = tester.Load(args, filter.Apply)
+	}
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+
+		return 1
+	}
+
+	txn, err := store.NewTransaction(ctx, storage.WriteParams)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+
+		return 1
+	}
+
+	defer store.Abort(ctx, txn)
+
+	compiler := compile.NewCompilerWithRegalBuiltins().
+		WithPathConflictsCheck(storage.NonEmpty(ctx, store, txn)).
+		WithEnablePrintStatements(!testParams.benchmark)
+
+	if testParams.threshold > 0 && !testParams.coverage {
+		testParams.coverage = true
+	}
+
+	var cov *cover.Cover
+
+	var coverTracer topdown.QueryTracer
+
+	if testParams.coverage {
+		if testParams.benchmark {
+			fmt.Fprintln(os.Stderr, "coverage reporting is not supported when benchmarking tests")
+
+			return 1
+		}
+
+		cov = cover.New()
+		coverTracer = cov
+	}
+
+	runner := tester.NewRunner().
+		SetCompiler(compiler).
+		SetStore(store).
+		CapturePrintOutput(true).
+		SetCoverageQueryTracer(coverTracer).
+		SetRuntime(Runtime()).
+		SetModules(modules).
+		SetBundles(bundles).
+		SetTimeout(getTimeout()).
+		AddCustomBuiltins(builtins.TestContextBuiltins()).
+		Filter(testParams.runRegex)
+
+	for i := 0; i < testParams.count; i++ {
+		exitCode := runTests(ctx, txn, runner, testReporter(cov, modules))
+		if exitCode != 0 {
+			return exitCode
+		}
+	}
+
+	return 0
+}
+
+func testReporter(cov *cover.Cover, modules map[string]*ast.Module) tester.Reporter {
+	var reporter tester.Reporter
+
+	goBench := false
+
+	if !testParams.coverage {
+		switch testParams.outputFormat.String() {
+		case testJSONOutput:
+			reporter = tester.JSONReporter{Output: os.Stdout}
+		case benchmarkGoBenchOutput:
+			goBench = true
+
+			fallthrough
+		default:
+			reporter = tester.PrettyReporter{
+				Verbose:                  testParams.verbose,
+				Output:                   os.Stdout,
+				BenchmarkResults:         testParams.benchmark,
+				BenchMarkShowAllocations: testParams.benchMem,
+				BenchMarkGoBenchFormat:   goBench,
+			}
+		}
+	} else {
+		reporter = tester.JSONCoverageReporter{
+			Cover:     cov,
+			Modules:   modules,
+			Output:    os.Stdout,
+			Threshold: testParams.threshold,
+		}
+	}
+
+	return reporter
+}
+
+func getTimeout() time.Duration {
+	timeout := testParams.timeout
+	if timeout == 0 { // unset
+		timeout = 5 * time.Second
+		if testParams.benchmark {
+			timeout = 30 * time.Second
+		}
+	}
+
+	return timeout
+}
+
+func runTests(ctx context.Context, txn storage.Transaction, runner *tester.Runner, reporter tester.Reporter) int {
+	var err error
+
+	var ch chan *tester.Result
+
+	if testParams.benchmark {
+		benchOpts := tester.BenchmarkOptions{
+			ReportAllocations: testParams.benchMem,
+		}
+		ch, err = runner.RunBenchmarks(ctx, txn, benchOpts)
+	} else {
+		ch, err = runner.RunTests(ctx, txn)
+	}
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+
+		return 1
+	}
+
+	exitCode := 0
+	dup := make(chan *tester.Result)
+
+	go func() {
+		defer close(dup)
+
+		for tr := range ch {
+			if !tr.Pass() && !testParams.skipExitZero {
+				exitCode = 2
+			}
+
+			if tr.Skip && exitCode == 0 && testParams.skipExitZero {
+				// there is a skipped test, adding the flag -z exits 0 if there are no failures
+				exitCode = 0
+			}
+
+			dup <- tr
+		}
+	}()
+
+	if err := reporter.Report(dup); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+
+		if !testParams.benchmark {
+			if _, ok := err.(*cover.CoverageThresholdError); ok { //nolint: errorlint
+				return 2
+			}
+		}
+
+		return 1
+	}
+
+	return exitCode
+}
+
+func isThresholdValid(t float64) bool {
+	return 0 <= t && t <= 100
+}
+
+func init() {
+	testCommand.Flags().BoolVarP(&testParams.skipExitZero, "exit-zero-on-skipped", "z", false,
+		"skipped tests return status 0")
+	testCommand.Flags().BoolVarP(&testParams.verbose, "verbose", "v", false,
+		"set verbose reporting mode")
+	testCommand.Flags().DurationVar(&testParams.timeout, "timeout", 0,
+		"set test timeout (default 5s, 30s when benchmarking)")
+	testCommand.Flags().VarP(testParams.outputFormat, "format", "f",
+		"set output format")
+	testCommand.Flags().BoolVarP(&testParams.coverage, "coverage", "c", false,
+		"report coverage (overrides debug tracing)")
+	testCommand.Flags().Float64VarP(&testParams.threshold, "threshold", "", 0,
+		"set coverage threshold and exit with non-zero status if coverage is less than threshold %")
+	testCommand.Flags().BoolVar(&testParams.benchmark, "bench", false,
+		"benchmark the unit tests")
+	testCommand.Flags().StringVarP(&testParams.runRegex, "run", "r", "",
+		"run only test cases matching the regular expression.")
+
+	addBundleModeFlag(testCommand.Flags(), &testParams.bundleMode, false)
+	addBenchmemFlag(testCommand.Flags(), &testParams.benchMem, true)
+	addCountFlag(testCommand.Flags(), &testParams.count, "test")
+	addIgnoreFlag(testCommand.Flags(), &testParams.ignore)
+
+	RootCommand.AddCommand(testCommand)
+}
+
+func Runtime() *ast.Term {
+	obj := ast.NewObject()
+	env := ast.NewObject()
+
+	for _, s := range os.Environ() {
+		parts := strings.SplitN(s, "=", 2)
+		if len(parts) == 1 {
+			env.Insert(ast.StringTerm(parts[0]), ast.NullTerm())
+		} else if len(parts) > 1 {
+			env.Insert(ast.StringTerm(parts[0]), ast.StringTerm(parts[1]))
+		}
+	}
+
+	obj.Insert(ast.StringTerm("env"), ast.NewTerm(env))
+	obj.Insert(ast.StringTerm("version"), ast.StringTerm(version.Version))
+	obj.Insert(ast.StringTerm("commit"), ast.StringTerm(version.Vcs))
+
+	return ast.NewTerm(obj)
+}
+
+func addBundleModeFlag(fs *pflag.FlagSet, bundle *bool, value bool) {
+	fs.BoolVarP(bundle, "bundle", "b", value, "load paths as bundle files or root directories")
+}
+
+func addBenchmemFlag(fs *pflag.FlagSet, benchMem *bool, value bool) {
+	fs.BoolVar(benchMem, "benchmem", value, "report memory allocations with benchmark results")
+}
+
+func addCountFlag(fs *pflag.FlagSet, count *int, cmdType string) {
+	fs.IntVar(count, "count", 1, fmt.Sprintf("number of times to repeat each %s", cmdType))
+}
+
+func addIgnoreFlag(fs *pflag.FlagSet, ignoreNames *[]string) {
+	fs.StringSliceVarP(ignoreNames, "ignore", "", []string{},
+		"set file and directory names to ignore during loading (e.g., '.*' excludes hidden files)")
+}

--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -1,0 +1,164 @@
+# Custom Rules
+
+Regal is built to be easily extended. Creating custom rules is a great way to enforce naming conventions, best practices
+or more opinionated rules across teams and organizations. If you'd like to provide your own linter rules for a project,
+you may do so by placing them in a `rules` directory inside the `.regal` directory preferably placed in the root of your
+project (which is also where custom configuration resides).
+
+If you so prefer, custom rules may also be provided using the `--rules` option for `regal lint`, which may point either
+to a Rego file, or a directory containing Rego files and potentially data (JSON or YAML).
+
+## Developing Rules
+
+Regal rules works primarily on the abstract syntax tree (AST) as parsed by OPA, with a few custom additions. The AST of
+each policy scanned will be provided as input to the linter policies, and additional data useful in the context of
+linting, as well as some purpose-built custom functions are made available in any Regal policy.
+
+If we were to write the simplest policy possible, and parse it using `opa parse`, it would contain nothing but a package
+declaration:
+
+**policy.rego**
+```rego
+package policy
+```
+
+Using `opa parse --format json --json-include locations policy.rego`, we're provided with the AST of the above policy:
+
+```json
+{
+  "package": {
+    "location": {
+      "file": "policy.rego",
+      "row": 1,
+      "col": 1
+    },
+    "path": [
+      {
+        "location": {
+          "file": "policy.rego",
+          "row": 1,
+          "col": 9
+        },
+        "type": "var",
+        "value": "data"
+      },
+      {
+        "location": {
+          "file": "policy.rego",
+          "row": 1,
+          "col": 9
+        },
+        "type": "string",
+        "value": "policy"
+      }
+    ]
+  }
+}
+```
+
+As trivial as may be, it's enough to build our first linter rule! Let's say we'd like to enforce a uniform naming
+convention on any policy in a repository. Packages may be named anything, but must start with the name of the
+organization (Acme Corp). So `package acme.corp.policy` should be allowed, but not `package policy` or
+`package policy.acme.corp`. One exception: policy authors should be allowed to write policy for the `system.log` package
+provided by OPA to allow
+[masking](https://www.openpolicyagent.org/docs/latest/management-decision-logs/#masking-sensitive-data) sensitive data
+from decision logs.
+
+An example policy to implement this requirement might look something like this:
+
+```rego
+package custom.regal.rules.naming
+
+import future.keywords.contains
+import future.keywords.if
+
+import data.regal.result
+
+# METADATA
+# title: acme-corp-package
+# description: All packages must use "acme.corp" base name
+# related_resources:
+# - description: documentation
+#   ref: https://www.acmecorp.example.org/docs/regal/package
+# custom:
+#   category: naming
+report contains violation if {
+	not acme_corp_package
+	not system_log_package
+
+	violation := result.fail(rego.metadata.rule(), result.location(input["package"].path[1]))
+}
+
+acme_corp_package if {
+	input["package"].path[1].value == "acme"
+	input["package"].path[2].value == "corp"
+}
+
+system_log_package if {
+	input["package"].path[1].value == "system"
+	input["package"].path[2].value == "log"
+}
+```
+
+Starting from top to bottom, these are the components comprising our custom rule:
+
+1. The package of custom rules **must** start with `custom.regal.rules`, followed by the category of the rule.
+2. Importing `data.regal` provides policy authors with custom built-in functions to help author rules, but is optional.
+3. Regal rules make heavy use of [metadata annotations](https://www.openpolicyagent.org/docs/latest/annotations/) in
+   order to document the purpose of the rule, along with any other information that could potentially be useful.
+   All rules **must** have a `title`, a `description`, and a `category` (placed under the `custom` object). Providing
+   links to additional documentation under `related_resources` is recommended, but not required.
+4. Regal will evaluate any rule named `report` in each linter policy, so at least one `report` rule **must** be present.
+5. In our example `report` rule, we evaluate another rule (`acme_corp_package`) in order to know if the package name
+   starts with `acme.corp`, and another rule (`system_log_package`) to know if it starts with `system.log`. If neither
+   of the conditions are true, the rule fails and violation is created.
+6. The violation is created by calling `result.fail`, which takes the metadata from the rule and returns it, which will
+   later be included in the final report provided by Regal.
+7. The `result.location` helps extract the location from the element failing the test. Make sure to use it!
+
+## Parsing and Testing
+
+Regal provides a few tools mirrored from OPA in order to help test and debug custom rules. These are necessary since OPA
+is not aware of the custom [built-in functions](#built-in-functions) included in Regal, and will fail when encountering
+e.g. `regal.parse_module` in a custom linter policy. The following commands are included with Regal to help you author
+custom rules:
+
+- `regal parse` works similarly to `opa parse`, but will always output JSON and include location information, and any
+  additional data added to the AST by Regal.
+- `regal test` works like `opa test`
+
+Given we want to test `p.rego` against the available set of rules, we can have OPA parse it and pipe the output
+to `opa eval` for evaluation:
+
+```shell
+$ regal parse p.rego | opa eval -f pretty -b bundle -I data.regal.main.report
+[
+  {
+    "category": "variables",
+    "description": "Unconditional assignment in rule body",
+    "related_resources": [
+      {
+        "description": "documentation",
+        "ref": "https://docs.styra.com/regal/rules/unconditional-assignment"
+      }
+    ],
+    "title": "unconditional-assignment"
+  }
+]
+```
+
+## Built-in Functions
+
+Regal provides a few custom built-in functions tailor-made for linter policies.
+
+### `regal.parse_module(filename, policy)`
+
+Works just like `rego.parse_module`, but provides an AST including location information, and custom additions added
+by Regal, like the text representation of each line in the original policy. This is useful for authoring tests to assert
+linter rules work as expected.
+
+### `regal.json_pretty(data)`
+
+Printing nested objects and arrays is quite helpful for debugging AST nodes, but the standard representation — where
+everything is displayed on a single line — not so much. This built-in allows marshalling JSON similar to `json.marshal`,
+but with newlines and spaces added for a more pleasant experience.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,38 @@
+# Development
+
+If you'd like to contribute to Regal, here are some pointers to help get you started.
+
+## Building
+
+1. Run the `build.sh` script to populate the `data` directory with any data necessary for linting (such as the built-in
+   function metadata from OPA)
+2. Build the `regal` executable by running `go build`
+
+## Testing
+
+To run all tests, including the Rego rules unit tests:
+
+```shell
+go test ./...
+```
+
+## Linting
+
+Regal uses [golangci-lint](https://golangci-lint.run/) with most linters enabled. In order to check your code, run:
+
+```shell
+golangci-lint run ./...
+```
+
+In order to please the [gci](https://github.com/daixiang0/gci) linter, you may either manually order imports, or have
+them automatically ordered and grouped by the tool:
+
+```shell
+gci write \
+  -s standard \
+  -s default \
+  -s "prefix(github.com/open-policy-agent/opa)" \
+  -s "prefix(github.com/styrainc/regal)" \
+  -s blank \
+  -s dot .
+```

--- a/pkg/builtins/builtins.go
+++ b/pkg/builtins/builtins.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/tester"
 	"github.com/open-policy-agent/opa/topdown/builtins"
 	"github.com/open-policy-agent/opa/types"
 
@@ -79,4 +80,24 @@ func RegalJSONPretty(_ rego.BuiltinContext, data *ast.Term) (*ast.Term, error) {
 	}
 
 	return ast.StringTerm(string(encoded)), nil
+}
+
+// TestContextBuiltins returns the list of builtins as expected by the test runner.
+func TestContextBuiltins() []*tester.Builtin {
+	return []*tester.Builtin{
+		{
+			Decl: &ast.Builtin{
+				Name: RegalParseModuleMeta.Name,
+				Decl: RegalParseModuleMeta.Decl,
+			},
+			Func: rego.Function2(RegalParseModuleMeta, RegalParseModule),
+		},
+		{
+			Decl: &ast.Builtin{
+				Name: RegalJSONPrettyMeta.Name,
+				Decl: RegalJSONPrettyMeta.Decl,
+			},
+			Func: rego.Function1(RegalJSONPrettyMeta, RegalJSONPretty),
+		},
+	}
 }


### PR DESCRIPTION
Mirror `opa test` but with awareness of custom built-ins.

Also restructure the docs to add separate pages for custom rule authoring and Regal development.

Fixes #59