### PR TITLE
docs: Update style guide links to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ development, whether you're an experienced Rego developer or just starting out.
 
 - Deliver an outstanding policy development experience by providing the best possible tools for that purpose
 - Identify common mistakes, bugs and inefficiencies in Rego policies, and suggest better approaches
-- Provide advice on [best practices](https://github.com/StyraInc/rego-style-guide), coding style, and tooling
+- Provide advice on [best practices](https://openpolicyagent.org/docs/style-guide), coding style, and tooling
 - Allow users, teams and organizations to enforce custom rules on their policy code
 
 

--- a/docs/readme-sections/goals.md
+++ b/docs/readme-sections/goals.md
@@ -4,5 +4,5 @@
 
 - Deliver an outstanding policy development experience by providing the best possible tools for that purpose
 - Identify common mistakes, bugs and inefficiencies in Rego policies, and suggest better approaches
-- Provide advice on [best practices](https://github.com/StyraInc/rego-style-guide), coding style, and tooling
+- Provide advice on [best practices](https://openpolicyagent.org/docs/style-guide), coding style, and tooling
 - Allow users, teams and organizations to enforce custom rules on their policy code

--- a/docs/rego-style-guide.md
+++ b/docs/rego-style-guide.md
@@ -1,7 +1,7 @@
 # Rego Style Guide rules in Regal
 
 Some notes, and a checklist for tracking, on implementing linter rules based on the
-[Rego Style Guide](https://github.com/StyraInc/rego-style-guide).
+[Rego Style Guide](https://openpolicyagent.org/docs/style-guide).
 
 Rules with a strikethrough are considered to be either impossible, or undesirable,
 for Regal to check, and should be targeted by other means.

--- a/docs/rules/bugs/internal-entrypoint.md
+++ b/docs/rules/bugs/internal-entrypoint.md
@@ -30,7 +30,7 @@ _authorized if {
 
 ## Rationale
 
-Rules marked as internal using the [underscore prefix convention](https://github.com/StyraInc/rego-style-guide#optionally-use-leading-underscore-for-rules-intended-for-internal-use)
+Rules marked as internal using the [underscore prefix convention](https://openpolicyagent.org/docs/style-guide#optionally-use-leading-underscore-for-rules-intended-for-internal-use)
 cannot be used as entrypoints, as entrypoints by definition are public. Either rename the rule to mark it as public,
 or use another public rule as an entrypoint, which may reference the internal rule.
 
@@ -48,6 +48,6 @@ rules:
 
 ## Related Resources
 
-- Rego Style Guide: [Optionally, use leading underscore for rules intended for internal use](https://github.com/StyraInc/rego-style-guide#optionally-use-leading-underscore-for-rules-intended-for-internal-use)
+- Rego Style Guide: [Optionally, use leading underscore for rules intended for internal use](https://openpolicyagent.org/docs/style-guide#optionally-use-leading-underscore-for-rules-intended-for-internal-use)
 - Regal Docs: [no-defined-entrypoint](https://openpolicyagent.org/projects/regal/rules/idiomatic/no-defined-entrypoint)
 - GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/bugs/internal-entrypoint/internal_entrypoint.rego)

--- a/docs/rules/bugs/leaked-internal-reference.md
+++ b/docs/rules/bugs/leaked-internal-reference.md
@@ -68,5 +68,5 @@ rules:
 
 ## Related Resources
 
-- Rego Style Guide: [Optionally, use leading underscore for rules intended for internal use](https://github.com/StyraInc/rego-style-guide#optionally-use-leading-underscore-for-rules-intended-for-internal-use)
+- Rego Style Guide: [Optionally, use leading underscore for rules intended for internal use](https://openpolicyagent.org/docs/style-guide#optionally-use-leading-underscore-for-rules-intended-for-internal-use)
 - GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference.rego)

--- a/docs/rules/custom/missing-metadata.md
+++ b/docs/rules/custom/missing-metadata.md
@@ -73,5 +73,5 @@ rules:
 
 - OPA Docs: [Metadata](https://www.openpolicyagent.org/docs/policy-language/#metadata)
 - OPA Docs: [Annotations](https://www.openpolicyagent.org/docs/policy-language/#annotations)
-- Rego Style Guide: [Use Metadata Annotations](https://github.com/StyraInc/rego-style-guide)
+- Rego Style Guide: [Use Metadata Annotations](https://openpolicyagent.org/docs/style-guide)
 - GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/custom/missing-metadata/missing_metadata.rego)

--- a/docs/rules/idiomatic/directory-package-mismatch.md
+++ b/docs/rules/idiomatic/directory-package-mismatch.md
@@ -131,7 +131,7 @@ rules:
 
 ## Related Resources
 
-- Rego Style Guide: [Package name should match file location](https://github.com/StyraInc/rego-style-guide#package-name-should-match-file-location)
+- Rego Style Guide: [Package name should match file location](https://openpolicyagent.org/docs/style-guide#package-name-should-match-file-location)
 - Regal Docs: [test-outside-test-package](https://openpolicyagent.org/projects/regal/rules/testing/test-outside-test-package)
 - OPA Docs: [Bundles](https://www.openpolicyagent.org/docs/management-bundles/)
 - GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch.rego)

--- a/docs/rules/idiomatic/non-raw-regex-pattern.md
+++ b/docs/rules/idiomatic/non-raw-regex-pattern.md
@@ -56,6 +56,6 @@ rules:
 
 ## Related Resources
 
-- Rego Style Guide: [Use raw strings for regex patterns](https://github.com/StyraInc/rego-style-guide#use-raw-strings-for-regex-patterns)
+- Rego Style Guide: [Use raw strings for regex patterns](https://openpolicyagent.org/docs/style-guide#use-raw-strings-for-regex-patterns)
 - OPA Docs: [Regex Functions Reference](https://www.openpolicyagent.org/docs/policy-reference/#regex)
 - GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/idiomatic/non-raw-regex-pattern/non_raw_regex_pattern.rego)

--- a/docs/rules/idiomatic/use-in-operator.md
+++ b/docs/rules/idiomatic/use-in-operator.md
@@ -42,5 +42,5 @@ rules:
 
 ## Related Resources
 
-- Rego Style Guide: [Use `in` to check for membership](https://github.com/StyraInc/rego-style-guide#use-in-to-check-for-membership)
+- Rego Style Guide: [Use `in` to check for membership](https://openpolicyagent.org/docs/style-guide#use-in-to-check-for-membership)
 - GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/idiomatic/use-in-operator/use_in_operator.rego)

--- a/docs/rules/idiomatic/use-some-for-output-vars.md
+++ b/docs/rules/idiomatic/use-some-for-output-vars.md
@@ -105,7 +105,7 @@ rules:
 
 ## Related Resources
 
-- Rego Style Guide: [Don't use undeclared variables](https://github.com/StyraInc/rego-style-guide#dont-use-undeclared-variables)
+- Rego Style Guide: [Don't use undeclared variables](https://openpolicyagent.org/docs/style-guide#dont-use-undeclared-variables)
 - OPA Docs: [The `some` keyword](https://www.openpolicyagent.org/docs/policy-language/#some-keyword)
 - Wikipedia: [Unification](https://en.wikipedia.org/wiki/Unification_(computer_science))
 - GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/idiomatic/use-some-for-output-vars/use_some_for_output_vars.rego)

--- a/docs/rules/imports/avoid-importing-input.md
+++ b/docs/rules/imports/avoid-importing-input.md
@@ -72,6 +72,6 @@ rules:
 
 ## Related Resources
 
-- Rego Style Guide: [Avoid importing `input`](https://github.com/StyraInc/rego-style-guide#avoid-importing-input)
+- Rego Style Guide: [Avoid importing `input`](https://openpolicyagent.org/docs/style-guide#avoid-importing-input)
 - OPA Docs: [Terraform Tutorial](https://www.openpolicyagent.org/docs/terraform)
 - GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/imports/avoid-importing-input/avoid_importing_input.rego)

--- a/docs/rules/imports/implicit-future-keywords.md
+++ b/docs/rules/imports/implicit-future-keywords.md
@@ -59,5 +59,5 @@ rules:
 
 ## Related Resources
 
-- Rego Style Guide: [Use explicit imports for future keywords](https://github.com/StyraInc/rego-style-guide#use-explicit-imports-for-future-keywords)
+- Rego Style Guide: [Use explicit imports for future keywords](https://openpolicyagent.org/docs/style-guide#use-explicit-imports-for-future-keywords)
 - GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/imports/implicit-future-keywords/implicit_future_keywords.rego)

--- a/docs/rules/imports/prefer-package-imports.md
+++ b/docs/rules/imports/prefer-package-imports.md
@@ -61,5 +61,5 @@ rules:
 
 ## Related Resources
 
-- Rego Style Guide: [Prefer importing packages over rules and functions](https://github.com/StyraInc/rego-style-guide#prefer-importing-packages-over-rules-and-functions)
+- Rego Style Guide: [Prefer importing packages over rules and functions](https://openpolicyagent.org/docs/style-guide#prefer-importing-packages-over-rules-and-functions)
 - GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports.rego)

--- a/docs/rules/style/avoid-get-and-list-prefix.md
+++ b/docs/rules/style/avoid-get-and-list-prefix.md
@@ -57,5 +57,5 @@ rules:
 
 ## Related Resources
 
-- Rego Style Guide: [Avoid prefixing rules and functions with `get_` or `list_`](https://github.com/StyraInc/rego-style-guide#avoid-prefixing-rules-and-functions-with-get_-or-list_)
+- Rego Style Guide: [Avoid prefixing rules and functions with `get_` or `list_`](https://openpolicyagent.org/docs/style-guide#avoid-prefixing-rules-and-functions-with-get_-or-list_)
 - GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/style/avoid-get-and-list-prefix/avoid_get_and_list_prefix.rego)

--- a/docs/rules/style/external-reference.md
+++ b/docs/rules/style/external-reference.md
@@ -89,5 +89,5 @@ rules:
 
 ## Related Resources
 
-- Rego Style Guide: [Prefer using arguments over input, data or rule references](https://github.com/StyraInc/rego-style-guide#prefer-using-arguments-over-input-data-or-rule-references)
+- Rego Style Guide: [Prefer using arguments over input, data or rule references](https://openpolicyagent.org/docs/style-guide#prefer-using-arguments-over-input-data-or-rule-references)
 - GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/style/external-reference/external_reference.rego)

--- a/docs/rules/style/function-arg-return.md
+++ b/docs/rules/style/function-arg-return.md
@@ -66,5 +66,5 @@ rules:
 
 ## Related Resources
 
-- Rego Style Guide: [Avoid using the last argument for the return value](https://github.com/StyraInc/rego-style-guide#avoid-using-the-last-argument-for-the-return-value)
+- Rego Style Guide: [Avoid using the last argument for the return value](https://openpolicyagent.org/docs/style-guide#avoid-using-the-last-argument-for-the-return-value)
 - GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/style/function-arg-return/function_arg_return.rego)

--- a/docs/rules/style/prefer-snake-case.md
+++ b/docs/rules/style/prefer-snake-case.md
@@ -46,5 +46,5 @@ rules:
 
 ## Related Resources
 
-- Rego Style Guide: [Prefer snake_case for rule names and variables](https://github.com/StyraInc/rego-style-guide#prefer-snake_case-for-rule-names-and-variables)
+- Rego Style Guide: [Prefer snake_case for rule names and variables](https://openpolicyagent.org/docs/style-guide#prefer-snake_case-for-rule-names-and-variables)
 - GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/style/prefer-snake-case/prefer_snake_case.rego)

--- a/docs/rules/style/prefer-some-in-iteration.md
+++ b/docs/rules/style/prefer-some-in-iteration.md
@@ -130,7 +130,7 @@ rules:
 
 ## Related Resources
 
-- Rego Style Guide: [Prefer some .. in for iteration](https://github.com/StyraInc/rego-style-guide#prefer-some--in-for-iteration)
+- Rego Style Guide: [Prefer some .. in for iteration](https://openpolicyagent.org/docs/style-guide#prefer-some--in-for-iteration)
 - Regal Docs: [Use `some` to declare output variables](https://openpolicyagent.org/projects/regal/rules/idiomatic/use-some-for-output-vars)
 - OPA Docs: [Membership and Iteration: `in`](https://www.openpolicyagent.org/docs/policy-language/#membership-and-iteration-in)
 - OPA Docs: [Some Keyword](https://www.openpolicyagent.org/docs/policy-language/#some-keyword)

--- a/docs/rules/style/unconditional-assignment.md
+++ b/docs/rules/style/unconditional-assignment.md
@@ -51,5 +51,5 @@ rules:
 
 ## Related Resources
 
-- Rego Style Guide: [Prefer unconditional assignment in rule head over rule body](https://github.com/StyraInc/rego-style-guide#prefer-unconditional-assignment-in-rule-head-over-rule-body)
+- Rego Style Guide: [Prefer unconditional assignment in rule head over rule body](https://openpolicyagent.org/docs/style-guide#prefer-unconditional-assignment-in-rule-head-over-rule-body)
 - GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/style/unconditional-assignment/unconditional_assignment.rego)

--- a/docs/rules/style/use-assignment-operator.md
+++ b/docs/rules/style/use-assignment-operator.md
@@ -81,5 +81,5 @@ rules:
 ## Related Resources
 
 - OPA Docs: [Equality: Assignment, Comparison, and Unification](https://www.openpolicyagent.org/docs/policy-language/#equality-assignment-comparison-and-unification)
-- Rego Style Guide: [Don't use unification operator for assignment or comparison](https://github.com/StyraInc/rego-style-guide#dont-use-unification-operator-for-assignment-or-comparison)
+- Rego Style Guide: [Don't use unification operator for assignment or comparison](https://openpolicyagent.org/docs/style-guide#dont-use-unification-operator-for-assignment-or-comparison)
 - GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator.rego)


### PR DESCRIPTION
Ideally, these will point to locations on the OPA site in the end, but for now I have corrected the repo location.

https://github.com/open-policy-agent/opa/pull/7932

https://github.com/open-policy-agent/rego-style-guide/pull/40