### PR TITLE
Fix `regal new rule` issues + refactor io code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,6 +35,23 @@
         "test",
         "bundle"
       ]
+    },
+    {
+      "name": "regal new rule --type builtin --category custom --name bar",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}",
+      "args": [
+        "new",
+        "rule",
+        "--type",
+        "builtin",
+        "--category",
+        "custom",
+        "--name",
+        "bar"
+      ]
     }
   ]
 }

--- a/internal/capabilities/capabilities_test.go
+++ b/internal/capabilities/capabilities_test.go
@@ -73,10 +73,7 @@ func TestSemverSort(t *testing.T) {
 		},
 	}
 
-	for i, c := range cases {
-		t.Logf("----- TestSemverSort[%d]", i)
-		t.Logf("// %s\n", c.note)
-
+	for _, c := range cases {
 		// Note that this actually sorts the input in-place, which is
 		// fine since we won't re-visit the same test case twice.
 		semverSort(c.input)

--- a/internal/embeds/templates/builtin/builtin_test.rego.tpl
+++ b/internal/embeds/templates/builtin/builtin_test.rego.tpl
@@ -19,10 +19,10 @@ test_rule_named_foo_not_allowed if {
 		"level": "error",
 		"location": {
 			"file": "policy.rego",
-			"row": 1,
+			"row": 3,
 			"col": 1,
 			"end": {
-				"row": 1,
+				"row": 3,
 				"col": 12,
 			},
 			"text": "foo := true",

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -1,12 +1,14 @@
 package io
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	files "io/fs"
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 
@@ -22,6 +24,211 @@ import (
 	"github.com/styrainc/regal/pkg/roast/encoding"
 )
 
+// FileWalkerFilter is a function that filters files and directories during a walk.
+type FileWalkerFilter func(path string, info os.DirEntry) bool
+
+// FileWalker is a utility for walking directories and files, applying
+// provided filters before processing each file or directory.
+type FileWalker struct {
+	// root is the root directory to start walking from.
+	root string
+	// filters are the filters to apply to each file or directory.
+	// If any filter returns true, the file or directory is skipped.
+	filters []FileWalkerFilter
+	// skipFunc is a special filter that allows skipping entire directory
+	// entire directory trees (like .git, node_modules, etc.).
+	skipFunc FileWalkerFilter
+	// statRoot indicates whether to stat the root directory before walking.
+	statRoot bool
+}
+
+// FileWalkerReducer extends FileWalker to allow reducing the results of the walk.
+type FileWalkerReducer[T any] struct {
+	*FileWalker
+
+	initial T
+}
+
+// DirectoryFilter is a filter for filtering directories.
+func DirectoryFilter(_ string, info os.DirEntry) bool {
+	return info.IsDir()
+}
+
+// FileNameFilter filters files by their exact name, not counting the path.
+func FileNameFilter(names ...string) FileWalkerFilter {
+	return func(_ string, info os.DirEntry) bool {
+		return slices.ContainsFunc(names, func(name string) bool {
+			return info.Name() == name
+		})
+	}
+}
+
+// SuffixesFilter filters any path that has a suffix matching any of the provided suffixes.
+func SuffixesFilter(suffixes ...string) FileWalkerFilter {
+	return func(_ string, info os.DirEntry) bool {
+		return slices.ContainsFunc(suffixes, func(suffix string) bool {
+			return strings.HasSuffix(info.Name(), suffix)
+		})
+	}
+}
+
+// NegateFilter negates the result of the provided filter, so that e.g.
+// NegateFilter(DirectoryFilter) will return true for files and false for directories.
+func NegateFilter(filter FileWalkerFilter) FileWalkerFilter {
+	return func(path string, info os.DirEntry) bool {
+		return !filter(path, info)
+	}
+}
+
+// DefaultSkipDirectories is a default skip function that skips common directories
+// that are not relevant for most file walks, such as .git, .idea, and node_modules.
+func DefaultSkipDirectories(_ string, info files.DirEntry) bool {
+	name := info.Name()
+
+	return info.IsDir() && (name == ".git" || name == ".idea" || name == "node_modules")
+}
+
+// NewFileWalker creates a new FileWalker with the specified root directory.
+func NewFileWalker(root string) *FileWalker {
+	return &FileWalker{
+		root: root,
+	}
+}
+
+// WithFilters adds filters to the FileWalker.
+func (fw *FileWalker) WithFilters(filters ...FileWalkerFilter) *FileWalker {
+	fw.filters = filters
+
+	return fw
+}
+
+// WithSkipFunc sets the skip function for the FileWalker. This is a special
+// filter that allows skipping traversal of entire directory trees (like
+// .git, node_modules, etc.).
+func (fw *FileWalker) WithSkipFunc(skipFunc FileWalkerFilter) *FileWalker {
+	fw.skipFunc = skipFunc
+
+	return fw
+}
+
+// WithStatBeforeWalk sets whether to stat the root directory before walking.
+// The underlying filepath.WalkDir implementation panics on non-existent paths,
+// so this is useful when the input isn't guaranteed to exist.
+func (fw *FileWalker) WithStatBeforeWalk(statRoot bool) *FileWalker {
+	fw.statRoot = statRoot
+
+	return fw
+}
+
+// Walk walks the file system rooted at the root, calling f for each file
+// not filtered out by the filters.
+func (fw *FileWalker) Walk(f func(string) error) error {
+	if err := fw.validate(); err != nil {
+		return err
+	}
+
+	return filepath.WalkDir(fw.root, fw.walker(f))
+}
+
+// WalkFS walks the file system rooted at the root using the provided files.FS,
+// calling f for each file not filtered out by the filters.
+func (fw *FileWalker) WalkFS(fs files.FS, f func(string) error) error {
+	if err := fw.validate(); err != nil {
+		return err
+	}
+
+	return files.WalkDir(fs, fw.root, fw.walker(f))
+}
+
+func (fw *FileWalker) validate() error {
+	if fw.root == "" {
+		return errors.New("root path is empty")
+	}
+
+	if fw.statRoot {
+		if _, err := os.Stat(fw.root); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (fw *FileWalker) walker(f func(string) error) func(path string, d files.DirEntry, err error) error {
+	return func(path string, d files.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("failed to walk directory %s: %w", path, err)
+		}
+
+		if fw.skipFunc != nil && fw.skipFunc(path, d) {
+			return files.SkipDir
+		}
+
+		for _, filter := range fw.filters {
+			if filter(path, d) {
+				return nil
+			}
+		}
+
+		return f(path)
+	}
+}
+
+// NewFileWalkReducer creates a new FileWalkerReducer with the specified root
+// directory and initial value for the accumulator.
+func NewFileWalkReducer[T any](root string, into T) *FileWalkerReducer[T] {
+	return &FileWalkerReducer[T]{
+		FileWalker: &FileWalker{root: root},
+		initial:    into,
+	}
+}
+
+// WithFilters adds filters to the FileWalkerReducer.
+func (fwr *FileWalkerReducer[T]) WithFilters(filters ...FileWalkerFilter) *FileWalkerReducer[T] {
+	fwr.filters = append(fwr.filters, filters...)
+
+	return fwr
+}
+
+// WithSkipFunc sets the skip function for the FileWalkerReducer.
+func (fwr *FileWalkerReducer[T]) WithSkipFunc(skipFunc FileWalkerFilter) *FileWalkerReducer[T] {
+	fwr.skipFunc = skipFunc
+
+	return fwr
+}
+
+// WithStatBeforeWalk sets whether to stat the root directory before walking.
+// The underlying filepath.WalkDir implementation panics on non-existent paths,
+// so this is useful when the input isn't guaranteed to exist.
+func (fwr *FileWalkerReducer[T]) WithStatBeforeWalk(statRoot bool) *FileWalkerReducer[T] {
+	fwr.statRoot = statRoot
+
+	return fwr
+}
+
+// Reduce walks the file system rooted at fwr.Root, calling f for each file.
+// The function f receives the path of the file and the current value of the
+// accumulator. It returns the new value of the accumulator and an error if any.
+func (fwr *FileWalkerReducer[T]) Reduce(f func(string, T) (T, error)) (T, error) {
+	curr := fwr.initial
+
+	err := fwr.Walk(func(path string) error {
+		var err error
+
+		curr, err = f(path, curr)
+
+		return err
+	})
+
+	return curr, err
+}
+
+// PathAppendReducer is a simple reducer function that appends the
+// given path to the current slice of strings.
+func PathAppendReducer(path string, curr []string) ([]string, error) {
+	return append(curr, path), nil
+}
+
 const PathSeparator = string(os.PathSeparator)
 
 // LoadRegalBundleFS loads bundle embedded from policy and data directory.
@@ -32,7 +239,7 @@ func LoadRegalBundleFS(fs files.FS) (bundle.Bundle, error) {
 	}
 
 	//nolint:wrapcheck
-	return bundle.NewCustomReader(embedLoader.WithFilter(ExcludeTestFilter())).
+	return bundle.NewCustomReader(embedLoader.WithFilter(ExcludeTestLegacyFilter())).
 		WithCapabilities(Capabilities()).
 		WithSkipBundleVerification(true).
 		WithProcessAnnotations(true).
@@ -43,7 +250,7 @@ func LoadRegalBundleFS(fs files.FS) (bundle.Bundle, error) {
 // LoadRegalBundlePath loads bundle from path.
 func LoadRegalBundlePath(path string) (bundle.Bundle, error) {
 	//nolint:wrapcheck
-	return bundle.NewCustomReader(bundle.NewDirectoryLoader(path).WithFilter(ExcludeTestFilter())).
+	return bundle.NewCustomReader(bundle.NewDirectoryLoader(path).WithFilter(ExcludeTestLegacyFilter())).
 		WithCapabilities(Capabilities()).
 		WithSkipBundleVerification(true).
 		WithProcessAnnotations(true).
@@ -75,7 +282,7 @@ func CloseFileIgnore(file *os.File) {
 	_ = file.Close()
 }
 
-func ExcludeTestFilter() filter.LoaderFilter {
+func ExcludeTestLegacyFilter() filter.LoaderFilter {
 	return func(_ string, info files.FileInfo, _ int) bool {
 		return strings.HasSuffix(info.Name(), "_test.rego") &&
 			// (anderseknert): This is an outlier, but not sure we need something
@@ -84,21 +291,47 @@ func ExcludeTestFilter() filter.LoaderFilter {
 	}
 }
 
+func ExcludeTestsFilter(_ string, info os.DirEntry) bool {
+	return strings.HasSuffix(info.Name(), "_test.rego") && info.Name() != "todo_test.rego"
+}
+
+func IsDir(path string) bool {
+	info, err := os.Stat(path)
+
+	return err == nil && info.IsDir()
+}
+
+// WithCreateRecursive creates a file at the given path, ensuring that all parent directories
+// are created recursively. It then calls the provided function with the created file as an argument
+// before closing the file.
+func WithCreateRecursive(path string, fn func(f *os.File) error) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o770); err != nil {
+		return err
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return fn(file)
+}
+
 // FindInputPath consults the filesystem and returns the input.json or input.yaml closes to the
 // file provided as arguments.
 func FindInputPath(file string, workspacePath string) string {
 	relative := strings.TrimPrefix(file, workspacePath)
 	components := strings.Split(filepath.Dir(relative), PathSeparator)
+	supported := []string{"input.json", "input.yaml"}
 
 	for i := range components {
 		current := components[:len(components)-i]
+
 		prefix := filepath.Join(append([]string{workspacePath}, current...)...)
-
-		for _, ext := range []string{"json", "yaml", "yml"} {
-			inputPath := filepath.Join(prefix, "input."+ext)
-
-			_, err := os.Stat(inputPath)
-			if err == nil {
+		for _, name := range supported {
+			inputPath := filepath.Join(prefix, name)
+			if _, err := os.Stat(inputPath); err == nil {
 				return inputPath
 			}
 		}
@@ -112,60 +345,35 @@ func FindInputPath(file string, workspacePath string) string {
 // Note that:
 // - This function doesn't do error handling. If the file can't be read, nothing is returned.
 // - While the input data theoretically could be anything JSON/YAML value, we only support an object.
-func FindInput(file string, workspacePath string) (string, map[string]any) {
+func FindInput(file string, workspacePath string) (inputPath string, input map[string]any) {
 	relative := strings.TrimPrefix(file, workspacePath)
 	components := strings.Split(filepath.Dir(relative), PathSeparator)
-
-	var (
-		inputPath string
-		content   []byte
-	)
+	supported := []string{"input.json", "input.yaml"}
 
 	for i := range components {
-		current := components[:len(components)-i]
-
-		inputPathJSON := filepath.Join(workspacePath, filepath.Join(current...), "input.json")
-
-		f, err := os.Open(inputPathJSON)
-		if err == nil {
-			inputPath = inputPathJSON
-			content, _ = io.ReadAll(f)
-
-			break
-		}
-
-		inputPathYAML := filepath.Join(workspacePath, filepath.Join(current...), "input.yaml")
-
-		f, err = os.Open(inputPathYAML)
-		if err == nil {
-			inputPath = inputPathYAML
-			content, _ = io.ReadAll(f)
-
-			break
+		current := filepath.Join(components[:len(components)-i]...)
+		for _, name := range supported {
+			inputPath := filepath.Join(workspacePath, current, name)
+			if content, err := os.ReadFile(inputPath); err == nil {
+				if err = unmarshallerFor(name)(content, &input); err == nil {
+					return inputPath, input
+				}
+			}
 		}
 	}
 
-	if inputPath == "" || content == nil {
-		return "", nil
-	}
-
-	var input map[string]any
-
-	if strings.HasSuffix(inputPath, ".json") {
-		if err := encoding.JSON().Unmarshal(content, &input); err != nil {
-			return "", nil
-		}
-	} else if strings.HasSuffix(inputPath, ".yaml") {
-		if err := yaml.Unmarshal(content, &input); err != nil {
-			return "", nil
-		}
-	}
-
-	return inputPath, input
+	return "", nil
 }
 
-func IsSkipWalkDirectory(info files.DirEntry) bool {
-	return info.IsDir() && (info.Name() == ".git" || info.Name() == ".idea" || info.Name() == "node_modules")
+func unmarshallerFor(name string) func([]byte, any) error {
+	switch name {
+	case "input.json":
+		return encoding.JSON().Unmarshal
+	case "input.yaml", "input.yml":
+		return yaml.Unmarshal
+	}
+
+	panic("no decoder for file type: " + name)
 }
 
 // WalkFiles walks the file system rooted at root, calling f for each file. This is
@@ -173,17 +381,10 @@ func IsSkipWalkDirectory(info files.DirEntry) bool {
 // are passed to the callback, and where directories that should commonly  be ignored
 // (.git, node_modules, etc.) are skipped.
 func WalkFiles(root string, f func(path string) error) error {
-	return filepath.WalkDir(root, func(path string, info os.DirEntry, _ error) error { //nolint:wrapcheck
-		if IsSkipWalkDirectory(info) {
-			return filepath.SkipDir
-		}
-
-		if info.IsDir() {
-			return nil
-		}
-
-		return f(path)
-	})
+	return NewFileWalker(root).
+		WithFilters(DirectoryFilter).
+		WithSkipFunc(DefaultSkipDirectories).
+		Walk(f)
 }
 
 // FindManifestLocations walks the file system rooted at root, and returns the
@@ -191,68 +392,59 @@ func WalkFiles(root string, f func(path string) error) error {
 func FindManifestLocations(root string) ([]string, error) {
 	var foundBundleRoots []string
 
-	if err := WalkFiles(root, func(path string) error {
-		if filepath.Base(path) == ".manifest" {
-			if rel, err := filepath.Rel(root, path); err == nil {
-				foundBundleRoots = append(foundBundleRoots, filepath.Dir(rel))
+	return NewFileWalkReducer(root, foundBundleRoots).
+		WithSkipFunc(DefaultSkipDirectories).
+		WithFilters(DirectoryFilter, NegateFilter(FileNameFilter(".manifest"))).
+		Reduce(func(path string, curr []string) ([]string, error) {
+			rel, err := filepath.Rel(root, path)
+			if err == nil {
+				curr = append(curr, filepath.Dir(rel))
 			}
-		}
 
-		return nil
-	}); err != nil {
-		return nil, fmt.Errorf("failed to walk workspace path: %w", err)
-	}
-
-	return foundBundleRoots, nil
+			return curr, err
+		})
 }
 
 func ModulesFromCustomRuleFS(customRuleFS files.FS, rootPath string) (map[string]*ast.Module, error) {
 	modules := make(map[string]*ast.Module)
-	filter := ExcludeTestFilter()
 
-	err := files.WalkDir(customRuleFS, rootPath, func(path string, d files.DirEntry, err error) error {
-		if err != nil {
-			return fmt.Errorf("failed to walk custom rule FS: %w", err)
-		}
+	err := NewFileWalker(rootPath).
+		WithFilters(DirectoryFilter, ExcludeTestsFilter).
+		WalkFS(customRuleFS, func(path string) error {
+			bs, err := FSReadAll(customRuleFS, path)
+			if err != nil {
+				return fmt.Errorf("failed to read custom rule file: %w", err)
+			}
 
-		if d.IsDir() {
+			m, err := ast.ParseModule(path, outil.ByteSliceToString(bs))
+			if err != nil {
+				return fmt.Errorf("failed to parse custom rule file %q: %w", path, err)
+			}
+
+			modules[path] = m
+
 			return nil
-		}
-
-		info, err := d.Info()
-		if err != nil {
-			return fmt.Errorf("failed to get info for custom rule file: %w", err)
-		}
-
-		if filter("", info, 0) {
-			return nil
-		}
-
-		f, err := customRuleFS.Open(path)
-		if err != nil {
-			return fmt.Errorf("failed to open custom rule file: %w", err)
-		}
-		defer f.Close()
-
-		bs, err := io.ReadAll(f)
-		if err != nil {
-			return fmt.Errorf("failed to read custom rule file: %w", err)
-		}
-
-		m, err := ast.ParseModule(path, outil.ByteSliceToString(bs))
-		if err != nil {
-			return fmt.Errorf("failed to parse custom rule file %q: %w", path, err)
-		}
-
-		modules[path] = m
-
-		return nil
-	})
+		})
 	if err != nil {
 		return nil, fmt.Errorf("failed to walk custom rule FS: %w", err)
 	}
 
 	return modules, nil
+}
+
+func FSReadAll(fs files.FS, path string) ([]byte, error) {
+	f, err := fs.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %w", path, err)
+	}
+	defer f.Close()
+
+	bs, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %q: %w", path, err)
+	}
+
+	return bs, nil
 }
 
 // NOTE: These are mirrored here merely to provide correct capabilities for the

--- a/internal/lsp/bundles/bundles.go
+++ b/internal/lsp/bundles/bundles.go
@@ -25,11 +25,6 @@ func LoadDataBundle(path string) (bundle.Bundle, error) {
 }
 
 func dataFileLoaderFilter(abspath string, info os.FileInfo, _ int) bool {
-	if info.IsDir() {
-		return false
-	}
-
-	basename := filepath.Base(abspath)
-
-	return !slices.Contains([]string{".manifest", "data.json", "data.yml", "data.yaml"}, basename)
+	return !info.IsDir() &&
+		!slices.Contains([]string{".manifest", "data.json", "data.yml", "data.yaml"}, filepath.Base(abspath))
 }

--- a/internal/lsp/eval_test.go
+++ b/internal/lsp/eval_test.go
@@ -108,7 +108,6 @@ func TestFindInputPath(t *testing.T) {
 	}{
 		{"json", `{"x": true}`},
 		{"yaml", "x: true"},
-		{"yml", "x: true"},
 	}
 
 	for _, tc := range cases {

--- a/pkg/fixer/fixes/fmt.go
+++ b/pkg/fixer/fixes/fmt.go
@@ -1,6 +1,7 @@
 package fixes
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 
@@ -22,11 +23,7 @@ type Fmt struct {
 func (f *Fmt) Name() string {
 	// this allows this fix config to also be registered under another name so that different
 	// configurations can be registered under other linter rule names.
-	if f.NameOverride != "" {
-		return f.NameOverride
-	}
-
-	return "opa-fmt"
+	return cmp.Or(f.NameOverride, "opa-fmt")
 }
 
 func (f *Fmt) Fix(fc *FixCandidate, opts *RuntimeOptions) ([]FixResult, error) {


### PR DESCRIPTION
- Fix issue where `regal new rule` would delete the `features` node from the config file
- Fix issue where `regal new rule` would add an internal `capabilities_url` attribute to the config file
- Fix test template for new built-in rules, as the location in the generated code was wrong
- The `--output` flag is now honored also when generating docs
- Add launch configuration for easier debugging of `regal new rule` in the future
- A **bunch** of refactoring done, mostly in our code dealing with io. I'm particularly happy about the new FIleWalker feature and how it compares to our previous code. But there's something here for everyone :)

Fixes #1497

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->