### PR TITLE
Rule: prefer-equals-comparison

### DIFF
--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -91,6 +91,8 @@ rules:
       level: error
     non-raw-regex-pattern:
       level: error
+    prefer-equals-comparison:
+      level: error
     prefer-set-or-object-rule:
       level: error
     single-item-in:
@@ -135,9 +137,9 @@ rules:
     unresolved-import:
       level: error
     unresolved-reference:
-      level: error
       excepted_export_patterns:
         - "**.test_*"
+      level: error
     use-rego-v1:
       level: error
   performance:

--- a/bundle/regal/lsp/documentlink/documentlink_test.rego
+++ b/bundle/regal/lsp/documentlink/documentlink_test.rego
@@ -15,7 +15,7 @@ test_documentlink_ranges_in_inline_ignores if {
 			"imports": {"unresolved-reference": {}},
 		}
 
-	items = {
+	items == {
 		{
 			"range": {
 				"end": {

--- a/bundle/regal/rules/idiomatic/prefer-equals-comparison/prefer_equals_comparison.rego
+++ b/bundle/regal/rules/idiomatic/prefer-equals-comparison/prefer_equals_comparison.rego
@@ -1,0 +1,30 @@
+# METADATA
+# description: Prefer `==` for equality comparison
+package regal.rules.idiomatic["prefer-equals-comparison"]
+
+import data.regal.ast
+import data.regal.result
+
+report contains violation if {
+	some rule_index, expr
+	ast.found.expressions[rule_index][expr].terms[0].value[0].value == "eq"
+	expr.terms[0].value[0].type == "var"
+	expr.terms[0].type == "ref"
+
+	_unassignable(expr.terms[1], rule_index)
+	_unassignable(expr.terms[2], rule_index)
+
+	violation := result.fail(rego.metadata.chain(), result.location(expr))
+}
+
+_unassignable(term, _) if ast.is_constant(term)
+
+_unassignable(term, _) if {
+	term.type == "ref"
+	ast.static_ref(term.value)
+}
+
+_unassignable(term, rule_index) if {
+	term.type == "var"
+	not ast.is_output_var(input.rules[to_number(rule_index)], term)
+}

--- a/bundle/regal/rules/idiomatic/prefer-equals-comparison/prefer_equals_comparison_test.rego
+++ b/bundle/regal/rules/idiomatic/prefer-equals-comparison/prefer_equals_comparison_test.rego
@@ -1,0 +1,119 @@
+package regal.rules.idiomatic["prefer-equals-comparison_test"]
+
+import data.regal.ast
+import data.regal.config
+
+import data.regal.rules.idiomatic["prefer-equals-comparison"] as rule
+
+test_fail_impossible_assignment_2_constants if {
+	# this is of course also a constant-condition violation, but no rule
+	# should make assumptions about what other rules exist, or what they do
+	r := rule.report with input as ast.policy("r if true = true")
+
+	r == {{
+		"category": "idiomatic",
+		"description": "Prefer `==` for equality comparison",
+		"level": "error",
+		"location": {
+			"file": "policy.rego",
+			"row": 3,
+			"col": 6,
+			"end": {
+				"row": 3,
+				"col": 17,
+			},
+			"text": "r if true = true",
+		},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/prefer-equals-comparison", "idiomatic"),
+		}],
+		"title": "prefer-equals-comparison",
+	}}
+}
+
+test_fail_impossible_assignment_static_ref_equals_constant if {
+	r := rule.report with input as ast.policy("r if input.foo = 22")
+
+	r == {{
+		"category": "idiomatic",
+		"description": "Prefer `==` for equality comparison",
+		"level": "error",
+		"location": {
+			"file": "policy.rego",
+			"row": 3,
+			"col": 6,
+			"end": {
+				"row": 3,
+				"col": 20,
+			},
+			"text": "r if input.foo = 22",
+		},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/prefer-equals-comparison", "idiomatic"),
+		}],
+		"title": "prefer-equals-comparison",
+	}}
+}
+
+test_fail_impossible_assignment_constant_equals_static_ref if {
+	r := rule.report with input as ast.policy("r if 42 = input.bar")
+
+	r == {{
+		"category": "idiomatic",
+		"description": "Prefer `==` for equality comparison",
+		"level": "error",
+		"location": {
+			"file": "policy.rego",
+			"row": 3,
+			"col": 6,
+			"end": {
+				"row": 3,
+				"col": 20,
+			},
+			"text": "r if 42 = input.bar",
+		},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/prefer-equals-comparison", "idiomatic"),
+		}],
+		"title": "prefer-equals-comparison",
+	}}
+}
+
+test_fail_impossible_assignment_input_var_equals_static_ref if {
+	r := rule.report with input as ast.policy(`r if {
+		x := 42
+		x = input.bar
+	}`)
+
+	r == {{
+		"category": "idiomatic",
+		"description": "Prefer `==` for equality comparison",
+		"level": "error",
+		"location": {
+			"col": 3,
+			"row": 5,
+			"end": {
+				"col": 16,
+				"row": 5,
+			},
+			"file": "policy.rego",
+			"text": "\t\tx = input.bar",
+		},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/prefer-equals-comparison", "idiomatic"),
+		}],
+		"title": "prefer-equals-comparison",
+	}}
+}
+
+test_success_not_impossible_assignment_output_var_equals_static_ref if {
+	r := rule.report with input as ast.policy(`r if {
+		x = input.bar
+	}`)
+
+	r == set()
+}

