### PR TITLE
Fix documentLink issue when no user config provided

### DIFF
--- a/bundle/regal/config/config.rego
+++ b/bundle/regal/config/config.rego
@@ -15,7 +15,7 @@ path_prefix := data.internal.path_prefix
 
 # METADATA
 # description: the base URL for documentation of linter rules
-docs["base_url"] := "https://docs.styra.com/regal/rules"
+docs["base_url"] := "https://www.openpolicyagent.org/projects/regal/rules"
 
 # METADATA
 # description: returns the canonical URL for documentation of the given rule

--- a/bundle/regal/lsp/codeaction/codeaction.rego
+++ b/bundle/regal/lsp/codeaction/codeaction.rego
@@ -1,7 +1,7 @@
 # METADATA
 # description: Handler for Code Actions
 # related_resources:
-#   - https://docs.styra.com/regal/language-server#code-actions
+#   - https://www.openpolicyagent.org/projects/regal/language-server#code-actions
 #   - https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_codeAction
 # schemas:
 #   - input:        schema.regal.lsp.common

--- a/bundle/regal/lsp/codeaction/codeaction_test.rego
+++ b/bundle/regal/lsp/codeaction/codeaction_test.rego
@@ -101,7 +101,7 @@ test_code_actions_specific_to_vscode_reported_on_client_match if {
 			"title": "Show documentation for use-assignment-operator",
 			"kind": "quickfix",
 			"command": {
-				"arguments": ["https://docs.styra.com/regal/rules/style/use-assignment-operator"],
+				"arguments": ["https://www.openpolicyagent.org/projects/regal/rules/style/use-assignment-operator"],
 				"command": "vscode.open",
 				"title": "Show documentation for use-assignment-operator",
 				"tooltip": "Show documentation for use-assignment-operator",
@@ -158,7 +158,7 @@ test_code_actions_only_quickfix if {
 			"title": "Show documentation for use-assignment-operator",
 			"kind": "quickfix",
 			"command": {
-				"arguments": ["https://docs.styra.com/regal/rules/style/use-assignment-operator"],
+				"arguments": ["https://www.openpolicyagent.org/projects/regal/rules/style/use-assignment-operator"],
 				"command": "vscode.open",
 				"title": "Show documentation for use-assignment-operator",
 				"tooltip": "Show documentation for use-assignment-operator",
@@ -237,7 +237,7 @@ _diagnostics["use-assignment-operator"] := object.union(
 		"code": "use-assignment-operator",
 		"message": "Use := instead of = for assignment",
 		"range": {"start": {"line": 2, "character": 0}, "end": {"line": 2, "character": 1}},
-		"codeDescription": {"href": "https://docs.styra.com/regal/rules/style/use-assignment-operator"},
+		"codeDescription": {"href": "https://www.openpolicyagent.org/projects/regal/rules/style/use-assignment-operator"},
 	},
 	{},
 )

--- a/bundle/regal/lsp/documentlink/documentlink.rego
+++ b/bundle/regal/lsp/documentlink/documentlink.rego
@@ -40,7 +40,7 @@ items contains item if {
 	col := loc.col + pos
 
 	item := {
-		"target": concat("/", ["https://docs.styra.com/regal/rules", _category_for[rule], rule]),
+		"target": concat("/", ["https://www.openpolicyagent.org/projects/regal/rules", _category_for[rule], rule]),
 		"range": {
 			"start": {"line": row, "character": col},
 			"end": {"line": row, "character": col + count(rule)},

--- a/bundle/regal/lsp/documentlink/documentlink_test.rego
+++ b/bundle/regal/lsp/documentlink/documentlink_test.rego
@@ -27,7 +27,7 @@ test_documentlink_ranges_in_inline_ignores if {
 					"line": 2,
 				},
 			},
-			"target": "https://docs.styra.com/regal/rules/style/messy-rule",
+			"target": "https://www.openpolicyagent.org/projects/regal/rules/style/messy-rule",
 			"tooltip": "See documentation for messy-rule",
 		},
 		{
@@ -41,7 +41,7 @@ test_documentlink_ranges_in_inline_ignores if {
 					"line": 2,
 				},
 			},
-			"target": "https://docs.styra.com/regal/rules/imports/unresolved-reference",
+			"target": "https://www.openpolicyagent.org/projects/regal/rules/imports/unresolved-reference",
 			"tooltip": "See documentation for unresolved-reference",
 		},
 	}

--- a/bundle/regal/lsp/signaturehelp/signaturehelp.rego
+++ b/bundle/regal/lsp/signaturehelp/signaturehelp.rego
@@ -5,8 +5,6 @@
 #   - input.params: schema.regal.lsp.signaturehelp
 package regal.lsp.signaturehelp
 
-import rego.v1
-
 # METADATA
 # entrypoint: true
 result["response"] := signature

--- a/bundle/regal/main/main_test.rego
+++ b/bundle/regal/main/main_test.rego
@@ -342,7 +342,7 @@ test_main_lint if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": "https://docs.styra.com/regal/rules/style/use-assignment-operator",
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/use-assignment-operator",
 		}],
 		"title": "use-assignment-operator",
 	}}

