### PR TITLE
fix: Don't use OS path separator when walking FS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@
 
 <!-- markdownlint-disable MD041 -->
 
+Regal is a linter, debugger and language server for [Rego](https://www.openpolicyagent.org/docs/policy-language/),
+making your Rego magnificent, and you the ruler of rules!
+
+With its extensive set of linter rules, documentation and editor integrations, Regal is the perfect companion for policy
+development, whether you're an experienced Rego developer or just starting out.
+
 > [!IMPORTANT]
 > Regal is now an official OPA project!
 > ([More Info](https://blog.openpolicyagent.org/note-from-teemu-tim-and-torin-to-the-open-policy-agent-community-2dbbfe494371))
@@ -23,12 +29,6 @@
 > Regal's documentation to openpolicyagent.org from the next release. Please
 > [file an issue](https://github.com/open-policy-agent/regal/issues/new)
 > for any problems you run into.
-
-Regal is a linter, debugger and language server for [Rego](https://www.openpolicyagent.org/docs/policy-language/),
-making your Rego magnificent, and you the ruler of rules!
-
-With its extensive set of linter rules, documentation and editor integrations, Regal is the perfect companion for policy
-development, whether you're an experienced Rego developer or just starting out.
 
 
 <!-- markdownlint-disable MD033 -->

--- a/docs/readme-sections/intro.md
+++ b/docs/readme-sections/intro.md
@@ -1,5 +1,11 @@
 <!-- markdownlint-disable MD041 -->
 
+Regal is a linter, debugger and language server for [Rego](https://www.openpolicyagent.org/docs/policy-language/),
+making your Rego magnificent, and you the ruler of rules!
+
+With its extensive set of linter rules, documentation and editor integrations, Regal is the perfect companion for policy
+development, whether you're an experienced Rego developer or just starting out.
+
 > [!IMPORTANT]
 > Regal is now an official OPA project!
 > ([More Info](https://blog.openpolicyagent.org/note-from-teemu-tim-and-torin-to-the-open-policy-agent-community-2dbbfe494371))
@@ -8,9 +14,3 @@
 > Regal's documentation to openpolicyagent.org from the next release. Please
 > [file an issue](https://github.com/open-policy-agent/regal/issues/new)
 > for any problems you run into.
-
-Regal is a linter, debugger and language server for [Rego](https://www.openpolicyagent.org/docs/policy-language/),
-making your Rego magnificent, and you the ruler of rules!
-
-With its extensive set of linter rules, documentation and editor integrations, Regal is the perfect companion for policy
-development, whether you're an experienced Rego developer or just starting out.

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -1,7 +1,6 @@
 package compile
 
 import (
-	"os"
 	"strings"
 	"sync"
 
@@ -50,7 +49,11 @@ var RegalSchemaSet = sync.OnceValue(func() *ast.SchemaSet {
 
 			util.Must0(encoding.JSON().Unmarshal(util.Must(embeds.SchemasFS.ReadFile(path)), &schemaAny))
 
-			spl := strings.Split(strings.TrimSuffix(path, ".json"), string(os.PathSeparator))
+			// > This is unlike io/fs.WalkDir, which always uses slash separated paths.
+			// https://pkg.go.dev/path/filepath#WalkDir
+			//
+			// https://github.com/open-policy-agent/regal/issues/1679
+			spl := strings.Split(strings.TrimSuffix(path, ".json"), "/")
 			ref := ast.Ref([]*ast.Term{ast.SchemaRootDocument}).Extend(ast.MustParseRef(strings.Join(spl[1:], ".")))
 
 			schemaSet.Put(ref, schemaAny)

--- a/internal/io/files/walker.go
+++ b/internal/io/files/walker.go
@@ -192,6 +192,8 @@ func (fwr *WalkReducer[T]) Reduce(f func(string, T) (T, error)) (T, error) {
 // calling f for each file. The function f receives the path of the file and
 // the current value of the accumulator. It returns the new value of the
 // accumulator and an error if any.
+// NOTE: Unlike that path passed to f is always /-separated when walking an FS
+// implementation (as opposed to a directory, where the separator is OS-specific).
 func (fwr *WalkReducer[T]) ReduceFS(target fs.FS, f func(string, T) (T, error)) (T, error) {
 	curr := fwr.initial
 	err := fwr.WalkFS(target, func(path string) (err error) {


### PR DESCRIPTION
Also moved the "important" section in the readme somewhat as it's not as important now.

Fixes #1679

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->