### PR TITLE
build: Add windows runners to build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ permissions: read-all
 jobs:
   build-matrix:
     env:
-      RQ_VERSION: v0.0.9
+      RQ_VERSION: v0.0.15
     name: Matrix
     strategy:
       matrix:
@@ -122,3 +122,21 @@ jobs:
           files: ./coverage.json
           name: regal
           token: ${{ secrets.CODECOV_TOKEN }} # required
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+      - uses: open-policy-agent/setup-opa@34a30e8a924d1b03ce2cf7abe97250bbb1f332b5 # v2.2.0
+        with:
+          version: latest
+          static: ${{ matrix.os.static }}
+      # TODO: windows tests are failing, but we should still run the build & tests for inspection
+      - run: go build
+        continue-on-error: true
+      - run: go test ./...
+        continue-on-error: true
+      - run: go test -tags e2e ./e2e
+        continue-on-error: true

--- a/internal/capabilities/capabilities_test.go
+++ b/internal/capabilities/capabilities_test.go
@@ -2,11 +2,17 @@ package capabilities
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
 func TestLookupFromFile(t *testing.T) {
 	t.Parallel()
+
+	// TODO: https://github.com/open-policy-agent/regal/issues/1683
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
 
 	// Test that we are able to load a capabilities file using a file://
 	// URL.

--- a/internal/io/io_test.go
+++ b/internal/io/io_test.go
@@ -33,7 +33,10 @@ func TestFindManifestLocations(t *testing.T) {
 			t.Errorf("expected 2 locations, got %d", len(locations))
 		}
 
-		expected := []string{"foo/bar/baz", "foo/bar/qux"}
+		expected := []string{
+			filepath.FromSlash("foo/bar/baz"),
+			filepath.FromSlash("foo/bar/qux"),
+		}
 
 		if !slices.Equal(locations, expected) {
 			t.Errorf("expected %v, got %v", expected, locations)

--- a/internal/lsp/server_load_workspace_test.go
+++ b/internal/lsp/server_load_workspace_test.go
@@ -3,6 +3,7 @@ package lsp
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"testing"
 
@@ -117,6 +118,10 @@ func TestLoadWorkspaceContents(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+
+			if len(tc.unreadableFiles) > 0 && runtime.GOOS == "windows" {
+				t.Skip("file permissions used to test unreadableFiles doesn't work on windows")
+			}
 
 			tempDir := testutil.TempDirectoryOf(t, tc.files)
 

--- a/internal/lsp/server_rename_test.go
+++ b/internal/lsp/server_rename_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/open-policy-agent/regal/internal/lsp/clients"
 	"github.com/open-policy-agent/regal/internal/lsp/log"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
+	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	"github.com/open-policy-agent/regal/internal/testutil"
 	"github.com/open-policy-agent/regal/pkg/config"
 )
@@ -165,7 +166,7 @@ func TestLanguageServerFixRenameParamsWhenTargetOutsideRoot(t *testing.T) {
 	ls.client.Identifier = clients.IdentifierVSCode
 	// the root where the client stated the workspace is
 	// this is what would be set if a config file were in the parent instead
-	ls.workspaceRootURI = fmt.Sprintf("file://%s/workspace/", tmpDir)
+	ls.workspaceRootURI = uri.FromPath(clients.IdentifierGeneric, filepath.Join(tmpDir, "workspace"))
 	ls.loadedConfig = &config.Config{
 		Rules: map[string]config.Category{
 			"idiomatic": {

--- a/internal/lsp/server_single_file_test.go
+++ b/internal/lsp/server_single_file_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/open-policy-agent/regal/internal/lsp/clients"
 	"github.com/open-policy-agent/regal/internal/lsp/test"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
+	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	"github.com/open-policy-agent/regal/internal/testutil"
 )
 
@@ -38,7 +40,7 @@ rules:
 
 	// set up the workspace content with some example rego and regal config
 	tempDir := testutil.TempDirectoryOf(t, files)
-	mainRegoURI := fileURIScheme + tempDir + mainRegoFileName
+	mainRegoURI := uri.FromPath(clients.IdentifierGeneric, filepath.Join(tempDir, filepath.FromSlash(mainRegoFileName)))
 
 	receivedMessages := make(chan types.FileDiagnostics, defaultBufferedChannelSize)
 	clientHandler := test.HandlerFor(methodTdPublishDiagnostics, test.SendsToChannel(receivedMessages))

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -14,9 +14,11 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/util"
 
+	"github.com/open-policy-agent/regal/internal/lsp/clients"
 	"github.com/open-policy-agent/regal/internal/lsp/handler"
 	"github.com/open-policy-agent/regal/internal/lsp/log"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
+	"github.com/open-policy-agent/regal/internal/lsp/uri"
 )
 
 const (
@@ -92,7 +94,10 @@ func createAndInitServer(
 
 	ls.SetConn(connServer)
 
-	request := types.InitializeParams{RootURI: fileURIScheme + tempDir, ClientInfo: types.ClientInfo{Name: "go test"}}
+	request := types.InitializeParams{
+		RootURI:    uri.FromPath(clients.IdentifierGeneric, tempDir),
+		ClientInfo: types.ClientInfo{Name: "go test"},
+	}
 
 	var response types.InitializeResult
 	if err := connClient.Call(ctx, "initialize", request, &response); err != nil {

--- a/internal/lsp/uri/uri.go
+++ b/internal/lsp/uri/uri.go
@@ -9,6 +9,9 @@ import (
 	"github.com/open-policy-agent/regal/internal/lsp/clients"
 )
 
+// uris always use / as the uriSeparator, regardless of system.
+const uriSeparator = "/"
+
 var drivePattern = regexp.MustCompile(`^\/?([A-Za-z]):`)
 
 // FromPath converts a file path to a URI for a given client.
@@ -16,7 +19,7 @@ var drivePattern = regexp.MustCompile(`^\/?([A-Za-z]):`)
 // will convert the path to the appropriate format for the client.
 func FromPath(client clients.Identifier, path string) string {
 	path = strings.TrimPrefix(path, "file://")
-	path = strings.TrimPrefix(path, "/")
+	path = strings.TrimPrefix(path, uriSeparator)
 
 	var driveLetter string
 	if matches := drivePattern.FindStringSubmatch(path); len(matches) > 0 {
@@ -27,7 +30,7 @@ func FromPath(client clients.Identifier, path string) string {
 		path = strings.TrimPrefix(path, driveLetter)
 	}
 
-	parts := strings.Split(filepath.ToSlash(path), "/")
+	parts := strings.Split(filepath.ToSlash(path), uriSeparator)
 	for i, part := range parts {
 		parts[i] = url.QueryEscape(part)
 		parts[i] = strings.ReplaceAll(parts[i], "+", "%20")
@@ -35,17 +38,17 @@ func FromPath(client clients.Identifier, path string) string {
 
 	if client == clients.IdentifierVSCode {
 		if driveLetter != "" {
-			return "file:///" + url.QueryEscape(driveLetter) + strings.Join(parts, "/")
+			return "file:///" + url.QueryEscape(driveLetter) + strings.Join(parts, uriSeparator)
 		}
 
-		return "file:///" + strings.Join(parts, "/")
+		return "file:///" + strings.Join(parts, uriSeparator)
 	}
 
 	if driveLetter != "" {
-		return "file:///" + driveLetter + strings.Join(parts, "/")
+		return "file:///" + driveLetter + strings.Join(parts, uriSeparator)
 	}
 
-	return "file:///" + strings.Join(parts, "/")
+	return "file:///" + strings.Join(parts, uriSeparator)
 }
 
 // ToPath converts a URI to a file path from a format for a given client.
@@ -65,7 +68,7 @@ func ToPath(client clients.Identifier, uri string) string {
 	// handling case for windows when the drive letter is set
 	if client == clients.IdentifierVSCode &&
 		drivePattern.MatchString(path) {
-		path = strings.TrimPrefix(path, "/")
+		path = strings.TrimPrefix(path, uriSeparator)
 	}
 
 	// Convert path to use system separators

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -119,7 +119,7 @@ func TestFindConfig(t *testing.T) {
 				}
 
 				if testData.ExpectedName != "" {
-					if got, exp := strings.TrimPrefix(configFile.Name(), root), testData.ExpectedName; got != exp {
+					if got, exp := strings.TrimPrefix(configFile.Name(), root), filepath.FromSlash(testData.ExpectedName); got != exp {
 						t.Fatalf("expected config file %q, got %q", exp, got)
 					}
 				}

--- a/pkg/fixer/fixer_test.go
+++ b/pkg/fixer/fixer_test.go
@@ -1,6 +1,7 @@
 package fixer
 
 import (
+	"path/filepath"
 	"slices"
 	"testing"
 
@@ -120,12 +121,12 @@ func TestFixViolations(t *testing.T) {
 	// targeted specific fix for a given violation
 	violations := []report.Violation{{
 		Title:    "directory-package-mismatch",
-		Location: report.Location{File: "root/main.rego"},
+		Location: report.Location{File: filepath.FromSlash("root/main.rego")},
 	}}
 
 	memfp := fileprovider.NewInMemoryFileProvider(map[string]string{
-		"root/main.rego":         "package foo.bar\n\nallow := true\n",
-		"root/foo/bar/main.rego": "package foo.bar\n\nallow := true\n", // file in correct place
+		filepath.FromSlash("root/main.rego"):         "package foo.bar\n\nallow := true\n",
+		filepath.FromSlash("root/foo/bar/main.rego"): "package foo.bar\n\nallow := true\n", // file in correct place
 	})
 
 	f := NewFixer().SetOnConflictOperation(OnConflictRename).RegisterFixes(fixes.NewDefaultFixes()...)
@@ -136,14 +137,14 @@ func TestFixViolations(t *testing.T) {
 	}
 
 	expectedFileFixedViolations := map[string][]string{
-		"root/main.rego":           {"directory-package-mismatch"},
-		"root/foo/bar/main_1.rego": {"directory-package-mismatch"},
-		"root/foo/bar/main.rego":   {}, // no fixes
+		filepath.FromSlash("root/main.rego"):           {"directory-package-mismatch"},
+		filepath.FromSlash("root/foo/bar/main_1.rego"): {"directory-package-mismatch"},
+		filepath.FromSlash("root/foo/bar/main.rego"):   {}, // no fixes
 	}
 	expectedFileContents := map[string]string{
-		"root/main.rego":           "package foo.bar\n\nallow := true\n", // old file yet to be deleted
-		"root/foo/bar/main_1.rego": "package foo.bar\n\nallow := true\n",
-		"root/foo/bar/main.rego":   "package foo.bar\n\nallow := true\n", // file in correct place
+		filepath.FromSlash("root/main.rego"):           "package foo.bar\n\nallow := true\n", // old file yet to be deleted
+		filepath.FromSlash("root/foo/bar/main_1.rego"): "package foo.bar\n\nallow := true\n",
+		filepath.FromSlash("root/foo/bar/main.rego"):   "package foo.bar\n\nallow := true\n", // file in correct place
 	}
 
 	if got, exp := fixReport.TotalFixes(), uint(2); got != exp {

--- a/pkg/fixer/fixes/directorypackagemismatch_test.go
+++ b/pkg/fixer/fixes/directorypackagemismatch_test.go
@@ -1,6 +1,7 @@
 package fixes
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -157,8 +158,8 @@ func TestFixDirectoryPackageMismatch(t *testing.T) {
 					t.Fatalf("expected from path to be %s, got %s", tc.expected.Rename.FromPath, fixResult.Rename.FromPath)
 				}
 
-				if fixResult.Rename.ToPath != tc.expected.Rename.ToPath {
-					t.Fatalf("expected to path to be %s, got %s", tc.expected.Rename.ToPath, fixResult.Rename.ToPath)
+				if exp, got := fixResult.Rename.ToPath, filepath.FromSlash(tc.expected.Rename.ToPath); exp != got {
+					t.Fatalf("expected to path to be %s, got %s", exp, got)
 				}
 			}
 		})

--- a/pkg/fixer/rename_test.go
+++ b/pkg/fixer/rename_test.go
@@ -1,6 +1,9 @@
 package fixer
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 func TestRenameCandidate(t *testing.T) {
 	t.Parallel()
@@ -48,7 +51,7 @@ func TestRenameCandidate(t *testing.T) {
 			t.Parallel()
 
 			actual := renameCandidate(tc.oldName)
-			if actual != tc.expected {
+			if actual != filepath.FromSlash(tc.expected) {
 				t.Errorf("expected %s, got %s", tc.expected, actual)
 			}
 		})

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -140,12 +139,14 @@ func RegoVersionFromMap(
 	}
 
 	selectedVersion := defaultVersion
-	dir := path.Join("/", filepath.Dir(filename))
+	dir := filepath.Dir(filename)
 
 	var longestMatch int
 
 	for versionedDir := range versionsMap {
-		matchingVersionedDir := path.Join("/", versionedDir, "/")
+		matchingVersionedDir := filepath.Join(
+			string(os.PathSeparator), filepath.FromSlash(versionedDir), string(os.PathSeparator),
+		)
 
 		if strings.HasPrefix(dir, matchingVersionedDir) {
 			// >= as the versioned dir might be "" for the project root

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/ast"
@@ -119,7 +120,7 @@ func TestRegoVersionFromVersionsMap(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			actualVersion := RegoVersionFromMap(tc.VersionsMap, tc.Filename, ast.RegoUndefined)
+			actualVersion := RegoVersionFromMap(tc.VersionsMap, filepath.FromSlash(tc.Filename), ast.RegoUndefined)
 			if actualVersion != tc.ExpectedVersion {
 				t.Errorf("Expected %v, got %v", tc.ExpectedVersion, actualVersion)
 			}


### PR DESCRIPTION
We used to run tests on windows runners, hopefully it'll help catch bugs earlier.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->