### PR TITLE
internal/io: explicitly disable lazy loading of regal bundle

### DIFF
--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -41,6 +41,7 @@ func LoadRegalBundleFS(fs fs.FS) (*bundle.Bundle, error) {
 		WithCapabilities(Capabilities()).
 		WithSkipBundleVerification(true).
 		WithProcessAnnotations(true).
+		WithLazyLoadingMode(false). // NB(sr): This is OPA's default, unless when using bundle plugins
 		WithBundleName("regal").
 		Read()
 	if err != nil {


### PR DESCRIPTION
For virtually all OPA users, this will make no difference. But if you use Regal together with OPA and bundle activation plugin(s), like EOPA, the default will be flipped. As a consequence, the internal Regal bundle cannot be loaded, and every linting fails.

This only affects users that

1. build something that embeds Regal as Go module
2. register extensions with OPA's bundle loader

Since de-registering such extensions isn't well-supported, it's hard to test for this.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->