--- a/bundle/regal/regal.rego
+++ b/bundle/regal/regal.rego
@@ -1,10 +1,9 @@
 # METADATA
 # scope: subpackages
 # authors:
-#   - Styra
+#   - The OPA community
 # related_resources:
-#   - https://www.styra.com
-#   - https://docs.styra.com/regal
+#   - https://www.openpolicyagent.org/projects/regal
 # schemas:
 #   - input: schema.regal.ast
 package regal

--- a/bundle/regal/rules/imports/circular-import/circular_import.rego
+++ b/bundle/regal/rules/imports/circular-import/circular_import.rego
@@ -2,7 +2,7 @@
 # description: Circular import
 # related_resources:
 # - description: documentation
-#   ref: https://docs.styra.com/regal/rules/imports/circular-import
+#   ref: https://www.openpolicyagent.org/projects/regal/rules/imports/circular-import
 # schemas:
 # - input: schema.regal.ast
 package regal.rules.imports["circular-import"]

--- a/bundle/regal/rules/style/double-negative/double_negative.rego
+++ b/bundle/regal/rules/style/double-negative/double_negative.rego
@@ -2,7 +2,7 @@
 # description: Avoid double negatives
 # related_resources:
 # - description: documentation
-#   ref: https://docs.styra.com/regal/rules/style/double-negative
+#   ref: https://www.openpolicyagent.org/projects/regal/rules/style/double-negative
 # schemas:
 # - input: schema.regal.ast
 package regal.rules.style["double-negative"]

--- a/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration.rego
+++ b/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration.rego
@@ -49,7 +49,7 @@ _has_sub_attribute(ref) if {
 }
 
 # don't walk top level iteration refs:
