### PR TITLE
build: reduce update-caps top-level workflow permission to read

### DIFF
--- a/.github/workflows/update-caps.yml
+++ b/.github/workflows/update-caps.yml
@@ -6,13 +6,15 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   fetch:
     name: Fetch EOPA caps
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       RQ_VERSION: v0.0.9
     steps:


### PR DESCRIPTION
The goal of this change is to improve the OpenSSF Scorecard score (this repo self-publishes to https://scorecard.dev/viewer/?uri=github.com/open-policy-agent/regal).

There's a pretty harsh penalty for any top-level workflow permission set to `write` (see [Token Permissions](https://github.com/ossf/scorecard/blob/ab2f6e92482462fe66246d9e32f642855a691dc1/docs/checks.md#token-permissions)), so this would be a good improvement to the score.