### PR TITLE
build: Remove tap key

### DIFF
--- a/.github/workflows/push-tags.yaml
+++ b/.github/workflows/push-tags.yaml
@@ -34,15 +34,7 @@ jobs:
         with:
           install-only: true
 
-      - name: Generate GitHub App Token
-        id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-        with:
-          app_id: ${{ secrets.PLATFORM_AUTOMATION_GH_APP_ID }}
-          private_key: ${{ secrets.PLATFORM_AUTOMATION_GH_APP_PEM_KEY }}
-
       - name: Run GoReleaser
         run: goreleaser release
         env:
-          TAP_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We are no longer using the tap functionality in GoReleaser