-# https://docs.styra.com/regal/rules/bugs/top-level-iteration
+# https://www.openpolicyagent.org/projects/regal/rules/bugs/top-level-iteration
 _possible_top_level_iteration(rule) if {
 	not rule.body
 	rule.head.value.type == "ref"

--- a/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package.rego
+++ b/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package.rego
@@ -2,7 +2,7 @@
 # description: Rule name repeats package
 # related_resources:
 #   - description: documentation
-#     ref: https://docs.styra.com/regal/rules/style/rule-name-repeats-package
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/rule-name-repeats-package
 package regal.rules.style["rule-name-repeats-package"]
 
 import data.regal.ast

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -268,7 +268,7 @@ func lint(args []string, params *lintParams) (result report.Report, err error) {
 }
 
 func updateCheckAndWarn(params *lintParams, regalRules *bundle.Bundle, userConfig *config.Config) {
-	mergedConfig, err := config.LoadConfigWithDefaultsFromBundle(regalRules, userConfig)
+	mergedConfig, err := config.WithDefaultsFromBundle(regalRules, userConfig)
 	if err != nil {
 		if params.debug {
 			log.Printf("failed to merge user config with default config when checking version: %v", err)

--- a/internal/lsp/completions/manager.go
+++ b/internal/lsp/completions/manager.go
@@ -9,6 +9,7 @@ import (
 	"github.com/open-policy-agent/regal/internal/lsp/cache"
 	"github.com/open-policy-agent/regal/internal/lsp/completions/providers"
 	"github.com/open-policy-agent/regal/internal/lsp/rego"
+	"github.com/open-policy-agent/regal/internal/lsp/rego/query"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 )
 
@@ -29,12 +30,12 @@ func NewManager(c *cache.Cache, opts *ManagerOptions) *Manager {
 	return &Manager{c: c, opts: opts}
 }
 
-func NewDefaultManager(ctx context.Context, c *cache.Cache, store storage.Store) *Manager {
+func NewDefaultManager(ctx context.Context, c *cache.Cache, store storage.Store, qc *query.Cache) *Manager {
 	m := NewManager(c, &ManagerOptions{})
 
 	m.RegisterProvider(&providers.BuiltIns{})
 	m.RegisterProvider(&providers.PackageRefs{})
-	m.RegisterProvider(providers.NewPolicy(ctx, store))
+	m.RegisterProvider(providers.NewPolicy(ctx, store, qc))
 
 	return m
 }

--- a/internal/lsp/completions/providers/policy_test.go
+++ b/internal/lsp/completions/providers/policy_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
 
 	"github.com/open-policy-agent/regal/internal/lsp/cache"
+	"github.com/open-policy-agent/regal/internal/lsp/rego/query"
 	"github.com/open-policy-agent/regal/internal/lsp/test"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/parse"
@@ -45,7 +46,7 @@ allow if {
 	params := types.NewCompletionParams(testCaseFileURI, 5, 11, nil)
 	opts := &Options{Client: types.NewGenericClient()}
 
-	result, err := NewPolicy(t.Context(), store).Run(t.Context(), c, params, opts)
+	result, err := NewPolicy(t.Context(), store, query.NewCache()).Run(t.Context(), c, params, opts)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -79,7 +80,7 @@ func TestPolicyProvider_Example2(t *testing.T) {
 	params := types.NewCompletionParams("file:///file2.rego", 5, 11, nil)
 	opts := &Options{Client: types.NewGenericClient()}
 
-	result, err := NewPolicy(t.Context(), store).Run(t.Context(), c, params, opts)
+	result, err := NewPolicy(t.Context(), store, query.NewCache()).Run(t.Context(), c, params, opts)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/lsp/eval.go
+++ b/internal/lsp/eval.go
@@ -12,7 +12,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/topdown/print"
 
 	rbundle "github.com/open-policy-agent/regal/bundle"
-	rrego "github.com/open-policy-agent/regal/internal/lsp/rego"
+	rquery "github.com/open-policy-agent/regal/internal/lsp/rego/query"
 	"github.com/open-policy-agent/regal/internal/util"
 	"github.com/open-policy-agent/regal/pkg/builtins"
 	"github.com/open-policy-agent/regal/pkg/config"
@@ -104,7 +104,7 @@ func prepareRegoArgs(
 	args := []func(*rego.Rego){rego.ParsedQuery(query), rego.EnablePrintStatements(true), rego.PrintHook(printHook)}
 	args = append(args, builtins.RegalBuiltinRegoFuncs...)
 	args = append(args, bundleArgs...)
-	args = append(args, rrego.SchemaResolvers()...)
+	args = append(args, rquery.SchemaResolvers()...)
 
 	var caps *config.Capabilities
 	if cfg != nil && cfg.Capabilities != nil {

--- a/internal/lsp/hover/hover.go
+++ b/internal/lsp/hover/hover.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-policy-agent/regal/internal/lsp/cache"
 	"github.com/open-policy-agent/regal/internal/lsp/examples"
 	"github.com/open-policy-agent/regal/internal/lsp/rego"
+	"github.com/open-policy-agent/regal/internal/lsp/rego/query"
 	types2 "github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/pkg/roast/util/concurrent"
 )
@@ -160,13 +161,13 @@ func UpdateBuiltinPositions(cache *cache.Cache, uri string, builtins map[string]
 	return nil
 }
 
-func UpdateKeywordLocations(ctx context.Context, cache *cache.Cache, uri string) error {
+func UpdateKeywordLocations(ctx context.Context, pq *query.Prepared, cache *cache.Cache, uri string) error {
 	fileContents, module, ok := cache.GetContentAndModule(uri)
 	if !ok {
 		return fmt.Errorf("failed to determine keyword locations: missing file contents for uri %q", uri)
 	}
 
-	keywords, err := rego.AllKeywords(ctx, filepath.Base(uri), fileContents, module)
+	keywords, err := rego.AllKeywords(ctx, pq, filepath.Base(uri), fileContents, module)
 	if err != nil {
 		return fmt.Errorf("failed to determine keyword locations: %w", err)
 	}

--- a/internal/lsp/rego/query/query.go
+++ b/internal/lsp/rego/query/query.go
@@ -1,11 +1,229 @@
 package query
 
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"sync"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/bundle"
+	"github.com/open-policy-agent/opa/v1/rego"
+	"github.com/open-policy-agent/opa/v1/resolver"
+	"github.com/open-policy-agent/opa/v1/storage"
+	"github.com/open-policy-agent/opa/v1/topdown"
+
+	rbundle "github.com/open-policy-agent/regal/bundle"
+	"github.com/open-policy-agent/regal/internal/compile"
+	"github.com/open-policy-agent/regal/internal/util"
+	"github.com/open-policy-agent/regal/pkg/builtins"
+	"github.com/open-policy-agent/regal/pkg/roast/rast"
+	"github.com/open-policy-agent/regal/pkg/roast/util/concurrent"
+)
+
 const (
 	Keywords          = "data.regal.ast.keywords"
 	RuleHeadLocations = "data.regal.ast.rule_head_locations"
 	Completion        = "data.regal.lsp.completion.items"
+	MainEval          = "data.regal.lsp.main.eval"
 )
+
+var simpleRefPattern = regexp.MustCompile(`^[a-zA-Z\.]$`)
+
+type (
+	Cache struct {
+		prepared *concurrent.Map[string, *Prepared]
+	}
+
+	Prepared struct {
+		body     ast.Body
+		prepared *rego.PreparedEvalQuery
+		store    storage.Store
+	}
+
+	schemaResolver struct {
+		value ast.Value
+	}
+
+	regoOptions = []func(*rego.Rego)
+)
+
+func SchemaResolvers() []func(*rego.Rego) {
+	return schemaResolvers()
+}
+
+func NewCache() *Cache {
+	return &Cache{prepared: concurrent.MapOf(make(map[string]*Prepared, 5))}
+}
+
+func (q *Prepared) EvalQuery() *rego.PreparedEvalQuery {
+	return q.prepared
+}
+
+func (q *Prepared) String() string {
+	return q.body.String()
+}
+
+func (c *Cache) Store(ctx context.Context, query string, store storage.Store) error {
+	parsedQuery := parseQuery(query)
+
+	pq, err := prepareQuery(ctx, parsedQuery, store)
+	if err != nil {
+		return fmt.Errorf("failed preparing query %q: %w", query, err)
+	}
+
+	c.prepared.Set(query, &Prepared{body: parsedQuery, prepared: pq, store: store})
+
+	return nil
+}
+
+func (c *Cache) Get(query string) *Prepared {
+	p, _ := c.prepared.Get(query)
+
+	return p
+}
+
+func (c *Cache) GetOrSet(ctx context.Context, store storage.Store, query string) (*Prepared, error) {
+	cq, ok := c.prepared.Get(query)
+	if !ok {
+		parsedQuery := parseQuery(query)
+
+		pq, err := prepareQuery(ctx, parsedQuery, store)
+		if err != nil {
+			return nil, fmt.Errorf("failed preparing query %q: %w", query, err)
+		}
+
+		cq = &Prepared{body: parsedQuery, prepared: pq, store: store}
+
+		c.prepared.Set(query, cq)
+
+		return cq, nil
+	}
+
+	if isBundleDevelopmentMode() {
+		// In dev mode, we always prepare the query to ensure changes in the bundle are reflected
+		// immediately. We can however reuse the query and the store (if set).
+		pq, err := prepareQuery(ctx, cq.body, cq.store)
+		if err != nil {
+			return nil, fmt.Errorf("failed preparing query %q: %w", query, err)
+		}
+
+		cq.prepared = pq
+	}
+
+	return cq, nil
+}
+
+func prepareQuery(ctx context.Context, query ast.Body, store storage.Store) (*rego.PreparedEvalQuery, error) {
+	args, txn := prepareQueryArgs(ctx, query, store, rbundle.LoadedBundle())
+
+	// Note that we currently don't provide metrics or profiling here, and
+	// most likely we should — need to consider how to best make that conditional
+	// and how to present it if enabled.
+	pq, err := rego.New(args...).PrepareForEval(ctx)
+	if err != nil {
+		if store != nil {
+			store.Abort(ctx, txn)
+		}
+
+		if isBundleDevelopmentMode() {
+			// Try falling back to the embedded bundle, or else we'll
+			// easily have errors popping up as notifications, making it
+			// really hard to fix the issue that broke the query (like a parse error)
+			args, txn = prepareQueryArgs(ctx, query, store, rbundle.EmbeddedBundle())
+			if pq, err = rego.New(args...).PrepareForEval(ctx); err == nil {
+				if store != nil && txn != nil {
+					if err = store.Commit(ctx, txn); err != nil {
+						return nil, err
+					}
+				}
+
+				return &pq, nil
+			}
+
+			if store != nil {
+				store.Abort(ctx, txn)
+			}
+		}
+
+		return nil, err
+	}
+
+	if store != nil && txn != nil {
+		if err = store.Commit(ctx, txn); err != nil {
+			return nil, err
+		}
+	}
+
+	return &pq, nil
+}
+
+func prepareQueryArgs(
+	ctx context.Context,
+	query ast.Body,
+	store storage.Store,
+	rb *bundle.Bundle,
+) (regoOptions, storage.Transaction) {
+	args := make([]func(*rego.Rego), 0, 5+len(builtins.RegalBuiltinRegoFuncs))
+	args = append(args, rego.ParsedQuery(query), rego.ParsedBundle("regal", rb))
+	args = append(args, builtins.RegalBuiltinRegoFuncs...)
+
+	// For debugging
+	args = append(args, rego.EnablePrintStatements(true), rego.PrintHook(topdown.NewPrintHook(os.Stderr)))
+	args = append(args, SchemaResolvers()...)
+
+	var txn storage.Transaction
+	if store != nil {
+		txn, _ = store.NewTransaction(ctx, storage.WriteParams)
+		args = append(args, rego.Store(store), rego.Transaction(txn))
+	} else {
+		args = append(args, rego.StoreReadAST(true))
+	}
+
+	return args, txn
+}
+
+func parseQuery(query string) ast.Body {
+	if simpleRefPattern.MatchString(query) { // Try cheap parsing if possible
+		return rast.RefStringToBody(query)
+	}
+
+	return ast.MustParseBody(query)
+}
 
 func AllQueries() []string {
 	return []string{Keywords, RuleHeadLocations, Completion}
+}
+
+func isBundleDevelopmentMode() bool {
+	return os.Getenv("REGAL_BUNDLE_PATH") != ""
+}
+
+var schemaResolvers = sync.OnceValue(func() (resolvers []func(*rego.Rego)) {
+	ss := compile.RegalSchemaSet()
+	added := util.NewSet[string]()
+
+	// Find all schema references in the bundle and add the schemas to the base cache.
+	for _, module := range rbundle.LoadedBundle().Modules {
+		for _, annos := range module.Parsed.Annotations {
+			for _, s := range annos.Schemas {
+				if len(s.Schema) == 0 || added.Contains(s.Schema.String()) {
+					continue
+				}
+				resolvers = append(resolvers, rego.Resolver(
+					ast.DefaultRootRef.Extend(s.Schema),
+					schemaResolver{value: ast.MustInterfaceToValue(ss.Get(s.Schema))},
+				))
+				added.Add(s.Schema.String())
+			}
+		}
+	}
+
+	return resolvers
+})
+
+// Eval implements the resolver.Resolver interface to resolve schemas from annotations at runtime.
+func (sr schemaResolver) Eval(context.Context, resolver.Input) (resolver.Result, error) {
+	return resolver.Result{Value: sr.value}, nil
 }

--- a/internal/lsp/rego/rego.go
+++ b/internal/lsp/rego/rego.go
@@ -4,27 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"regexp"
-	"sync"
 
 	"github.com/open-policy-agent/opa/v1/ast"
-	"github.com/open-policy-agent/opa/v1/bundle"
 	"github.com/open-policy-agent/opa/v1/rego"
-	"github.com/open-policy-agent/opa/v1/resolver"
-	"github.com/open-policy-agent/opa/v1/storage"
-	"github.com/open-policy-agent/opa/v1/topdown"
 
-	rbundle "github.com/open-policy-agent/regal/bundle"
-	"github.com/open-policy-agent/regal/internal/compile"
 	"github.com/open-policy-agent/regal/internal/lsp/rego/query"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/util"
-	"github.com/open-policy-agent/regal/pkg/builtins"
 	"github.com/open-policy-agent/regal/pkg/roast/encoding"
 	"github.com/open-policy-agent/regal/pkg/roast/rast"
 	"github.com/open-policy-agent/regal/pkg/roast/transform"
-	"github.com/open-policy-agent/regal/pkg/roast/util/concurrent"
 )
 
 var (
@@ -32,8 +21,6 @@ var (
 	errNoResults          = errors.New("no results returned from evaluation")
 	errExcpectedOneResult = errors.New("expected exactly one result from evaluation")
 	errExcpectedOneExpr   = errors.New("expected exactly one expression in result")
-	prepared              = concurrent.MapOf(make(map[string]*cachedQuery, 5))
-	simpleRefPattern      = regexp.MustCompile(`^[a-zA-Z\.]$`)
 )
 
 // init [storage.Store] initializes the storage store with the built-in queries.
@@ -85,6 +72,8 @@ type (
 		Client      types.Client `json:"client"`
 		File        File         `json:"file"`
 		Environment Environment  `json:"environment"`
+
+		Query *query.Prepared `json:"-"` // for now, might expose to Rego later
 	}
 
 	Requirements struct {
@@ -103,12 +92,9 @@ type (
 		Regal  RegalContext `json:"regal"`
 	}
 
-	regoOptions = []func(*rego.Rego)
-
-	cachedQuery struct {
-		body     ast.Body
-		prepared *rego.PreparedEvalQuery
-		store    storage.Store
+	Result[R any] struct {
+		Response R   `json:"response"`
+		Regal    any `json:"regal"`
 	}
 
 	policy struct {
@@ -131,14 +117,6 @@ func (c Input[T]) String() string { // For debugging only
 	return s
 }
 
-type schemaResolver struct {
-	value ast.Value
-}
-
-func SchemaResolvers() []func(*rego.Rego) {
-	return schemaResolvers()
-}
-
 func PositionFromLocation(loc *ast.Location) types.Position {
 	//nolint:gosec
 	return types.Position{Line: uint(loc.Row - 1), Character: uint(loc.Col - 1)}
@@ -147,14 +125,6 @@ func PositionFromLocation(loc *ast.Location) types.Position {
 func LocationFromPosition(pos types.Position) *ast.Location {
 	//nolint: gosec
 	return &ast.Location{Row: int(pos.Line + 1), Col: int(pos.Character + 1)}
-}
-
-func ParseQuery(query string) ast.Body {
-	if simpleRefPattern.MatchString(query) { // Try cheap parsing if possible
-		return rast.RefStringToBody(query)
-	}
-
-	return ast.MustParseBody(query)
 }
 
 // AllBuiltinCalls returns all built-in calls in the module, excluding operators
@@ -198,10 +168,12 @@ func AllBuiltinCalls(module *ast.Module, builtins map[string]*ast.Builtin) []Bui
 }
 
 // AllKeywords returns all keywords in the module.
-func AllKeywords(ctx context.Context, fileName, contents string, module *ast.Module) (map[string][]KeywordUse, error) {
+func AllKeywords(
+	ctx context.Context, pq *query.Prepared, fileName, contents string, module *ast.Module,
+) (map[string][]KeywordUse, error) {
 	var keywords map[string][]KeywordUse
 
-	if err := policyToValue(ctx, query.Keywords, policy{module, fileName, contents}, &keywords); err != nil {
+	if err := policyToValue(ctx, pq, policy{module, fileName, contents}, &keywords); err != nil {
 		return nil, fmt.Errorf("failed querying for all keywords: %w", err)
 	}
 
@@ -209,10 +181,12 @@ func AllKeywords(ctx context.Context, fileName, contents string, module *ast.Mod
 }
 
 // AllRuleHeadLocations returns mapping of rules names to the head locations.
-func AllRuleHeadLocations(ctx context.Context, fileName, contents string, module *ast.Module) (RuleHeads, error) {
+func AllRuleHeadLocations(
+	ctx context.Context, pq *query.Prepared, fileName, contents string, module *ast.Module,
+) (RuleHeads, error) {
 	var locations RuleHeads
 
-	err := policyToValue(ctx, string(query.RuleHeadLocations), policy{module, fileName, contents}, &locations)
+	err := policyToValue(ctx, pq, policy{module, fileName, contents}, &locations)
 	if err != nil {
 		return nil, fmt.Errorf("failed querying for rule head locations: %w", err)
 	}
@@ -220,28 +194,18 @@ func AllRuleHeadLocations(ctx context.Context, fileName, contents string, module
 	return locations, nil
 }
 
-type Result[R any] struct {
-	Response R   `json:"response"`
-	Regal    any `json:"regal"`
-}
-
-func QueryEval[P any, R any](ctx context.Context, query string, input Input[P]) (Result[R], error) {
+func QueryEval[P any, R any](ctx context.Context, pq *query.Prepared, input Input[P]) (Result[R], error) {
 	var result Result[R]
 
-	if err := CachedQueryEval(ctx, query, rast.StructToValue(input), &result); err != nil {
-		return result, fmt.Errorf("failed querying %q: %w", query, err)
+	if err := CachedQueryEval(ctx, pq, rast.StructToValue(input), &result); err != nil {
+		return result, fmt.Errorf("failed querying %q: %w", pq, err)
 	}
 
 	return result, nil
 }
 
-func CachedQueryEval[T any](ctx context.Context, query string, input ast.Value, toValue *T) error {
-	cq, err := getOrSetCachedQuery(ctx, query, nil)
-	if err != nil {
-		return fmt.Errorf("failed preparing query: %w", err)
-	}
-
-	result, err := toValidResult(cq.prepared.Eval(ctx, rego.EvalParsedInput(input)))
+func CachedQueryEval[T any](ctx context.Context, pq *query.Prepared, input ast.Value, toValue *T) error {
+	result, err := toValidResult(pq.EvalQuery().Eval(ctx, rego.EvalParsedInput(input)))
 	if err != nil {
 		return err
 	}
@@ -249,36 +213,13 @@ func CachedQueryEval[T any](ctx context.Context, query string, input ast.Value, 
 	return util.WrapErr(encoding.JSONRoundTrip(result.Expressions[0].Value, toValue), "failed to unmarshal value")
 }
 
-func StoreAllCachedQueries(ctx context.Context, store storage.Store) error {
-	for _, q := range query.AllQueries() {
-		if err := StoreCachedQuery(ctx, q, store); err != nil {
-			return fmt.Errorf("failed storing cached query %q: %w", q, err)
-		}
-	}
-
-	return nil
-}
-
-func StoreCachedQuery(ctx context.Context, query string, store storage.Store) error {
-	parsedQuery := ParseQuery(query)
-
-	pq, err := prepareQuery(ctx, parsedQuery, store)
-	if err != nil {
-		return fmt.Errorf("failed preparing query %q: %w", query, err)
-	}
-
-	prepared.Set(query, &cachedQuery{body: parsedQuery, prepared: pq, store: store})
-
-	return nil
-}
-
-func policyToValue[T any](ctx context.Context, query string, policy policy, toValue *T) error {
+func policyToValue[T any](ctx context.Context, pq *query.Prepared, policy policy, toValue *T) error {
 	input, err := transform.ToAST(policy.fileName, policy.contents, policy.module, false)
 	if err != nil {
 		return fmt.Errorf("failed to prepare input: %w", err)
 	}
 
-	return CachedQueryEval(ctx, query, input, toValue)
+	return CachedQueryEval(ctx, pq, input, toValue)
 }
 
 func toValidResult(rs rego.ResultSet, err error) (rego.Result, error) {
@@ -294,136 +235,4 @@ func toValidResult(rs rego.ResultSet, err error) (rego.Result, error) {
 	}
 
 	return rs[0], nil
-}
-
-func prepareQueryArgs(
-	ctx context.Context,
-	query ast.Body,
-	store storage.Store,
-	rb *bundle.Bundle,
-) (regoOptions, storage.Transaction) {
-	args := make([]func(*rego.Rego), 0, 5+len(builtins.RegalBuiltinRegoFuncs))
-	args = append(args, rego.ParsedQuery(query), rego.ParsedBundle("regal", rb))
-	args = append(args, builtins.RegalBuiltinRegoFuncs...)
-
-	// For debugging
-	args = append(args, rego.EnablePrintStatements(true), rego.PrintHook(topdown.NewPrintHook(os.Stderr)))
-	args = append(args, SchemaResolvers()...)
-
-	var txn storage.Transaction
-	if store != nil {
-		txn, _ = store.NewTransaction(ctx, storage.WriteParams)
-		args = append(args, rego.Store(store), rego.Transaction(txn))
-	} else {
-		args = append(args, rego.StoreReadAST(true))
-	}
-
-	return args, txn
-}
-
-func getOrSetCachedQuery(ctx context.Context, query string, store storage.Store) (*cachedQuery, error) {
-	cq, ok := prepared.Get(query)
-	if !ok {
-		parsedQuery := ParseQuery(query)
-
-		pq, err := prepareQuery(ctx, parsedQuery, store)
-		if err != nil {
-			return nil, fmt.Errorf("failed preparing query %q: %w", query, err)
-		}
-
-		cq = &cachedQuery{body: parsedQuery, prepared: pq, store: store}
-
-		prepared.Set(query, cq)
-
-		return cq, nil
-	}
-
-	if isBundleDevelopmentMode() {
-		// In dev mode, we always prepare the query to ensure changes in the bundle are reflected
-		// immediately. We can however reuse the query and the store (if set).
-		pq, err := prepareQuery(ctx, cq.body, cq.store)
-		if err != nil {
-			return nil, fmt.Errorf("failed preparing query %q: %w", query, err)
-		}
-
-		cq.prepared = pq
-	}
-
-	return cq, nil
-}
-
-func prepareQuery(ctx context.Context, query ast.Body, store storage.Store) (*rego.PreparedEvalQuery, error) {
-	args, txn := prepareQueryArgs(ctx, query, store, rbundle.LoadedBundle())
-
-	// Note that we currently don't provide metrics or profiling here, and
-	// most likely we should — need to consider how to best make that conditional
-	// and how to present it if enabled.
-	pq, err := rego.New(args...).PrepareForEval(ctx)
-	if err != nil {
-		if store != nil {
-			store.Abort(ctx, txn)
-		}
-
-		if isBundleDevelopmentMode() {
-			// Try falling back to the embedded bundle, or else we'll
-			// easily have errors popping up as notifications, making it
-			// really hard to fix the issue that broke the query (like a parse error)
-			args, txn = prepareQueryArgs(ctx, query, store, rbundle.EmbeddedBundle())
-			if pq, err = rego.New(args...).PrepareForEval(ctx); err == nil {
-				if store != nil && txn != nil {
-					if err = store.Commit(ctx, txn); err != nil {
-						return nil, err
-					}
-				}
-
-				return &pq, nil
-			}
-
-			if store != nil {
-				store.Abort(ctx, txn)
-			}
-		}
-
-		return nil, err
-	}
-
-	if store != nil && txn != nil {
-		if err = store.Commit(ctx, txn); err != nil {
-			return nil, err
-		}
-	}
-
-	return &pq, nil
-}
-
-func isBundleDevelopmentMode() bool {
-	return os.Getenv("REGAL_BUNDLE_PATH") != ""
-}
-
-var schemaResolvers = sync.OnceValue(func() (resolvers []func(*rego.Rego)) {
-	ss := compile.RegalSchemaSet()
-	added := util.NewSet[string]()
-
-	// Find all schema references in the bundle and add the schemas to the base cache.
-	for _, module := range rbundle.LoadedBundle().Modules {
-		for _, annos := range module.Parsed.Annotations {
-			for _, s := range annos.Schemas {
-				if len(s.Schema) == 0 || added.Contains(s.Schema.String()) {
-					continue
-				}
-				resolvers = append(resolvers, rego.Resolver(
-					ast.DefaultRootRef.Extend(s.Schema),
-					schemaResolver{value: ast.MustInterfaceToValue(ss.Get(s.Schema))},
-				))
-				added.Add(s.Schema.String())
-			}
-		}
-	}
-
-	return resolvers
-})
-
-// Eval implements the resolver.Resolver interface to resolve schemas from annotations at runtime.
-func (sr schemaResolver) Eval(_ context.Context, _ resolver.Input) (resolver.Result, error) {
-	return resolver.Result{Value: sr.value}, nil
 }

--- a/internal/lsp/server_load_workspace_test.go
+++ b/internal/lsp/server_load_workspace_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/regal/internal/lsp/clients"
+	"github.com/open-policy-agent/regal/internal/lsp/log"
 	"github.com/open-policy-agent/regal/internal/testutil"
 	"github.com/open-policy-agent/regal/pkg/config"
 )
@@ -132,7 +133,9 @@ func TestLoadWorkspaceContents(t *testing.T) {
 				}
 			}
 
-			server := NewLanguageServer(t.Context(), &LanguageServerOptions{})
+			opts := &LanguageServerOptions{Logger: log.NewLogger(log.LevelDebug, t.Output())}
+
+			server := NewLanguageServer(t.Context(), opts)
 			server.workspaceRootURI = "file://" + tempDir
 			server.client.Identifier = clients.IdentifierGeneric
 			server.loadedConfig = &config.Config{}

--- a/pkg/config/bundle.go
+++ b/pkg/config/bundle.go
@@ -11,10 +11,10 @@ import (
 	"github.com/open-policy-agent/regal/pkg/roast/encoding"
 )
 
-// LoadConfigWithDefaultsFromBundle returns a complete configuration based on the default
+// WithDefaultsFromBundle returns a complete configuration based on the default
 // (embedded) configuration and (optionally) a user-provided configuration. Panics if the
 // embedded configuration can't be read, as that is a hard dependency.
-func LoadConfigWithDefaultsFromBundle(regalBundle *bundle.Bundle, userConfig *Config) (Config, error) {
+func WithDefaultsFromBundle(regalBundle *bundle.Bundle, userConfig *Config) (Config, error) {
 	bundled := util.Must(util.SearchMap(regalBundle.Data, "regal", "config", "provided"))
 
 	bundledConf, ok := bundled.(map[string]any)

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -570,7 +570,7 @@ func (l Linter) GetConfig() (*config.Config, error) {
 		return l.combinedCfg, nil
 	}
 
-	mergedConf, err := config.LoadConfigWithDefaultsFromBundle(rbundle.LoadedBundle(), l.userConfig)
+	mergedConf, err := config.WithDefaultsFromBundle(rbundle.LoadedBundle(), l.userConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read provided config: %w", err)
 	}

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -718,7 +718,7 @@ func BenchmarkRegalNoEnabledRulesPrepareOnce(b *testing.B) {
 // meaning you do NOT want to do this more than occasionally. You may however find it helpful to use this with
 // a single, or handful of rules to get a better idea of how long they take to run, and relative to each other.
 func BenchmarkEachRule(b *testing.B) {
-	conf := testutil.Must(config.LoadConfigWithDefaultsFromBundle(bundle.LoadedBundle(), nil))(b)
+	conf := testutil.Must(config.WithDefaultsFromBundle(bundle.LoadedBundle(), nil))(b)
 
 	linter := NewLinter().
 		WithInputPaths([]string{"../../bundle"}).


### PR DESCRIPTION
Pretty sure the documentLink issue Charlie found was only the tip of the iceberg, as we did a lot of initialization logic seemingly only when a custom user config was found..

Good to have that fixed!

Also, update references to docs.styra.com to now point at their new OPA docs home.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->