### PR TITLE
Add benchmark for testing all rules individually

### DIFF
--- a/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator.rego
+++ b/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator.rego
@@ -7,9 +7,9 @@ import data.regal.result
 
 report contains violation if {
 	# foo = "bar"
-	# default foo = "bar
+	# default foo = "bar"
 	# foo(bar) = "baz"
-	# default foo(_) = "bar
+	# default foo(_) = "bar"
 	some rule in input.rules
 	not rule.head.assign
 	not rule.head.key


### PR DESCRIPTION
This is currently very expensive/slow, but it's still a good benchmark to keep around for knowing the cost of some rule relative to others.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->