### PR TITLE
Fix false positive in narrow-argument

### DIFF
--- a/bundle/regal/lsp/completion/providers/locals/locals.rego
+++ b/bundle/regal/lsp/completion/providers/locals/locals.rego
@@ -12,7 +12,9 @@ items contains item if {
 	line != ""
 
 	location.in_rule_body(line)
-	not _excluded(line, input.params.position)
+
+	# no suggestions in function args definition, as those would recursively contribute to themselves
+	not _function_args_position(substring(line, 0, input.params.position.character))
 
 	word := location.word_at(line, input.params.position.character + 1)
 
@@ -24,7 +26,6 @@ items contains item if {
 	})
 
 	startswith(local, word.text)
-
 	not local in _same_line_loop_vars(line)
 
 	item := {
@@ -37,11 +38,6 @@ items contains item if {
 		},
 	}
 }
-
-# exclude local suggestions in function args definition,
-# as those would recursively contribute to themselves
-# regal ignore:narrow-argument
-_excluded(line, position) if _function_args_position(substring(line, 0, position.character))
 
 _function_args_position(text) if {
 	contains(text, "(")

--- a/bundle/regal/result/result.rego
+++ b/bundle/regal/result/result.rego
@@ -212,8 +212,6 @@ ranged_from_ref(ref) := ranged_location_between(ref[0], regal.last(ref))
 # description: |
 #   creates a ranged location where the start location is the left hand side of an infix
 #   expression, like `"foo" == "bar"`, and the end location is the end of the infix operator
-# # narrow-argument false positive: https://github.com/open-policy-agent/regal/issues/1701
-# # regal ignore:narrow-argument
 infix_expr_location(terms) := location(sprintf("%s:%s:%s:%s", array.concat(
 	array.slice(split(terms[1].location, ":"), 0, 2),
 	array.slice(split(terms[0].location, ":"), 2, 4),

--- a/bundle/regal/rules/custom/narrow-argument/narrow_argument_test.rego
+++ b/bundle/regal/rules/custom/narrow-argument/narrow_argument_test.rego
@@ -89,6 +89,14 @@ test_fail_can_be_narrowed_prefixed_array_ref if {
 	}}
 }
 
+test_success_can_not_be_narrowed_prefixed_array_ref_arg_is_least_common_denominator if {
+	r := rule.report with input as ast.policy(`
+		fun(terms) := [terms[1].location, terms[0].location]
+	`)
+
+	r == set()
+}
+
 test_success_can_not_be_narrowed_arg_is_least_common_denominator if {
 	r := rule.report with input as ast.policy(`
 		fun(obj) if obj.typ == "string"

--- a/bundle/regal/util/util.rego
+++ b/bundle/regal/util/util.rego
@@ -188,14 +188,20 @@ longest_prefix(coll) := [] if {
 	arr := to_array(coll)
 	end := min([count(seq) | some seq in arr]) - 1
 	rng := numbers.range(0, end)
-	eqn := max([n |
+
+	# collect indices where items differ
+	# we only care about the first diff, but no way to exit early with that value
+	dif := [n |
 		some n in rng
 
 		first := arr[0][n]
-		every sub in arr {
-			sub[n] == first
-		}
-	])
 
-	prefix := array.slice(arr[0], 0, eqn + 1)
+		some sub in arr
+		sub[n] != first
+	]
+
+	prefix := array.slice(arr[0], 0, _longest_dif(dif, end))
 }
+
+_longest_dif(diff, len) := len + 1 if count(diff) == 0
+_longest_dif(diff, _) := diff[0] if count(diff) > 0

--- a/bundle/regal/util/util_test.rego
+++ b/bundle/regal/util/util_test.rego
@@ -79,6 +79,10 @@ test_longest_prefix[test.coll] if {
 			"coll": [["a", "b", "c"], ["a", "b", "c", 1], ["a", "b", "c", "d"]],
 			"want": ["a", "b", "c"],
 		},
+		{
+			"coll": [["a", 1, "b"], ["a", 2, "b"]],
+			"want": ["a"],
+		},
 	]
 
 	some test in tests


### PR DESCRIPTION
This rule did not properly handle function arg refs of arrays, and would incorrectly report that `f(x) if x[0] + x[1]` could be narrowed to `x[1]`.

Fixes #1701

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->