### PR TITLE
docs: Update README re: move to open-policy-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@
 
 <!-- markdownlint-disable MD041 -->
 
+> [!IMPORTANT]
+> Regal is now an official OPA project!
+> ([More Info](https://blog.openpolicyagent.org/note-from-teemu-tim-and-torin-to-the-open-policy-agent-community-2dbbfe494371))
+> For those previously installing Regal from StyraInc/regal, please update your
+> scripts and documentation to refer to this Repo. We will be migrating the
+> Regal's documentation to openpolicyagent.org from the next release. Please
+> [file an issue](https://github.com/open-policy-agent/regal/issues/new)
+> for any problems you run into.
+
 Regal is a linter, debugger and language server for [Rego](https://www.openpolicyagent.org/docs/policy-language/),
 making your Rego magnificent, and you the ruler of rules!
 

--- a/docs/readme-sections/intro.md
+++ b/docs/readme-sections/intro.md
@@ -1,5 +1,14 @@
 <!-- markdownlint-disable MD041 -->
 
+> [!IMPORTANT]
+> Regal is now an official OPA project!
+> ([More Info](https://blog.openpolicyagent.org/note-from-teemu-tim-and-torin-to-the-open-policy-agent-community-2dbbfe494371))
+> For those previously installing Regal from StyraInc/regal, please update your
+> scripts and documentation to refer to this Repo. We will be migrating the
+> Regal's documentation to openpolicyagent.org from the next release. Please
+> [file an issue](https://github.com/open-policy-agent/regal/issues/new)
+> for any problems you run into.
+
 Regal is a linter, debugger and language server for [Rego](https://www.openpolicyagent.org/docs/policy-language/),
 making your Rego magnificent, and you the ruler of rules!
 


### PR DESCRIPTION
This is to help keep users right while we update the docs. [More Info](https://blog.openpolicyagent.org/note-from-teemu-tim-and-torin-to-the-open-policy-agent-community-2dbbfe494371)