### PR TITLE
Use custom regal.last built-in for last array element lookup

### DIFF
--- a/bundle/regal/ast.rego
+++ b/bundle/regal/ast.rego
@@ -116,7 +116,7 @@ _find_vars(path, value, last) := _find_every_vars(path, value) if {
 find_vars(node) := [var |
 	walk(node, [path, value])
 
-	some var in _find_vars(path, value, path[count(path) - 1])
+	some var in _find_vars(path, value, regal.last(path))
 ]
 
 # METADATA
@@ -126,7 +126,7 @@ find_vars(node) := [var |
 find_builtin_calls(node) := [value |
 	walk(node, [path, value])
 
-	path[count(path) - 1] == "terms"
+	regal.last(path) == "terms"
 
 	value[0].type == "ref"
 	value[0].value[0].type == "var"

--- a/bundle/regal/rules/bugs/bugs.rego
+++ b/bundle/regal/rules/bugs/bugs.rego
@@ -85,7 +85,7 @@ report contains violation if {
 
 	rule.head.value.type == "ref"
 
-	last := rule.head.value.value[count(rule.head.value.value) - 1]
+	last := regal.last(rule.head.value.value)
 	last.type == "var"
 
 	illegal_value_ref(last.value)

--- a/bundle/regal/rules/imports/imports.rego
+++ b/bundle/regal/rules/imports/imports.rego
@@ -12,7 +12,7 @@ _identifiers := [_ident(imported) |
 ]
 
 # regular import
-_ident(imported) := path[count(path) - 1].value if {
+_ident(imported) := regal.last(path).value if {
 	not imported.alias
 	path := imported.path.value
 }
@@ -122,7 +122,7 @@ report contains violation if {
 
 	some imported in input.imports
 
-	imported.path.value[count(imported.path.value) - 1].value == imported.alias
+	regal.last(imported.path.value).value == imported.alias
 
 	violation := result.fail(rego.metadata.rule(), result.location(imported.path.value[0]))
 }

--- a/bundle/regal/rules/style/style.rego
+++ b/bundle/regal/rules/style/style.rego
@@ -59,7 +59,7 @@ report contains violation if {
 	expr.terms[1].type in {"array", "boolean", "object", "null", "number", "set", "string", "var"}
 	expr.terms[2].type == "ref"
 
-	last := expr.terms[2].value[count(expr.terms[2].value) - 1]
+	last := regal.last(expr.terms[2].value)
 
 	last.type == "var"
 	startswith(last.value, "$")
@@ -83,7 +83,7 @@ report contains violation if {
 	expr.terms[1].type == "ref"
 	expr.terms[2].type in {"array", "boolean", "object", "null", "number", "set", "string", "var"}
 
-	last := expr.terms[1].value[count(expr.terms[1].value) - 1]
+	last := regal.last(expr.terms[1].value)
 
 	last.type == "var"
 	startswith(last.value, "$")

--- a/docs/rules/rules/rule-shadows-builtin.md
+++ b/docs/rules/rules/rule-shadows-builtin.md
@@ -34,5 +34,5 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Built-in Functions](https://www.openpolicyagent.org/docs/latest/policy-reference/#built-in-functions)] 
+- OPA Docs: [Built-in Functions](https://www.openpolicyagent.org/docs/latest/policy-reference/#built-in-functions)
 - OPA Repo: [builtin_metadata.json](https://github.com/open-policy-agent/opa/blob/main/builtin_metadata.json)

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -16,6 +16,10 @@ func NewCompilerWithRegalBuiltins() *ast.Compiler {
 		Name: builtins.RegalJSONPrettyMeta.Name,
 		Decl: builtins.RegalJSONPrettyMeta.Decl,
 	})
+	caps.Builtins = append(caps.Builtins, &ast.Builtin{
+		Name: builtins.RegalLastMeta.Name,
+		Decl: builtins.RegalLastMeta.Decl,
+	})
 
 	return ast.NewCompiler().WithCapabilities(caps)
 }

--- a/internal/test/rego_test.go
+++ b/internal/test/rego_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/tester"
@@ -44,7 +43,7 @@ func TestRunRegoUnitTests(t *testing.T) {
 		CapturePrintOutput(true).
 		SetRuntime(ast.NewTerm(ast.NewObject())).
 		SetBundles(bundle).
-		AddCustomBuiltins(customBuiltins())
+		AddCustomBuiltins(builtins.TestContextBuiltins())
 
 	ch, err := runner.RunTests(ctx, txn)
 	if err != nil {
@@ -59,24 +58,5 @@ func TestRunRegoUnitTests(t *testing.T) {
 				t.Errorf("%v\n%v", string(rc.Output), rc.Location)
 			}
 		})
-	}
-}
-
-func customBuiltins() []*tester.Builtin {
-	return []*tester.Builtin{
-		{
-			Decl: &ast.Builtin{
-				Name: builtins.RegalParseModuleMeta.Name,
-				Decl: builtins.RegalParseModuleMeta.Decl,
-			},
-			Func: rego.Function2(builtins.RegalParseModuleMeta, builtins.RegalParseModule),
-		},
-		{
-			Decl: &ast.Builtin{
-				Name: builtins.RegalJSONPrettyMeta.Name,
-				Decl: builtins.RegalJSONPrettyMeta.Decl,
-			},
-			Func: rego.Function1(builtins.RegalJSONPrettyMeta, builtins.RegalJSONPretty),
-		},
 	}
 }

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -125,6 +125,7 @@ func (l Linter) prepareRegoArgs() []func(*rego.Rego) {
 		rego.PrintHook(topdown.NewPrintHook(os.Stderr)),
 		rego.Function2(builtins.RegalParseModuleMeta, builtins.RegalParseModule),
 		rego.Function1(builtins.RegalJSONPrettyMeta, builtins.RegalJSONPretty),
+		rego.Function1(builtins.RegalLastMeta, builtins.RegalLast),
 	)
 
 	if l.configBundle != nil {


### PR DESCRIPTION
Since 20% of evaluation time is spent here, this seems like a reasonable addition until fixed in OPA.

**main**
```
1669 files linted. 4779 violations found in 1664 files.
regal lint assets  55.83s user 3.51s system 602% cpu 9.850 total
```

**regal.last**
```
1669 files linted. 4779 violations found in 1664 files.
regal lint assets  36.86s user 2.27s system 517% cpu 7.559 total
```