### PR TITLE
Implement simple concurrent Rego evaluation

### DIFF
--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -163,7 +163,9 @@ func (l Linter) lintWithRegoRules(ctx context.Context, input rules.Input) (repor
 	aggregate := report.Report{}
 
 	var wg sync.WaitGroup
+
 	var mu sync.Mutex
+
 	errCh := make(chan error)
 	doneCh := make(chan bool)
 
@@ -177,21 +179,25 @@ func (l Linter) lintWithRegoRules(ctx context.Context, input rules.Input) (repor
 
 		go func(name string) {
 			defer wg.Done()
+
 			enhancedAST, err := parse.EnhanceAST(name, input.FileContent[name], input.Modules[name])
 			if err != nil {
 				errCh <- fmt.Errorf("failed preparing AST: %w", err)
+
 				return
 			}
 
 			resultSet, err := linterQuery.Eval(ctx, rego.EvalInput(enhancedAST))
 			if err != nil {
 				errCh <- fmt.Errorf("error encountered in query evaluation %w", err)
+
 				return
 			}
 
 			result, err := resultSetToReport(resultSet)
 			if err != nil {
 				errCh <- fmt.Errorf("failed to convert result set to report: %w", err)
+
 				return
 			}
 


### PR DESCRIPTION
This only makes the rego evaluation concurrent.

An option to write output to a file has also been added.

Fixes: https://github.com/StyraInc/regal/issues/113, at least as a first pass. There is always GOMAXPROCS.