### PR TITLE
fix: Correct end location in unresolved-reference

### DIFF
--- a/bundle/regal/rules/imports/unresolved-reference/unresolved_reference.rego
+++ b/bundle/regal/rules/imports/unresolved-reference/unresolved_reference.rego
@@ -62,7 +62,6 @@ _refs contains ref if {
 
 	not terms[0].value in _shadowed_imports
 
-	# util.to_location_row inlined for some extra performance
 	row := to_number(regex.replace(terms[0].location, `^(\d+):.*`, "$1"))
 	ref := {
 		"name": name,
@@ -132,14 +131,17 @@ _to_location_object(loc, text, file) := {"location": {
 	"col": col,
 	"text": text,
 	"end": {
-		"row": end_row,
+		"row": row,
 		"col": end_col,
 	},
 }} if {
-	[r, c, er, ec] := split(loc, ":")
+	vals := split(loc, ":")
 
-	row := to_number(r)
-	col := to_number(c)
-	end_row := to_number(er)
-	end_col := to_number(ec)
+	row := to_number(vals[0])
+	col := to_number(vals[1])
+
+	from_col := substring(text, col - 1, -1)
+	ref_text := substring(from_col, 0, indexof(from_col, " "))
+
+	end_col := to_number(vals[1]) + count(ref_text)
 }

--- a/bundle/regal/rules/imports/unresolved-reference/unresolved_reference_test.rego
+++ b/bundle/regal/rules/imports/unresolved-reference/unresolved_reference_test.rego
@@ -15,17 +15,17 @@ test_fail_identifies_unresolved_reference if {
 	x := 1
 	`)
 	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
-	expected := {with_location({
+
+	r == {with_location({
 		"file": "p1.rego",
 		"row": 4,
 		"col": 7,
 		"end": {
 			"row": 4,
-			"col": 10,
+			"col": 14,
 		},
 		"text": "\tx := bar.baz",
 	})}
-	r == expected
 }
 
 test_success_no_unresolved_reference if {
@@ -53,17 +53,17 @@ test_fail_identifies_unresolved_reference_with_alias if {
 	x := 1
 	`)
 	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
-	expected := {with_location({
+
+	r == {with_location({
 		"file": "p1.rego",
 		"row": 4,
 		"col": 7,
 		"end": {
 			"row": 4,
-			"col": 10,
+			"col": 14,
 		},
 		"text": "\tx := baz.qux",
 	})}
-	r == expected
 }
 
 test_success_identifies_reference_with_alias if {
@@ -77,6 +77,7 @@ test_success_identifies_reference_with_alias if {
 	qux := 1
 	`)
 	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
+
 	r == set()
 }
 
@@ -90,17 +91,17 @@ test_fail_identifies_unresolved_full_path if {
 	x := 1
 	`)
 	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
-	expected := {with_location({
+
+	r == {with_location({
 		"file": "p1.rego",
 		"row": 3,
 		"col": 7,
 		"end": {
 			"row": 3,
-			"col": 11,
+			"col": 19,
 		},
 		"text": "\tx := data.bar.baz",
 	})}
-	r == expected
 }
 
 test_success_identifies_full_path if {
@@ -113,6 +114,7 @@ test_success_identifies_full_path if {
 	baz := 1
 	`)
 	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
+
 	r == set()
 }
 
@@ -139,14 +141,14 @@ test_fail_everything_all_at_once if {
 	`)
 	r := rule.aggregate_report with input as {"aggregate": (((agg1 | agg2) | agg3) | agg4)}
 
-	expected := {
+	r == {
 		with_location({
 			"file": "p1.rego",
 			"row": 5,
 			"col": 7,
 			"end": {
 				"row": 5,
-				"col": 10,
+				"col": 18,
 			},
 			"text": "\tx := bar.unknown",
 		}),
@@ -156,7 +158,7 @@ test_fail_everything_all_at_once if {
 			"col": 7,
 			"end": {
 				"row": 6,
-				"col": 10,
+				"col": 18,
 			},
 			"text": "\ty := qux.unknown",
 		}),
@@ -166,12 +168,11 @@ test_fail_everything_all_at_once if {
 			"col": 7,
 			"end": {
 				"row": 7,
-				"col": 11,
+				"col": 23,
 			},
 			"text": "\tz := data.qux.unknown",
 		}),
 	}
-	r == expected
 }
 
 test_success_everything_all_at_once if {
@@ -261,7 +262,7 @@ test_fail_builtin_namespaces_are_not_ignored if {
 		"col": 14,
 		"end": {
 			"row": 4,
-			"col": 18,
+			"col": 26,
 		},
 		"text": "\tfun(foo) := time.now_nss",
 	})}


### PR DESCRIPTION
Not 100% accurate, as it won't correctly report the end location of cases like `foo["bar baz"]`... but good enough,

Fixes #1586

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->