### PR TITLE
lsp: document highlighting supporting function args

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -10,72 +10,119 @@ import (
 	"github.com/open-policy-agent/opa/v1/bundle"
 
 	rio "github.com/open-policy-agent/regal/internal/io"
+	"github.com/open-policy-agent/regal/internal/mode"
 )
 
 // Bundle FS will include the tests as well, but since that has negligible impact on the size of the binary,
 // it's preferable to filter them out from the bundle than to e.g. create a separate directory for tests.
 var (
-	//go:embed *
-	regalBundle    embed.FS
-	lastErrMsg     = atomic.Pointer[string]{}
-	EmbeddedBundle = sync.OnceValue(func() *bundle.Bundle {
+	Embedded = sync.OnceValue(func() *bundle.Bundle {
 		return rio.MustLoadRegalBundleFS(regalBundle)
 	})
+	Dev = &devMode{}
+
+	//go:embed *
+	regalBundle embed.FS
+
+	lastErrMsg     = atomic.Pointer[string]{}
 	successLogOnce = sync.OnceFunc(func() {
 		fmt.Fprintln(os.Stderr, "Successfully loaded development bundle")
 	})
-	Dev = &DevSettings{}
 )
 
-type DevSettings struct {
-	bundlePath string
-	mux        sync.RWMutex
+type devMode struct {
+	bundlePath  string
+	bndl        *bundle.Bundle
+	mux         sync.RWMutex
+	subscribers []chan struct{}
 }
 
-func (ds *DevSettings) SetBundlePath(path string) {
-	ds.mux.Lock()
-	ds.bundlePath = path
-	ds.mux.Unlock()
+// SetPath sets the path of a Regal development bundle, and attempts to load it immediately.
+func (dm *devMode) SetPath(path string) {
+	dm.mux.Lock()
+
+	if path != dm.bundlePath {
+		dm.bundlePath = path
+		dm.mux.Unlock()
+
+		dm.Reload()
+	} else {
+		dm.mux.Unlock()
+	}
 }
 
-func (ds *DevSettings) BundlePath() string {
-	ds.mux.RLock()
-	defer ds.mux.RUnlock()
+// Bundle returns the currently loaded Regal development bundle, or nil
+// when no bundle is loaded.
+func (dm *devMode) Bundle() *bundle.Bundle {
+	dm.mux.RLock()
+	defer dm.mux.RUnlock()
 
-	return ds.bundlePath
+	return dm.bndl
 }
 
-// LoadedBundle contains the Regal bundle.
-func LoadedBundle() *bundle.Bundle {
-	// For development, allow bundle to be loaded dynamically from path instead
-	// of the normal one embedded in the compiled binary. This allows editing e.g.
-	// LSP policies while the language server is running. This should be considered
-	// *very* experimental at this point.
-	if devPath := Dev.BundlePath(); devPath != "" {
-		b, err := rio.LoadRegalBundlePath(devPath)
-		if err == nil {
-			if last := lastErrMsg.Load(); last != nil {
-				lastErrMsg.Store(nil)
+func (dm *devMode) Reload() {
+	dm.mux.Lock()
+	defer dm.mux.Unlock()
 
-				fmt.Fprintln(os.Stderr, "development bundle back to a good state, no longer using embedded bundle")
-			}
+	if dm.bundlePath == "" {
+		dm.bndl = nil
 
-			successLogOnce()
+		return
+	}
 
-			return b
-		}
-
+	if b, err := rio.LoadRegalBundlePath(dm.bundlePath); err != nil {
 		// Avoid flooding the console/logs with the same error message
 		if curr, last := err.Error(), lastErrMsg.Load(); last == nil || *last != curr {
-			fmt.Fprintf(os.Stderr, "error loading development bundle from %s:\n%v\n", devPath, err)
+			fmt.Fprintf(os.Stderr, "error loading development bundle from %s:\n%v\n", dm.bundlePath, err)
 
 			lastErrMsg.Store(&curr)
 		}
 
-		// Now fallback to the embedded bundle if the development path fails, as the bundle may
-		// be requested at any time (and very frequently!) from the various LSP commands, and we
-		// don't want a broken language server while developing!
+		return
+	} else {
+		dm.bndl = b
 	}
 
-	return EmbeddedBundle()
+	if last := lastErrMsg.Load(); last != nil {
+		lastErrMsg.Store(nil)
+
+		fmt.Fprintln(os.Stderr, "development bundle back to a good state, no longer using embedded bundle")
+	}
+
+	for _, c := range dm.subscribers {
+		c <- struct{}{}
+	}
+
+	successLogOnce()
+}
+
+func (dm *devMode) Subscribe(c chan struct{}) {
+	dm.mux.Lock()
+	dm.subscribers = append(dm.subscribers, c)
+	dm.mux.Unlock()
+}
+
+// DevModeEnabled returns true if the Regal binary is compiled without
+// the standalone tags added in release builds, and the REGAL_BUNDLE_PATH
+// environment variable is set. This is an experimental feature intended
+// for Regal LSP development only, and can change at any time without notice.
+// Also note that this mode impacts only the Regal bundle used, and not things
+// like log levels, etc.
+func DevModeEnabled() bool {
+	// NOTE: For now, only the env var can be used to enable dev mode.
+	return !mode.Standalone && os.Getenv("REGAL_BUNDLE_PATH") != ""
+}
+
+// Loaded contains the loaded Regal bundle. For LSP development, allow bundle
+// to be loaded dynamically from path instead of the normal one embedded in
+// the compiled binary. This allows editing handler  policies while the language
+// server is running. This should be considered *very* experimental at this point.
+// In the (unlikely) case that you absolutely need to refer to the embedded bundle,
+// just call [Embedded] directly instead.
+func Loaded() *bundle.Bundle {
+	if bndl := Dev.Bundle(); bndl != nil && DevModeEnabled() {
+		return bndl
+	}
+
+	return Embedded()
 }

--- a/bundle/regal/ast/search.rego
+++ b/bundle/regal/ast/search.rego
@@ -181,11 +181,17 @@ find_vars(node) := array.concat(
 _rules := input.rules
 _rules := data.workspace.parsed[input.regal.file.uri].rules if not input.rules
 
+# even worse hack to support the new LSP router, and to allow those handlers to use code from
+# the AST package. object.get used here to circument schema validation of input..
+# there's no doubt that we need to find a better model for this going forward
+_rules := data.workspace.parsed[object.get(input, ["params", "textDocument", "uri"], null)].rules if not input.rules
+
 # METADATA:
 # description: |
 #   object containing all variables found in the input AST, keyed first by the index of
 #   the rule where the variables were found (as a numeric string), and then the context
 #   of the variable, which will be one of:
+#   - args
 #   - term
 #   - assign
 #   - every

--- a/bundle/regal/lsp/documenthighlight/documenthighlight_test.rego
+++ b/bundle/regal/lsp/documenthighlight/documenthighlight_test.rego
@@ -84,3 +84,62 @@ allow if true`
 		"kind": 1,
 	}}
 }
+
+test_arg_highlight_in_head_and_body[name] if {
+	file_content := `package p
+
+fun(user, action, resource) := user if {
+	user == "alice"
+	action.detail == "detail"
+	resource.type == input.nested[resource.foo]
+}`
+
+	some [name, inp, exp] in [
+		["user", {"line": 2, "character": 6}, {
+			{
+				"kind": 2,
+				"range": {"end": {"character": 8, "line": 2}, "start": {"character": 4, "line": 2}},
+			},
+			{
+				"kind": 3,
+				"range": {"end": {"character": 5, "line": 3}, "start": {"character": 1, "line": 3}},
+			},
+			{
+				"kind": 3,
+				"range": {"end": {"character": 35, "line": 2}, "start": {"character": 31, "line": 2}},
+			},
+		}],
+		["action", {"line": 2, "character": 12}, {
+			{
+				"kind": 2,
+				"range": {"end": {"character": 16, "line": 2}, "start": {"character": 10, "line": 2}},
+			},
+			{
+				"kind": 3,
+				"range": {"end": {"character": 7, "line": 4}, "start": {"character": 1, "line": 4}},
+			},
+		}],
+		["resource", {"line": 2, "character": 19}, {
+			{
+				"kind": 2,
+				"range": {"end": {"character": 26, "line": 2}, "start": {"character": 18, "line": 2}},
+			},
+			{
+				"kind": 3,
+				"range": {"end": {"character": 9, "line": 5}, "start": {"character": 1, "line": 5}},
+			},
+			{
+				"kind": 3,
+				"range": {"end": {"character": 39, "line": 5}, "start": {"character": 31, "line": 5}},
+			},
+		}],
+	]
+
+	items := documenthighlight.items with input as {
+		"params": {"textDocument": {"uri": "file://p.rego"}, "position": inp},
+		"regal": {"file": {"lines": split(file_content, "\n")}},
+	}
+		with data.workspace.parsed["file://p.rego"] as regal.parse_module("p.rego", file_content)
+
+	items == exp
+}

--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -163,7 +163,7 @@ func fix(args []string, params *fixParams) (err error) {
 	userConfigFile, err := readUserConfig(params.lintAndFixParams, configSearchPath)
 	switch {
 	case err == nil:
-		defer rio.CloseFileIgnore(userConfigFile)
+		defer rio.CloseIgnore(userConfigFile)
 
 		if params.debug {
 			log.Printf("found user config file: %s", userConfigFile.Name())

--- a/cmd/languageserver.go
+++ b/cmd/languageserver.go
@@ -59,6 +59,7 @@ func init() {
 			go ls.StartConfigWorker(ctx)
 			go ls.StartWorkspaceStateWorker(ctx)
 			go ls.StartTemplateWorker(ctx)
+			go ls.StartQueryCacheWorker(ctx)
 			go ls.StartWebServer(ctx)
 
 			sigChan := make(chan os.Signal, 1)

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -248,7 +248,7 @@ func lint(args []string, params *lintParams) (result report.Report, err error) {
 
 	regal = regal.WithUserConfig(userConfig)
 
-	go updateCheckAndWarn(params, rbundle.LoadedBundle(), &userConfig)
+	go updateCheckAndWarn(params, rbundle.Loaded(), &userConfig)
 
 	regal, err = regal.Prepare(ctx)
 	if err != nil {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -154,7 +154,7 @@ func opaTest(args []string) int {
 		return 1
 	}
 
-	regalBundle := rbundle.LoadedBundle()
+	regalBundle := rbundle.Loaded()
 
 	if err := store.Write(
 		ctx,

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -75,7 +75,7 @@ func readUserConfig(params lintAndFixParams, searchPath string) (userConfig *os.
 		log.Println("no user-provided config file found, will use the default config")
 	}
 
-	userConfig, err = config.FindConfig(searchPath)
+	userConfig, err = config.Find(searchPath)
 	if err != nil {
 		// if no config was found, attempt to load the user's global config if it exists
 		if globalConfigDir := config.GlobalConfigDir(false); globalConfigDir != "" {
@@ -100,7 +100,7 @@ func loadUserConfig(params lintAndFixParams, root string) (cfg config.Config, pa
 		return config.Config{}, "", nil // No user config provided, use default
 	}
 
-	defer rio.CloseFileIgnore(file)
+	defer rio.CloseIgnore(file)
 
 	cfg, err = config.FromFile(file)
 	if err != nil {
@@ -118,10 +118,9 @@ func loadUserConfig(params lintAndFixParams, root string) (cfg config.Config, pa
 }
 
 func getLinterContext(params lintAndFixParams) (context.Context, func()) {
-	ctx := context.Background()
 	if to := params.timeout; to != 0 {
-		return context.WithTimeout(ctx, to)
+		return context.WithTimeout(context.Background(), to)
 	}
 
-	return ctx, func() {}
+	return context.Background(), func() {}
 }

--- a/internal/capabilities/capabilities.go
+++ b/internal/capabilities/capabilities.go
@@ -19,6 +19,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/ast"
 
 	"github.com/open-policy-agent/regal/internal/capabilities/embedded"
+	"github.com/open-policy-agent/regal/internal/io"
 	"github.com/open-policy-agent/regal/internal/util"
 )
 
@@ -189,7 +190,7 @@ func lookupFileURL(parsedURL *url.URL) (*ast.Capabilities, error) {
 		path = path[1:]
 	}
 
-	return util.WithOpen(path, func(fd *os.File) (*ast.Capabilities, error) {
+	return io.WithOpen(path, func(fd *os.File) (*ast.Capabilities, error) {
 		return util.Wrap(ast.LoadCapabilitiesJSON(fd))("failed to load capabilities")
 	})
 }

--- a/internal/compile/compile_test.go
+++ b/internal/compile/compile_test.go
@@ -19,7 +19,7 @@ func TestSchemaSet(t *testing.T) {
 // 16	  66555594 ns/op	50239492 B/op	 1083664 allocs/op - main
 // 18	  62569440 ns/op	38723015 B/op	  944277 allocs/op - compiler-optimizations pr
 func BenchmarkCompileBundle(b *testing.B) {
-	bndl := bundle.LoadedBundle()
+	bndl := bundle.Loaded()
 	compiler := NewCompilerWithRegalBuiltins()
 
 	for b.Loop() {

--- a/internal/lsp/bundles/cache.go
+++ b/internal/lsp/bundles/cache.go
@@ -149,7 +149,7 @@ func (c *cacheBundle) Refresh(path string) (bool, error) {
 }
 
 func hasher(path string, curr map[string][]byte) (map[string][]byte, error) {
-	return rutil.WithOpen(path, func(file *os.File) (map[string][]byte, error) {
+	return rio.WithOpen(path, func(file *os.File) (map[string][]byte, error) {
 		hash := md5.New() //nolint:gosec
 		if _, err := io.Copy(hash, file); err != nil {
 			return nil, fmt.Errorf("failed to calculate MD5 hash for file %q: %w", path, err)

--- a/internal/lsp/eval.go
+++ b/internal/lsp/eval.go
@@ -169,7 +169,7 @@ func (l *LanguageServer) assembleEvalBundles() map[string]bundle.Bundle {
 	if hasCustomRules {
 		// If someone evaluates a custom Regal rule, provide them the Regal bundle
 		// in order to make all Regal functions available
-		allBundles["regal"] = *rbundle.LoadedBundle()
+		allBundles["regal"] = *rbundle.Loaded()
 	}
 
 	return allBundles

--- a/internal/lsp/rego/rego.go
+++ b/internal/lsp/rego/rego.go
@@ -127,8 +127,7 @@ func (c Input[T]) String() string { // For debugging only
 }
 
 func PositionFromLocation(loc *ast.Location) types.Position {
-	//nolint:gosec
-	return types.Position{Line: uint(loc.Row - 1), Character: uint(loc.Col - 1)}
+	return types.Position{Line: util.SafeIntToUint(loc.Row - 1), Character: util.SafeIntToUint(loc.Col - 1)}
 }
 
 func LocationFromPosition(pos types.Position) *ast.Location {
@@ -232,12 +231,13 @@ func policyToValue[T any](ctx context.Context, pq *query.Prepared, policy policy
 }
 
 func toValidResult(rs rego.ResultSet, err error) (rego.Result, error) {
+	rsLen := len(rs)
 	switch {
 	case err != nil:
 		return emptyResult, fmt.Errorf("evaluation failed: %w", err)
-	case len(rs) == 0:
+	case rsLen == 0:
 		return emptyResult, errNoResults
-	case len(rs) != 1:
+	case rsLen != 1:
 		return emptyResult, errExcpectedOneResult
 	case len(rs[0].Expressions) != 1:
 		return emptyResult, errExcpectedOneExpr

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 )
 
-// NullToEmpty returns empty slice if provided slice is nil.
-func NullToEmpty[T any](a []T) []T {
+// NilSliceToEmpty returns empty slice if provided slice is nil.
+func NilSliceToEmpty[T any](a []T) []T {
 	if a == nil {
 		return []T{}
 	}
@@ -281,15 +281,11 @@ func WrapErr(err error, msg string) error {
 	return fmt.Errorf("%s: %w", msg, err)
 }
 
-// WithOpen opens a file at the provided path, and passes the opened file to f.
-func WithOpen[T any](path string, f func(*os.File) (T, error)) (T, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return Zero[T](), fmt.Errorf("failed to open file '%s': %w", path, err)
+// SendToAll sends the provided value to all provided channels.
+func SendToAll[T any](val T, ch ...chan T) {
+	for _, c := range ch {
+		c <- val
 	}
-	defer file.Close()
-
-	return f(file)
 }
 
 // Pointer returns a pointer to the provided value.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -123,7 +123,7 @@ func (d *Default) mapToConfig(result any) error {
 }
 
 func FromPath(path string) (Config, error) {
-	return util.Wrap(util.WithOpen(path, FromFile))("failed to open config file")
+	return util.Wrap(rio.WithOpen(path, FromFile))("failed to open config file")
 }
 
 func FromFile(file *os.File) (Config, error) {
@@ -133,9 +133,9 @@ func FromFile(file *os.File) (Config, error) {
 	return conf, err
 }
 
-// FindConfig attempts to find either the .regal directory or .regal.yaml
+// Find attempts to find either the .regal directory or .regal.yaml
 // config file, and returns the appropriate file or an error.
-func FindConfig(path string) (*os.File, error) {
+func Find(path string) (*os.File, error) {
 	regalDir, regalDirError := FindRegalDirectory(path)
 	regalConfigFile, regalConfigFileError := FindRegalConfigFile(path)
 
@@ -284,7 +284,7 @@ func FindBundleRootDirectories(path string) ([]string, error) {
 			// Opening files as part of walking is generally not a good idea...
 			// but I think we can assume the number of .regal directories in a project
 			// is limited to a reasonable number.
-			roots, err := util.WithOpen(path, rootsFromRegalConfigDirOrFile)
+			roots, err := rio.WithOpen(path, rootsFromRegalConfigDirOrFile)
 			if err != nil {
 				return fmt.Errorf("failed to get roots from .regal directory: %w", err)
 			}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -105,7 +105,7 @@ func TestFindConfig(t *testing.T) {
 			t.Parallel()
 
 			test.WithTempFS(testData.FS, func(root string) {
-				configFile, err := FindConfig(filepath.Join(root, "foo", "bar", "baz"))
+				configFile, err := Find(filepath.Join(root, "foo", "bar", "baz"))
 				if testData.Error != "" {
 					testutil.ErrMustContain(err, testData.Error)(t)
 				} else if err != nil {

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -94,7 +94,7 @@ func init() {
 // NewLinter creates a new Regal linter.
 func NewLinter() Linter {
 	return Linter{
-		ruleBundles: []*bundle.Bundle{rbundle.LoadedBundle()},
+		ruleBundles: []*bundle.Bundle{rbundle.Loaded()},
 	}
 }
 
@@ -526,7 +526,7 @@ func (l Linter) GetConfig() (*config.Config, error) {
 		return l.combinedCfg, nil
 	}
 
-	mergedConf, err := config.WithDefaultsFromBundle(rbundle.LoadedBundle(), l.userConfig)
+	mergedConf, err := config.WithDefaultsFromBundle(rbundle.Loaded(), l.userConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read provided config: %w", err)
 	}
@@ -659,12 +659,12 @@ func getEnabledRules(rs rego.ResultSet) ([]string, error) {
 func (l Linter) createDataBundle(conf config.Config) *bundle.Bundle {
 	params := map[string]any{
 		"disable_all":      l.disableAll,
-		"disable_category": util.NullToEmpty(l.disableCategory),
-		"disable":          util.NullToEmpty(l.disable),
+		"disable_category": util.NilSliceToEmpty(l.disableCategory),
+		"disable":          util.NilSliceToEmpty(l.disable),
 		"enable_all":       l.enableAll,
-		"enable_category":  util.NullToEmpty(l.enableCategory),
-		"enable":           util.NullToEmpty(l.enable),
-		"ignore_files":     util.NullToEmpty(l.ignoreFiles),
+		"enable_category":  util.NilSliceToEmpty(l.enableCategory),
+		"enable":           util.NilSliceToEmpty(l.enable),
+		"ignore_files":     util.NilSliceToEmpty(l.ignoreFiles),
 	}
 
 	return &bundle.Bundle{

--- a/pkg/linter/linter_bench_test.go
+++ b/pkg/linter/linter_bench_test.go
@@ -105,7 +105,7 @@ func BenchmarkRegalNoEnabledRulesPrepareOnce(b *testing.B) {
 // meaning you do NOT want to do this more than occasionally. You may however find it helpful to use this with
 // a single, or handful of rules to get a better idea of how long they take to run, and relative to each other.
 func BenchmarkEachRule(b *testing.B) {
-	conf := testutil.Must(config.WithDefaultsFromBundle(bundle.LoadedBundle(), nil))(b)
+	conf := testutil.Must(config.WithDefaultsFromBundle(bundle.Loaded(), nil))(b)
 
 	linter := NewLinter().
 		WithInputPaths([]string{"../../bundle"}).

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -301,7 +301,7 @@ func (tr CompactReporter) Publish(_ context.Context, r report.Report) error {
 
 // Publish prints a JSON report to the configured output.
 func (tr JSONReporter) Publish(_ context.Context, r report.Report) error {
-	r.Violations = util.NullToEmpty(r.Violations)
+	r.Violations = util.NilSliceToEmpty(r.Violations)
 
 	enc := encoding.JSON().NewEncoder(tr.out)
 	enc.SetIndent("", "  ")
@@ -317,7 +317,7 @@ func (tr GitHubReporter) Publish(ctx context.Context, r report.Report) error {
 		return err
 	}
 
-	r.Violations = util.NullToEmpty(r.Violations)
+	r.Violations = util.NilSliceToEmpty(r.Violations)
 
 	for _, violation := range r.Violations { //nolint:gocritic
 		if _, err := fmt.Fprintf(tr.out,


### PR DESCRIPTION
A function arg variable at requested position will now have the document highlight handler return all references of that arg from the function head/body for highlighting, making it easy to quickly identify the locations where the arg is used.

Less interesting to users is the *much* improved `REGAL_BUNDLE_PATH` development mode added with this PR. This is the result of a substantial side quest when working on the highlighting feature, and finding the current implementation to perform too poorly. Which was no surprise given how previously we'd re-prepare the query on every call to `LoadedBundle`, which sometimes happens several times per second!  The new implementation instead makes use of a watcher process, and re-prepares the relevant LSP query only when a file in the bundle is changed and that change is saved.

Also properly documented the dev mode feature as it now makes LSP development so much more enjoyable.

Finally, renamed a few methods to avoid duplicating names from the package (like `config.FindConfig` -> `config.Find`)