### PR TITLE
docs: set the rule type for unresolved-import

### DIFF
--- a/docs/rules/imports/unresolved-import.md
+++ b/docs/rules/imports/unresolved-import.md
@@ -4,6 +4,8 @@
 
 **Category**: Imports
 
+**Type**: Aggregate - only runs when more than one file is provided for linting
+
 **Avoid**
 
 Imports that can't be resolved.
@@ -38,7 +40,7 @@ import data.users
 This linter rule provides the following configuration options:
 
 ```yaml
-rules: 
+rules:
   imports:
     unresolved-import:
       # one of "error", "warning", "ignore"


### PR DESCRIPTION
This was missing and should be set for aggregate rules.

x-ref: https://github.com/StyraInc/regal/issues/803#issuecomment-2152263828

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->