### PR TITLE
Go 1.23 -> 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/styrainc/regal
 
-go 1.23.9
-
-toolchain go1.24.3
+go 1.24.3
 
 require (
 	dario.cat/mergo v1.0.2

--- a/internal/capabilities/capabilities_test.go
+++ b/internal/capabilities/capabilities_test.go
@@ -1,7 +1,6 @@
 package capabilities
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 )
@@ -19,7 +18,7 @@ func TestLookupFromFile(t *testing.T) {
 
 	urlForPath := "file://" + path
 
-	caps, err := Lookup(context.Background(), urlForPath)
+	caps, err := Lookup(t.Context(), urlForPath)
 	if err != nil {
 		t.Errorf("unexpected error from Lookup: %v", err)
 	}
@@ -39,7 +38,7 @@ func TestLookupFromEmbedded(t *testing.T) {
 	// Test that we can load a one of the existing OPA capabilities files
 	// via the embedded database.
 
-	caps, err := Lookup(context.Background(), "regal:///capabilities/opa/v0.55.0")
+	caps, err := Lookup(t.Context(), "regal:///capabilities/opa/v0.55.0")
 	if err != nil {
 		t.Errorf("unexpected error from Lookup: %v", err)
 	}

--- a/internal/lsp/completions/manager_test.go
+++ b/internal/lsp/completions/manager_test.go
@@ -1,7 +1,6 @@
 package completions
 
 import (
-	"context"
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/ast"
@@ -40,7 +39,7 @@ func TestManagerEarlyExitInsideComment(t *testing.T) {
 		},
 	}
 
-	completions, err := mgr.Run(context.Background(), completionParams, nil)
+	completions, err := mgr.Run(t.Context(), completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/internal/lsp/completions/providers/builtins_test.go
+++ b/internal/lsp/completions/providers/builtins_test.go
@@ -1,7 +1,6 @@
 package providers
 
 import (
-	"context"
 	"slices"
 	"strings"
 	"testing"
@@ -36,7 +35,7 @@ allow if c`
 		},
 	}
 
-	completions, err := p.Run(context.Background(), c, completionParams, &Options{
+	completions, err := p.Run(t.Context(), c, completionParams, &Options{
 		Builtins: rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion()),
 	})
 	if err != nil {
@@ -73,7 +72,7 @@ allow := c`
 		},
 	}
 
-	completions, err := p.Run(context.Background(), c, completionParams, &Options{
+	completions, err := p.Run(t.Context(), c, completionParams, &Options{
 		Builtins: rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion()),
 	})
 	if err != nil {
@@ -112,7 +111,7 @@ allow if {
 		},
 	}
 
-	completions, err := p.Run(context.Background(), c, completionParams, &Options{
+	completions, err := p.Run(t.Context(), c, completionParams, &Options{
 		Builtins: rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion()),
 	})
 	if err != nil {
@@ -149,7 +148,7 @@ allow if gt`
 		},
 	}
 
-	completions, err := p.Run(context.Background(), c, completionParams, &Options{
+	completions, err := p.Run(t.Context(), c, completionParams, &Options{
 		Builtins: rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion()),
 	})
 	if err != nil {
@@ -184,7 +183,7 @@ allow if c`
 		},
 	}
 
-	completions, err := p.Run(context.Background(), c, completionParams, &Options{
+	completions, err := p.Run(t.Context(), c, completionParams, &Options{
 		Builtins: rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion()),
 	})
 	if err != nil {
@@ -221,7 +220,7 @@ default allow := f`
 		},
 	}
 
-	completions, err := p.Run(context.Background(), c, completionParams, &Options{
+	completions, err := p.Run(t.Context(), c, completionParams, &Options{
 		Builtins: rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion()),
 	})
 	if err != nil {

--- a/internal/lsp/completions/providers/packagerefs_test.go
+++ b/internal/lsp/completions/providers/packagerefs_test.go
@@ -1,7 +1,6 @@
 package providers
 
 import (
-	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -66,7 +65,7 @@ import
 		},
 	}
 
-	completions, err := p.Run(context.Background(), c, completionParams, nil)
+	completions, err := p.Run(t.Context(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -142,7 +141,7 @@ import
 		},
 	}
 
-	completions, err := p.Run(context.Background(), c, completionParams, nil)
+	completions, err := p.Run(t.Context(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/internal/lsp/completions/providers/policy_test.go
+++ b/internal/lsp/completions/providers/policy_test.go
@@ -1,7 +1,6 @@
 package providers
 
 import (
-	"context"
 	"slices"
 	"testing"
 
@@ -44,7 +43,7 @@ allow if {
 		},
 	}, inmem.OptRoundTripOnWrite(false))
 
-	locals := NewPolicy(context.Background(), store)
+	locals := NewPolicy(t.Context(), store)
 
 	params := types.CompletionParams{
 		TextDocument: types.TextDocumentIdentifier{
@@ -57,7 +56,7 @@ allow if {
 	}
 
 	result, err := locals.Run(
-		context.Background(),
+		t.Context(),
 		c,
 		params,
 		&Options{ClientIdentifier: clients.IdentifierGeneric},
@@ -102,7 +101,7 @@ import data.example
 		},
 	})
 
-	locals := NewPolicy(context.Background(), store)
+	locals := NewPolicy(t.Context(), store)
 	fileEdited := `package example2
 
 import data.example
@@ -126,7 +125,7 @@ allow if {
 	}
 
 	result, err := locals.Run(
-		context.Background(),
+		t.Context(),
 		c,
 		params,
 		&Options{ClientIdentifier: clients.IdentifierGeneric},

--- a/internal/lsp/completions/providers/rulehead_test.go
+++ b/internal/lsp/completions/providers/rulehead_test.go
@@ -1,7 +1,6 @@
 package providers
 
 import (
-	"context"
 	"slices"
 	"testing"
 
@@ -63,7 +62,7 @@ funckyfunc := true
 		},
 	}
 
-	completions, err := p.Run(context.Background(), c, completionParams, nil)
+	completions, err := p.Run(t.Context(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/internal/lsp/completions/providers/ruleheadkeyword_test.go
+++ b/internal/lsp/completions/providers/ruleheadkeyword_test.go
@@ -1,7 +1,6 @@
 package providers
 
 import (
-	"context"
 	"slices"
 	"testing"
 
@@ -32,7 +31,7 @@ deny` + " "
 		},
 	}
 
-	completions, err := p.Run(context.Background(), c, completionParams, nil)
+	completions, err := p.Run(t.Context(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -76,7 +75,7 @@ deny i
 		},
 	}
 
-	completions, err := p.Run(context.Background(), c, completionParams, nil)
+	completions, err := p.Run(t.Context(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -119,7 +118,7 @@ deny c
 		},
 	}
 
-	completions, err := p.Run(context.Background(), c, completionParams, nil)
+	completions, err := p.Run(t.Context(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -162,7 +161,7 @@ deny contains message i
 		},
 	}
 
-	completions, err := p.Run(context.Background(), c, completionParams, nil)
+	completions, err := p.Run(t.Context(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/internal/lsp/completions/refs/used_test.go
+++ b/internal/lsp/completions/refs/used_test.go
@@ -1,7 +1,6 @@
 package refs
 
 import (
-	"context"
 	"slices"
 	"testing"
 
@@ -30,7 +29,7 @@ deny contains input.parrot if {
 }
 `)
 
-	items, err := UsedInModule(context.Background(), mod)
+	items, err := UsedInModule(t.Context(), mod)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}

--- a/internal/lsp/config/watcher_test.go
+++ b/internal/lsp/config/watcher_test.go
@@ -24,7 +24,7 @@ foo: bar
 		t.Logf(l.String()+": "+s, a...)
 	}})
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	go func() {

--- a/internal/lsp/eval_test.go
+++ b/internal/lsp/eval_test.go
@@ -1,7 +1,6 @@
 package lsp
 
 import (
-	"context"
 	"maps"
 	"os"
 	"path/filepath"
@@ -20,7 +19,7 @@ func TestEvalWorkspacePath(t *testing.T) {
 	logger := newTestLogger(t)
 
 	ls := NewLanguageServer(
-		context.Background(),
+		t.Context(),
 		&LanguageServerOptions{LogWriter: logger, LogLevel: log.LevelDebug},
 	)
 
@@ -50,7 +49,7 @@ func TestEvalWorkspacePath(t *testing.T) {
 		"exists": true,
 	}
 
-	res, err := ls.EvalWorkspacePath(context.TODO(), "data.policy1.allow", input)
+	res, err := ls.EvalWorkspacePath(t.Context(), "data.policy1.allow", input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,11 +65,11 @@ func TestEvalWorkspacePathInternalData(t *testing.T) {
 	logger := newTestLogger(t)
 
 	ls := NewLanguageServer(
-		context.Background(),
+		t.Context(),
 		&LanguageServerOptions{LogWriter: logger, LogLevel: log.LevelDebug},
 	)
 
-	res, err := ls.EvalWorkspacePath(context.TODO(), "object.keys(data.internal)", map[string]any{})
+	res, err := ls.EvalWorkspacePath(t.Context(), "object.keys(data.internal)", map[string]any{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/lsp/lint_test.go
+++ b/internal/lsp/lint_test.go
@@ -1,7 +1,6 @@
 package lsp
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -98,7 +97,7 @@ allow[msg] { 1 == 1; msg := "hello" }
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			c := cache.NewCache()
 			c.SetFileContents(testData.fileURI, testData.content)
@@ -224,7 +223,7 @@ func TestLintWithConfigIgnoreWildcards(t *testing.T) {
 	state.SetFileDiagnostics(fileURI, []types.Diagnostic{})
 
 	if err := updateFileDiagnostics(
-		context.Background(),
+		t.Context(),
 		state,
 		conf,
 		fileURI,
@@ -258,7 +257,7 @@ func TestLintWithConfigIgnoreWildcards(t *testing.T) {
 	}
 
 	if err := updateFileDiagnostics(
-		context.Background(),
+		t.Context(),
 		state,
 		conf,
 		fileURI,

--- a/internal/lsp/rego/rego_test.go
+++ b/internal/lsp/rego/rego_test.go
@@ -1,7 +1,6 @@
 package rego
 
 import (
-	"context"
 	"testing"
 
 	"github.com/styrainc/regal/internal/parse"
@@ -16,7 +15,7 @@ func TestCodeLenses(t *testing.T) {
 
 	module := parse.MustParseModule(contents)
 
-	lenses, er := CodeLenses(context.TODO(), "p.rego", contents, module)
+	lenses, er := CodeLenses(t.Context(), "p.rego", contents, module)
 	if er != nil {
 		t.Fatalf("unexpected error: %v", er)
 	}
@@ -43,7 +42,7 @@ func TestAllRuleHeadLocations(t *testing.T) {
 
 	module := parse.MustParseModule(contents)
 
-	ruleHeads, er := AllRuleHeadLocations(context.TODO(), "p.rego", contents, module)
+	ruleHeads, er := AllRuleHeadLocations(t.Context(), "p.rego", contents, module)
 	if er != nil {
 		t.Fatalf("unexpected error: %v", er)
 	}
@@ -73,7 +72,7 @@ func TestAllKeywords(t *testing.T) {
 
 	module := parse.MustParseModule(contents)
 
-	keywords, er := AllKeywords(context.TODO(), "p.rego", contents, module)
+	keywords, er := AllKeywords(t.Context(), "p.rego", contents, module)
 	if er != nil {
 		t.Fatalf("unexpected error: %v", er)
 	}

--- a/internal/lsp/server_aggregates_test.go
+++ b/internal/lsp/server_aggregates_test.go
@@ -42,7 +42,7 @@ import rego.v1
 	messages := createMessageChannels(files)
 	clientHandler := createClientHandler(t, logger, messages)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	_, connClient := createAndInitServer(t, ctx, logger, tempDir, clientHandler)
@@ -169,7 +169,7 @@ package bar
 	logger := newTestLogger(t)
 	clientHandler := createClientHandler(t, logger, messages)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	tempDir := testutil.TempDirectoryOf(t, files)
@@ -219,7 +219,7 @@ import data.quz
 		".regal/config.yaml": ``,
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	tempDir := testutil.TempDirectoryOf(t, files)
@@ -355,7 +355,7 @@ import rego.v1
 	clientHandler := createClientHandler(t, logger, messages)
 
 	// set up the server and client connections
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	_, connClient := createAndInitServer(t, ctx, logger, tempDir, clientHandler)

--- a/internal/lsp/server_builtins_test.go
+++ b/internal/lsp/server_builtins_test.go
@@ -1,7 +1,6 @@
 package lsp
 
 import (
-	"context"
 	"testing"
 
 	"github.com/styrainc/regal/internal/lsp/log"
@@ -14,11 +13,11 @@ func TestProcessBuiltinUpdateExitsOnMissingFile(t *testing.T) {
 	logger := newTestLogger(t)
 
 	ls := NewLanguageServer(
-		context.Background(),
+		t.Context(),
 		&LanguageServerOptions{LogWriter: logger, LogLevel: log.LevelDebug},
 	)
 
-	if err := ls.processHoverContentUpdate(context.Background(), "file://missing.rego", "foo"); err != nil {
+	if err := ls.processHoverContentUpdate(t.Context(), "file://missing.rego", "foo"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/lsp/server_config_test.go
+++ b/internal/lsp/server_config_test.go
@@ -51,7 +51,7 @@ allow := true
 	mainRegoFileURI := fileURIScheme + childDir + mainRegoFileName
 
 	// set up the server and client connections
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	receivedMessages := make(chan types.FileDiagnostics, defaultBufferedChannelSize)
@@ -122,7 +122,7 @@ func TestLanguageServerCachesEnabledRulesAndUsesDefaultConfig(t *testing.T) {
 
 	tempDir := t.TempDir()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	// no op handler

--- a/internal/lsp/server_formatting_test.go
+++ b/internal/lsp/server_formatting_test.go
@@ -16,7 +16,7 @@ func TestFormatting(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// set up the server and client connections
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	clientHandler := func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {

--- a/internal/lsp/server_multi_file_test.go
+++ b/internal/lsp/server_multi_file_test.go
@@ -60,7 +60,7 @@ ignore:
 	clientHandler := createClientHandler(t, logger, messages)
 
 	// set up the server and client connections
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	ls, connClient := createAndInitServer(t, ctx, logger, tempDir, clientHandler)

--- a/internal/lsp/server_rename_test.go
+++ b/internal/lsp/server_rename_test.go
@@ -1,7 +1,6 @@
 package lsp
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,7 +23,7 @@ func TestLanguageServerFixRenameParams(t *testing.T) {
 
 	testutil.MustMkdirAll(t, tmpDir, "workspace", "foo", "bar")
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	logger := newTestLogger(t)
 
@@ -87,7 +86,7 @@ func TestLanguageServerFixRenameParams(t *testing.T) {
 func TestLanguageServerFixRenameParamsWithConflict(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	logger := newTestLogger(t)
 	tmpDir := t.TempDir()
 
@@ -185,7 +184,7 @@ func TestLanguageServerFixRenameParamsWithConflict(t *testing.T) {
 func TestLanguageServerFixRenameParamsWhenTargetOutsideRoot(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	logger := newTestLogger(t)
 	tmpDir := t.TempDir()
 

--- a/internal/lsp/server_single_file_test.go
+++ b/internal/lsp/server_single_file_test.go
@@ -63,7 +63,7 @@ rules:
 	}
 
 	// set up the server and client connections
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	_, connClient := createAndInitServer(t, ctx, newTestLogger(t), tempDir, clientHandler)

--- a/internal/lsp/server_template_test.go
+++ b/internal/lsp/server_template_test.go
@@ -109,7 +109,7 @@ func TestTemplateContentsForFile(t *testing.T) {
 			logger := newTestLogger(t)
 
 			ls := NewLanguageServer(
-				context.Background(),
+				t.Context(),
 				&LanguageServerOptions{LogWriter: logger, LogLevel: log.LevelDebug},
 			)
 
@@ -147,7 +147,7 @@ func TestTemplateContentsForFileInWorkspaceRoot(t *testing.T) {
 	testutil.MustWriteFile(t, filepath.Join(td, ".regal", "config.yaml"), []byte{})
 
 	ls := NewLanguageServer(
-		context.Background(),
+		t.Context(),
 		&LanguageServerOptions{LogWriter: logger, LogLevel: log.LevelDebug},
 	)
 
@@ -171,7 +171,7 @@ func TestTemplateContentsForFileWithUnknownRoot(t *testing.T) {
 	logger := newTestLogger(t)
 
 	ls := NewLanguageServer(
-		context.Background(),
+		t.Context(),
 		&LanguageServerOptions{LogWriter: logger, LogLevel: log.LevelDebug},
 	)
 
@@ -210,7 +210,7 @@ func TestNewFileTemplating(t *testing.T) {
 	tempDir := testutil.TempDirectoryOf(t, files)
 
 	// set up the server and client connections
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	receivedMessages := make(chan []byte, 10)

--- a/internal/lsp/store_test.go
+++ b/internal/lsp/store_test.go
@@ -1,7 +1,6 @@
 package lsp
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -22,7 +21,7 @@ func TestPutFileModStoresRoastRepresentation(t *testing.T) {
 	t.Parallel()
 
 	store := NewRegalStore()
-	ctx := context.Background()
+	ctx := t.Context()
 	fileURI := "file:///example.rego"
 	module := parse.MustParseModule("package example\n\nrule := true")
 
@@ -100,7 +99,7 @@ func TestPutFileRefs(t *testing.T) {
 	t.Parallel()
 
 	store := NewRegalStore()
-	ctx := context.Background()
+	ctx := t.Context()
 	fileURI := "file:///example.rego"
 
 	if err := PutFileRefs(ctx, store, fileURI, []string{"foo", "bar"}); err != nil {

--- a/pkg/fixer/fixer_test.go
+++ b/pkg/fixer/fixer_test.go
@@ -1,7 +1,6 @@
 package fixer
 
 import (
-	"context"
 	"slices"
 	"testing"
 
@@ -47,7 +46,7 @@ deny = true
 		"/root/main": ast.RegoV1,
 	})
 
-	fixReport, err := f.Fix(context.Background(), &l, memfp)
+	fixReport, err := f.Fix(t.Context(), &l, memfp)
 	if err != nil {
 		t.Fatalf("failed to fix: %v", err)
 	}

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -2,7 +2,6 @@ package linter
 
 import (
 	"bytes"
-	"context"
 	"embed"
 	"path/filepath"
 	"slices"
@@ -38,7 +37,7 @@ camelCase if {
 
 	linter := NewLinter().WithEnableAll(true).WithInputModules(&input)
 
-	result := testutil.Must(linter.Lint(context.Background()))(t)
+	result := testutil.Must(linter.Lint(t.Context()))(t)
 
 	if len(result.Violations) != 2 {
 		t.Fatalf("expected 2 violations, got %d", len(result.Violations))
@@ -96,7 +95,7 @@ r := input.foo[_]
 
 	linter := NewLinter().WithUserConfig(userConfig).WithInputModules(&input)
 
-	result := testutil.Must(linter.Lint(context.Background()))(t)
+	result := testutil.Must(linter.Lint(t.Context()))(t)
 
 	if len(result.Violations) != 1 {
 		t.Fatalf("expected 1 violation, got %d - violations: %v", len(result.Violations), result.Violations)
@@ -281,7 +280,7 @@ or := 1
 				linter = linter.WithUserConfig(*tc.userConfig)
 			}
 
-			result := testutil.Must(linter.Lint(context.Background()))(t)
+			result := testutil.Must(linter.Lint(t.Context()))(t)
 
 			if len(result.Violations) != len(tc.expViolations) {
 				t.Fatalf("expected %d violation, got %d: %v",
@@ -317,7 +316,7 @@ func TestLintWithCustomRule(t *testing.T) {
 		WithCustomRules([]string{filepath.Join("testdata", "custom.rego")}).
 		WithInputModules(&input)
 
-	result := testutil.Must(linter.Lint(context.Background()))(t)
+	result := testutil.Must(linter.Lint(t.Context()))(t)
 
 	if len(result.Violations) != 1 {
 		t.Fatalf("expected 1 violation, got %d", len(result.Violations))
@@ -338,7 +337,7 @@ func TestLintWithErrorInEnable(t *testing.T) {
 		WithEnabledRules("foo").
 		WithInputModules(&input)
 
-	_, err := linter.Lint(context.Background())
+	_, err := linter.Lint(t.Context())
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -360,7 +359,7 @@ func TestLintWithCustomEmbeddedRules(t *testing.T) {
 		WithCustomRulesFromFS(testLintWithCustomEmbeddedRulesFS, "testdata").
 		WithInputModules(&input)
 
-	result := testutil.Must(linter.Lint(context.Background()))(t)
+	result := testutil.Must(linter.Lint(t.Context()))(t)
 
 	if len(result.Violations) != 1 {
 		t.Fatalf("expected 1 violation, got %d", len(result.Violations))
@@ -385,7 +384,7 @@ func TestLintWithCustomRuleAndCustomConfig(t *testing.T) {
 		WithCustomRules([]string{filepath.Join("testdata", "custom.rego")}).
 		WithInputModules(&input)
 
-	result := testutil.Must(linter.Lint(context.Background()))(t)
+	result := testutil.Must(linter.Lint(t.Context()))(t)
 
 	if len(result.Violations) != 0 {
 		t.Fatalf("expected no violation, got %d", len(result.Violations))
@@ -483,7 +482,7 @@ func TestLintWithPrintHook(t *testing.T) {
 		WithPrintHook(topdown.NewPrintHook(&bb)).
 		WithInputModules(&input)
 
-	if _, err := linter.Lint(context.Background()); err != nil {
+	if _, err := linter.Lint(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -518,7 +517,7 @@ func TestLintWithAggregateRule(t *testing.T) {
 		WithEnabledRules("prefer-package-imports").
 		WithInputModules(&input)
 
-	result := testutil.Must(linter.Lint(context.Background()))(t)
+	result := testutil.Must(linter.Lint(t.Context()))(t)
 
 	if len(result.Violations) != 1 {
 		t.Fatalf("expected one violation, got %d", len(result.Violations))
@@ -550,7 +549,7 @@ func TestEnabledRules(t *testing.T) {
 		WithDisableAll(true).
 		WithEnabledRules("opa-fmt", "no-whitespace-comment")
 
-	enabledRules, err := linter.DetermineEnabledRules(context.Background())
+	enabledRules, err := linter.DetermineEnabledRules(t.Context())
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -592,12 +591,12 @@ rules:
 
 	linter := NewLinter().WithUserConfig(userConfig)
 
-	enabledRules, err := linter.DetermineEnabledRules(context.Background())
+	enabledRules, err := linter.DetermineEnabledRules(t.Context())
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	enabledAggRules, err := linter.DetermineEnabledAggregateRules(context.Background())
+	enabledAggRules, err := linter.DetermineEnabledAggregateRules(t.Context())
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -626,7 +625,7 @@ func TestEnabledAggregateRules(t *testing.T) {
 		WithDisableAll(true).
 		WithEnabledRules("opa-fmt", "unresolved-import", "use-assignment-operator")
 
-	enabledRules, err := linter.DetermineEnabledAggregateRules(context.Background())
+	enabledRules, err := linter.DetermineEnabledAggregateRules(t.Context())
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -655,7 +654,7 @@ import data.foo.bar.unresolved
 		WithExportAggregates(true). // needed to be able to test the aggregates are set
 		WithInputModules(&input)
 
-	result := testutil.Must(linter.Lint(context.Background()))(t)
+	result := testutil.Must(linter.Lint(t.Context()))(t)
 
 	if len(result.Aggregates) != 1 {
 		t.Fatalf("expected one aggregate, got %d", len(result.Aggregates))
@@ -693,7 +692,7 @@ import data.unresolved`,
 			WithExportAggregates(true).
 			WithInputModules(&input)
 
-		result := testutil.Must(linter.Lint(context.Background()))(t)
+		result := testutil.Must(linter.Lint(t.Context()))(t)
 
 		for k, aggs := range result.Aggregates {
 			allAggregates[k] = append(allAggregates[k], aggs...)
@@ -705,7 +704,7 @@ import data.unresolved`,
 		WithEnabledRules("unresolved-import").
 		WithAggregates(allAggregates)
 
-	result := testutil.Must(linter.Lint(context.Background()))(t)
+	result := testutil.Must(linter.Lint(t.Context()))(t)
 
 	if len(result.Violations) != 3 {
 		t.Fatalf("expected one violation, got %d", len(result.Violations))
@@ -744,7 +743,7 @@ func BenchmarkRegalLintingItself(b *testing.B) {
 	var rep report.Report
 
 	for range b.N {
-		rep, err = linter.Lint(context.Background())
+		rep, err = linter.Lint(b.Context())
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -763,7 +762,7 @@ func BenchmarkRegalLintingItselfPrepareOnce(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	ctx := context.Background()
+	ctx := b.Context()
 	linter := NewLinter().
 		WithInputPaths([]string{"../../bundle"}).
 		WithBaseCache(cache.NewBaseCache()).
@@ -797,7 +796,7 @@ func BenchmarkRegalNoEnabledRules(b *testing.B) {
 	var rep report.Report
 
 	for range b.N {
-		rep, err = linter.Lint(context.Background())
+		rep, err = linter.Lint(b.Context())
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -815,14 +814,14 @@ func BenchmarkRegalNoEnabledRulesPrepareOnce(b *testing.B) {
 		WithInputPaths([]string{"../../bundle"}).
 		WithBaseCache(cache.NewBaseCache()).
 		WithDisableAll(true).
-		MustPrepare(context.Background())
+		MustPrepare(b.Context())
 
 	var err error
 
 	var rep report.Report
 
 	for range b.N {
-		rep, err = linter.Lint(context.Background())
+		rep, err = linter.Lint(b.Context())
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -844,7 +843,7 @@ func BenchmarkEachRule(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	ctx := context.Background()
+	ctx := b.Context()
 	linter := NewLinter().
 		WithInputPaths([]string{"../../bundle"}).
 		WithBaseCache(cache.NewBaseCache()).

--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -2,7 +2,6 @@ package reporter
 
 import (
 	"bytes"
-	"context"
 	"os"
 	"strings"
 	"testing"
@@ -85,7 +84,7 @@ func TestPrettyReporterPublish(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	if err := NewPrettyReporter(&buf).Publish(context.Background(), rep); err != nil {
+	if err := NewPrettyReporter(&buf).Publish(t.Context(), rep); err != nil {
 		t.Fatal(err)
 	}
 
@@ -128,7 +127,7 @@ func TestPrettyReporterPublishLongText(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := NewPrettyReporter(&buf).Publish(context.Background(), longRep); err != nil {
+	if err := NewPrettyReporter(&buf).Publish(t.Context(), longRep); err != nil {
 		t.Fatal(err)
 	}
 
@@ -141,7 +140,7 @@ func TestPrettyReporterPublishNoViolations(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	if err := NewPrettyReporter(&buf).Publish(context.Background(), report.Report{}); err != nil {
+	if err := NewPrettyReporter(&buf).Publish(t.Context(), report.Report{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -154,7 +153,7 @@ func TestCompactReporterPublish(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	if err := NewCompactReporter(&buf).Publish(context.Background(), rep); err != nil {
+	if err := NewCompactReporter(&buf).Publish(t.Context(), rep); err != nil {
 		t.Fatal(err)
 	}
 
@@ -176,7 +175,7 @@ func TestCompactReporterPublishNoViolations(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	if err := NewCompactReporter(&buf).Publish(context.Background(), report.Report{}); err != nil {
+	if err := NewCompactReporter(&buf).Publish(t.Context(), report.Report{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -189,7 +188,7 @@ func TestJSONReporterPublish(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	if err := NewJSONReporter(&buf).Publish(context.Background(), rep); err != nil {
+	if err := NewJSONReporter(&buf).Publish(t.Context(), rep); err != nil {
 		t.Fatal(err)
 	}
 
@@ -202,7 +201,7 @@ func TestJSONReporterPublishNoViolations(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	if err := NewJSONReporter(&buf).Publish(context.Background(), report.Report{}); err != nil {
+	if err := NewJSONReporter(&buf).Publish(t.Context(), report.Report{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -216,7 +215,7 @@ func TestGitHubReporterPublish(t *testing.T) {
 	t.Setenv("GITHUB_STEP_SUMMARY", "")
 
 	var buf bytes.Buffer
-	if err := NewGitHubReporter(&buf).Publish(context.Background(), rep); err != nil {
+	if err := NewGitHubReporter(&buf).Publish(t.Context(), rep); err != nil {
 		t.Fatal(err)
 	}
 
@@ -238,7 +237,7 @@ func TestGitHubReporterPublishNoViolations(t *testing.T) {
 	t.Setenv("GITHUB_STEP_SUMMARY", "")
 
 	var buf bytes.Buffer
-	if err := NewGitHubReporter(&buf).Publish(context.Background(), report.Report{}); err != nil {
+	if err := NewGitHubReporter(&buf).Publish(t.Context(), report.Report{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -251,7 +250,7 @@ func TestSarifReporterPublish(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	if err := NewSarifReporter(&buf).Publish(context.Background(), rep); err != nil {
+	if err := NewSarifReporter(&buf).Publish(t.Context(), rep); err != nil {
 		t.Fatal(err)
 	}
 
@@ -265,7 +264,7 @@ func TestSarifReporterViolationWithoutRegion(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	if err := NewSarifReporter(&buf).Publish(context.Background(), report.Report{
+	if err := NewSarifReporter(&buf).Publish(t.Context(), report.Report{
 		Violations: []report.Violation{
 			{
 				Title:       "opa-fmt",
@@ -296,7 +295,7 @@ func TestSarifReporterPublishNoViolations(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	if err := NewSarifReporter(&buf).Publish(context.Background(), report.Report{}); err != nil {
+	if err := NewSarifReporter(&buf).Publish(t.Context(), report.Report{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -309,7 +308,7 @@ func TestJUnitReporterPublish(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	if err := NewJUnitReporter(&buf).Publish(context.Background(), rep); err != nil {
+	if err := NewJUnitReporter(&buf).Publish(t.Context(), rep); err != nil {
 		t.Fatal(err)
 	}
 
@@ -322,7 +321,7 @@ func TestJUnitReporterPublishNoViolations(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	if err := NewJUnitReporter(&buf).Publish(context.Background(), report.Report{}); err != nil {
+	if err := NewJUnitReporter(&buf).Publish(t.Context(), report.Report{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -335,7 +334,7 @@ func TestJUnitReporterPublishViolationWithoutText(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	if err := NewJUnitReporter(&buf).Publish(context.Background(), report.Report{
+	if err := NewJUnitReporter(&buf).Publish(t.Context(), report.Report{
 		Violations: []report.Violation{{Title: "no-text"}},
 	}); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
And use `t.Context()` in tests.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->