### PR TITLE
Improve pointless-reassignment to cover nested cases

### DIFF
--- a/bundle/regal/rules/style/pointless-reassignment/pointless_reassignment.rego
+++ b/bundle/regal/rules/style/pointless-reassignment/pointless_reassignment.rego
@@ -17,16 +17,15 @@ report contains violation if {
 	violation := result.fail(rego.metadata.chain(), result.location(rule))
 }
 
-# pointless reassignment in rule body
+# pointless reassignment in expressions
 report contains violation if {
-	expr := input.rules[_].body[_]
+	some expr
+	ast.found.expressions[_][expr].terms[0].value[0].value == "assign"
 
 	not expr.with
-
-	[lhs, rhs] := ast.assignment_terms(expr.terms)
-
-	lhs.type == "var"
-	rhs.type == "var"
+	expr.terms[0].type == "ref"
+	expr.terms[1].type == "var"
+	expr.terms[2].type == "var"
 
 	violation := result.fail(rego.metadata.chain(), result.infix_expr_location(expr.terms))
 }

--- a/bundle/regal/rules/style/pointless-reassignment/pointless_reassignment_test.rego
+++ b/bundle/regal/rules/style/pointless-reassignment/pointless_reassignment_test.rego
@@ -67,6 +67,40 @@ test_fail_pointless_reassignment_in_rule_body if {
 	}}
 }
 
+test_fail_pointless_reassignment_in_rule_body_nested if {
+	module := ast.with_rego_v1(`
+	rule if {
+		foo := "foo"
+
+		comp := [bar |
+			bar := foo
+		]
+	}
+	`)
+	r := rule.report with input as module
+
+	r == {{
+		"category": "style",
+		"description": "Pointless reassignment of variable",
+		"level": "error",
+		"location": {
+			"col": 4,
+			"row": 10,
+			"end": {
+				"col": 10,
+				"row": 10,
+			},
+			"file": "policy.rego",
+			"text": "\t\t\tbar := foo",
+		},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/pointless-reassignment", "style"),
+		}],
+		"title": "pointless-reassignment",
+	}}
+}
+
 test_success_pointless_reassignment_in_rule_body_using_with if {
 	module := ast.with_rego_v1(`
 	foo := input


### PR DESCRIPTION
Previously this rule would only check expressions at the topmost level of rule bodies. Now it checks expressions anywhere in the policy.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->