--- a/docs/rules/idiomatic/prefer-equals-comparison.md
+++ b/docs/rules/idiomatic/prefer-equals-comparison.md
@@ -1,0 +1,94 @@
+# prefer-equals-comparison
+
+**Summary**: Prefer `==` for equality comparison
+
+**Category**: Idiomatic
+
+**Avoid**
+```rego
+package policy
+
+allow if {
+    input.request.method = "GET"
+    # .. more conditions ..
+}
+```
+
+**Prefer**
+```rego
+package policy
+
+allow if {
+    input.request.method == "GET"
+    # .. more conditions ..
+}
+```
+
+## Rationale
+
+The unification operator (`=`) can be used for both assignment and equality comparison in Rego. This can be a really
+powerful feature where appropriate, but when the intent is to perform either assignment (`:=`) **or** an equality
+comparison (`==`), using the operators designed for those specific purposes helps communicate that intent much more
+clearly, and avoid some behaviors of the unification operator that may potentially be surprising (like in which order
+expresions are evaluated). This is not a general recommendation against using the unification operator, mind you! But to
+use the operators specifically for what they are designed for: `:=` for assignment, `==` for equality comparison, and
+`=` for unification.
+
+The OPA docs provide [more information](https://www.openpolicyagent.org/docs/policy-language#equality-assignment-comparison-and-unification)
+on the topic, but to demonstrate a valid use case for the unification operator, this would be a good example:
+
+```rego
+user_id := id if ["users", id] = input.path
+```
+
+Which without unification would need both comparison and assignment:
+
+```rego
+user_id := id if {
+    count(input.path) == 2
+    input.path[0] == "users"
+    id := input.path[1]
+}
+```
+
+## How comparison is determined
+
+Since the unification operator can be used for both assignment and comparison, this rule needs to determine that `=` is
+used for comparison only. The rule reports a violation only when both sides of the `=` operator are determined to be
+"unassignable", which is defined as:
+
+1. Literal values (strings, numbers, booleans, nulls) or composite values containing no variables
+2. References (e.g. `input.foo.bar`)
+3. An input variable — meaning a variable which has previously been assigned a value outside of the expression
+
+To provide a simple example of the the third point:
+
+```rego
+rule if {
+    x = input.x # assignment, provided that `x` is not assigned elsewhere
+}
+
+rule if {
+    x := 5
+    x = input.x # comparison, as `x` is assigned above and unassignable here
+}
+```
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules:
+  idiomatic:
+    prefer-equals-comparison:
+      # one of "error", "warning", "ignore"
+      level: error
+```
+
+## Related Resources
+
+- Regal Docs: [use-assignment-operator](https://www.openpolicyagent.org/projects/regal/rules/style/use-assignment-operator)
+- OPA Docs: [Equality: Assignment, Comparison, and Unification](https://www.openpolicyagent.org/docs/policy-language#equality-assignment-comparison-and-unification)
+- OPA Docs: [Comparisons](https://www.openpolicyagent.org/docs/policy-reference/builtins/comparison)
+- GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/idiomatic/prefer-equals-comparison/prefer_equals_comparison.rego)

--- a/e2e/testdata/violations/most_violations.rego
+++ b/e2e/testdata/violations/most_violations.rego
@@ -159,6 +159,8 @@ equals_pattern_matching(x) := x == "x"
 
 boolean_assignment := 1 < input.two
 
+prefer_equals_comparison if input.enabled = true
+
 # METADATA
 # description: ambiguous scope
 incremental if input.x

--- a/internal/embeds/templates/builtin/builtin.md.tpl
+++ b/internal/embeds/templates/builtin/builtin.md.tpl
@@ -35,9 +35,3 @@ rules:
       # one of "error", "warning", "ignore"
       level: error
 ```
-
-## Community
-
-If you think you've found a problem with this rule or its documentation, would like to suggest improvements, new rules,
-or just talk about Regal in general, please join us in the `#regal` channel in the Styra Community
-[Slack](https://inviter.co/styra)!


### PR DESCRIPTION
I remember how this used to feel almost impossible to do in Rego when I just got started working on Regal. Now, it's 30 lines of code, including metadata comments. We've come a long way.

Fixes #4 (!!!)

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->