### PR TITLE
Add docs for rules on imports

### DIFF
--- a/bundle/regal/rules/imports/imports.rego
+++ b/bundle/regal/rules/imports/imports.rego
@@ -60,11 +60,15 @@ report contains violation if {
 
 	imported.path.value[0].value == "input"
 
-	# If we want to allow aliasing input, eg `import input as tfplan`:
-	# count(imported.path.value) == 1
-	# imported.alias
+	# Allow aliasing input, eg `import input as tfplan`:
+	not _aliased_input(imported)
 
 	violation := result.fail(rego.metadata.rule(), result.location(imported.path.value[0]))
+}
+
+_aliased_input(imported) if {
+	count(imported.path.value) == 1
+	imported.alias
 }
 
 # METADATA

--- a/bundle/regal/rules/imports/imports_test.rego
+++ b/bundle/regal/rules/imports/imports_test.rego
@@ -46,6 +46,24 @@ test_fail_import_input if {
 	}}
 }
 
+test_sucess_import_aliased_input if {
+	report(`import input as tfplan`) == set()
+}
+
+test_fail_import_input_aliased_attribute if {
+	report(`import input.foo.bar as barbar`) == {{
+		"category": "imports",
+		"description": "Avoid importing input",
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/avoid-importing-input", "imports"),
+		}],
+		"title": "avoid-importing-input",
+		"location": {"col": 8, "file": "policy.rego", "row": 3, "text": `import input.foo.bar as barbar`},
+		"level": "error",
+	}}
+}
+
 test_fail_import_data if {
 	report(`import data`) == {{
 		"category": "imports",

--- a/docs/rules/imports/avoid-importing-input.md
+++ b/docs/rules/imports/avoid-importing-input.md
@@ -1,0 +1,80 @@
+# avoid-importing-input
+
+**Summary**: Avoid importing `input`
+
+**Category**: Imports
+
+**Avoid**
+```rego
+package policy
+
+import future.keywords.if
+
+# This is always redundant
+import input
+
+# This might be useful, but better to move to a local assignment
+import input.user.email
+
+allow if "admin" in input.user.roles
+
+allow if {
+    endswith(email, "@acmecorp.com")
+}
+```
+
+**Prefer**
+```rego
+package policy
+
+allow if "admin" in input.user.roles
+
+allow if {
+    email := input.user.email
+    endswith(email, "@acmecorp.com")
+}
+```
+
+**Exception**
+
+Using an alias for `input` can sometimes be useful, e.g. when using `input` is known to represent something specific,
+like a Terraform plan. Aliasing of specific input attributes should however be avoided in favor of local assignments.
+
+```rego
+package policy
+
+import future.keywords.if
+
+# This is acceptable
+import input as tfplan
+
+# But this should be avoided - use assignment instead:
+# username := input.user.name
+import input.user.name as username
+
+allow if {
+    some resource_change in tfplan.resource_changes
+    # ...
+}
+```
+
+## Rationale
+
+Using an import for `input` is not necessary, as both `input` and `data` are globally available. 
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules: 
+  imports:
+    avoid-importing-input:
+      # one of "error", "warning", "ignore"
+      level: error
+```
+
+## Related Resources
+
+- Rego Style Guide: [Avoid importing `input`](https://github.com/StyraInc/rego-style-guide#avoid-importing-input)
+- OPA docs: [Terraform Tutorial](https://www.openpolicyagent.org/docs/latest/terraform)

--- a/docs/rules/imports/implicit-future-keywords.md
+++ b/docs/rules/imports/implicit-future-keywords.md
@@ -1,0 +1,55 @@
+# implicit-future-keywords
+
+**Summary**: Implicit future keywords
+
+**Category**: Imports
+
+**Avoid**
+```rego
+package policy
+
+import future.keywords
+
+report contains violation if {
+    not "developer" in input.user.roles
+    
+    violation := "Required role 'developer' missing"
+}
+```
+
+**Prefer**
+```rego
+package policy
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+report contains violation if {
+    not "developer" in input.user.roles
+    
+    violation := "Required role 'developer' missing"
+}
+```
+
+## Rationale
+
+Using the "catch all" import of `future.keywords` is convenient, but it can lead to unexpected behavior. If future
+versions of OPA introduces new keywords, there's always a risk that these keywords will conflict with existing rule and
+variable names in your policy.
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules: 
+  imports:
+    implicit-future-keywords:
+      # one of "error", "warning", "ignore"
+      level: error
+```
+
+## Related Resources
+
+- Rego Style Guide: [Use explicit imports for future keywords](https://github.com/StyraInc/rego-style-guide#use-explicit-imports-for-future-keywords)

--- a/docs/rules/imports/import-shadows-import.md
+++ b/docs/rules/imports/import-shadows-import.md
@@ -1,0 +1,44 @@
+# import-shadows-import
+
+**Summary**: Import shadows import
+
+**Category**: Imports
+
+**Avoid**
+```rego
+package policy
+
+import data.permissions
+import data.users
+
+# Already imported
+import data.permissions
+```
+
+**Prefer**
+```rego
+package policy
+
+import data.permissions
+import data.users
+```
+
+## Rationale
+
+Duplicate imports are redundant, and while harmless, should just be removed.
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules: 
+  imports:
+    import-shadows-import:
+      # one of "error", "warning", "ignore"
+      level: error
+```
+
+## Related Resources
+
+- OPA Docs: [Strict Mode](https://www.openpolicyagent.org/docs/latest/policy-language/#strict-mode)

--- a/docs/rules/imports/redundant-data-import.md
+++ b/docs/rules/imports/redundant-data-import.md
@@ -1,0 +1,28 @@
+# redundant-data-import
+
+**Summary**: Redundant import of data
+
+**Category**: Imports
+
+**Avoid**
+```rego
+package policy
+
+import data
+```
+
+## Rationale
+
+Just like `input`, `data` is always globally available and does not need to be imported.
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules: 
+  imports:
+    redundant-data-import:
+      # one of "error", "warning", "ignore"
+      level: error
+```


### PR DESCRIPTION
And a tiny modification to the rule around importing `input` as we should allow aliasing input for e.g. Terraform policies.