### PR TITLE
jjlsp: GTD use URI for location

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1493,7 +1493,12 @@ func (l *LanguageServer) handleTextDocumentDefinition(params types.DefinitionPar
 
 	res := definition.Result
 
-	return types.Location{URI: res.File, Range: types.RangeBetween(res.Row-1, res.Col-1, res.Row-1, res.Col-1)}, nil
+	return types.Location{
+		// res.File will be relative to the workspace root. The response here needs
+		// a URI for the client to be able to navigate correctly.
+		URI:   util.EnsureSuffix(l.workspaceRootURI, "/") + res.File,
+		Range: types.RangeBetween(res.Row-1, res.Col-1, res.Row-1, res.Col-1),
+	}, nil
 }
 
 func (l *LanguageServer) handleTextDocumentDidOpen(params types.DidOpenTextDocumentParams) (any, error) {


### PR DESCRIPTION
Parsed modules use relative paths now to keep error messages correct for users. This means we have to contextualise filenames if we need to use them for URIs in LSP messages. This is done using the current root URI from the server.
