### PR TITLE
lsp: Use filename path for current buffer for defns

### DIFF
--- a/internal/lsp/eval_test.go
+++ b/internal/lsp/eval_test.go
@@ -5,13 +5,13 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
 	rio "github.com/open-policy-agent/regal/internal/io"
 	"github.com/open-policy-agent/regal/internal/lsp/log"
+	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	rparse "github.com/open-policy-agent/regal/internal/parse"
 	"github.com/open-policy-agent/regal/internal/testutil"
 )
@@ -40,12 +40,12 @@ func TestEvalWorkspacePath(t *testing.T) {
 	}
 	`
 
-	policy1URI := ls.workspaceRootURI + "/policy1.rego"
-	policy1RelativeFileName := strings.TrimPrefix(policy1URI, ls.workspaceRootURI+"/")
+	policy1URI := uri.FromRelativePath(ls.client.Identifier, "policy1.rego", ls.workspaceRootURI)
+	policy1RelativeFileName := uri.ToRelativePath(ls.client.Identifier, policy1URI, ls.workspaceRootURI)
 	module1 := testutil.Must(rparse.ModuleWithOpts(policy1RelativeFileName, policy1, rparse.ParserOptions()))(t)
 
-	policy2URI := ls.workspaceRootURI + "/policy2.rego"
-	policy2RelativeFileName := strings.TrimPrefix(policy2URI, ls.workspaceRootURI+"/")
+	policy2URI := uri.FromRelativePath(ls.client.Identifier, "policy2.rego", ls.workspaceRootURI)
+	policy2RelativeFileName := uri.ToRelativePath(ls.client.Identifier, policy2URI, ls.workspaceRootURI)
 	module2 := testutil.Must(rparse.ModuleWithOpts(policy2RelativeFileName, policy2, rparse.ParserOptions()))(t)
 
 	ls.cache.SetFileContents(policy1URI, policy1)

--- a/internal/lsp/lint.go
+++ b/internal/lsp/lint.go
@@ -11,8 +11,10 @@ import (
 	"github.com/open-policy-agent/opa/v1/storage"
 
 	"github.com/open-policy-agent/regal/internal/lsp/cache"
+	"github.com/open-policy-agent/regal/internal/lsp/clients"
 	"github.com/open-policy-agent/regal/internal/lsp/completions/refs"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
+	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	rparse "github.com/open-policy-agent/regal/internal/parse"
 	"github.com/open-policy-agent/regal/internal/util"
 	"github.com/open-policy-agent/regal/pkg/config"
@@ -46,6 +48,7 @@ type updateParseOpts struct {
 	Builtins         map[string]*ast.Builtin
 	RegoVersion      ast.RegoVersion
 	WorkspaceRootURI string
+	ClientIdentifier clients.Identifier
 }
 
 // updateParse updates the module cache with the latest parse result for a given URI,
@@ -61,7 +64,7 @@ func updateParse(ctx context.Context, opts updateParseOpts) (bool, error) {
 	options := rparse.ParserOptions()
 	options.RegoVersion = opts.RegoVersion
 
-	presentedFileName := strings.TrimPrefix(opts.FileURI, opts.WorkspaceRootURI+"/")
+	presentedFileName := uri.ToRelativePath(opts.ClientIdentifier, opts.FileURI, opts.WorkspaceRootURI)
 
 	module, err := rparse.ModuleWithOpts(presentedFileName, content, options)
 	if err == nil {

--- a/internal/lsp/lint_test.go
+++ b/internal/lsp/lint_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/ast"
 
 	"github.com/open-policy-agent/regal/internal/lsp/cache"
+	"github.com/open-policy-agent/regal/internal/lsp/clients"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/parse"
 	"github.com/open-policy-agent/regal/internal/testutil"
@@ -109,6 +110,7 @@ allow[msg] { 1 == 1; msg := "hello" }
 				Builtins:         ast.BuiltinMap,
 				RegoVersion:      testData.regoVersion,
 				WorkspaceRootURI: "",
+				ClientIdentifier: clients.IdentifierGeneric,
 			}))(t)
 
 			if success != testData.expectSuccess {

--- a/internal/lsp/server_rename_test.go
+++ b/internal/lsp/server_rename_test.go
@@ -32,7 +32,7 @@ func TestLanguageServerFixRenameParams(t *testing.T) {
 		}},
 	}
 
-	fileURI := ls.workspaceRootURI + "/foo/bar/policy.rego"
+	fileURI := uri.FromRelativePath(ls.client.Identifier, "foo/bar/policy.rego", ls.workspaceRootURI)
 	ls.cache.SetFileContents(fileURI, "package authz.main.rules")
 
 	params := testutil.Must(ls.fixRenameParams("fix my file!", fileURI))(t)
@@ -75,7 +75,7 @@ func TestLanguageServerFixRenameParamsWithConflict(t *testing.T) {
 		}},
 	}
 
-	fileURI := ls.workspaceRootURI + "/foo/bar/policy.rego"
+	fileURI := uri.FromRelativePath(ls.client.Identifier, "foo/bar/policy.rego", ls.workspaceRootURI)
 	conflictingFileURI := fmt.Sprintf("file://%s/workspace/authz/main/rules/policy.rego", tmpDir)
 
 	ls.cache.SetFileContents(fileURI, "package authz.main.rules")
@@ -148,7 +148,7 @@ func TestLanguageServerFixRenameParamsWhenTargetOutsideRoot(t *testing.T) {
 		}},
 	}
 
-	fileURI := ls.workspaceRootURI + "foo/bar/policy.rego"
+	fileURI := uri.FromRelativePath(ls.client.Identifier, "foo/bar/policy.rego", ls.workspaceRootURI)
 	ls.cache.SetFileContents(fileURI, "package authz.main.rules")
 
 	_, err := ls.fixRenameParams("fix my file!", fileURI)

--- a/internal/lsp/uri/uri.go
+++ b/internal/lsp/uri/uri.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/open-policy-agent/regal/internal/lsp/clients"
+	"github.com/open-policy-agent/regal/internal/util"
 )
 
 // uris always use / as the uriSeparator, regardless of system.
@@ -58,4 +59,25 @@ func ToPath(client clients.Identifier, uri string) string {
 
 	// Convert path to use system separators
 	return filepath.FromSlash(path)
+}
+
+// ToRelativePath converts a URI to a file path relative to the given workspace root URI.
+func ToRelativePath(client clients.Identifier, uri, workspaceRootURI string) string {
+	absolutePath := ToPath(client, uri)
+	workspaceRootPath := ToPath(client, workspaceRootURI)
+
+	// Ensure workspace root path has trailing separator for consistent trimming
+	if workspaceRootPath != "" {
+		workspaceRootPath = util.EnsureSuffix(workspaceRootPath, "/")
+	}
+
+	return strings.TrimPrefix(absolutePath, workspaceRootPath)
+}
+
+// FromRelativePath creates a URI from a relative path and workspace root URI.
+func FromRelativePath(client clients.Identifier, relativePath, workspaceRootURI string) string {
+	workspaceRootPath := ToPath(client, workspaceRootURI)
+	absolutePath := filepath.Join(workspaceRootPath, relativePath)
+
+	return FromPath(client, absolutePath)
 }

--- a/internal/lsp/uri/uri_test.go
+++ b/internal/lsp/uri/uri_test.go
@@ -173,3 +173,87 @@ func TestURIToPath_VSCode(t *testing.T) {
 		})
 	}
 }
+
+func TestToRelativePath(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		uri              string
+		workspaceRootURI string
+		want             string
+	}{
+		"unix simple": {
+			uri:              "file:///workspace/foo/bar.rego",
+			workspaceRootURI: "file:///workspace",
+			want:             "foo/bar.rego",
+		},
+		"unix with trailing slash in workspace": {
+			uri:              "file:///workspace/foo/bar.rego",
+			workspaceRootURI: "file:///workspace/",
+			want:             "foo/bar.rego",
+		},
+		"windows": {
+			uri:              "file:///c:/workspace/foo/bar.rego",
+			workspaceRootURI: "file:///c:/workspace",
+			want:             filepath.FromSlash("foo/bar.rego"),
+		},
+		"root path": {
+			uri:              "file:///workspace/policy.rego",
+			workspaceRootURI: "file:///workspace",
+			want:             "policy.rego",
+		},
+	}
+
+	for label, tc := range testCases {
+		t.Run(label, func(t *testing.T) {
+			t.Parallel()
+
+			got := ToRelativePath(clients.IdentifierGeneric, tc.uri, tc.workspaceRootURI)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFromRelativePath(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		relativePath     string
+		workspaceRootURI string
+		want             string
+	}{
+		"unix simple": {
+			relativePath:     "foo/bar.rego",
+			workspaceRootURI: "file:///workspace",
+			want:             "file:///workspace/foo/bar.rego",
+		},
+		"unix with trailing slash in workspace": {
+			relativePath:     "foo/bar.rego",
+			workspaceRootURI: "file:///workspace/",
+			want:             "file:///workspace/foo/bar.rego",
+		},
+		"windows": {
+			relativePath:     "foo/bar.rego",
+			workspaceRootURI: "file:///c:/workspace",
+			want:             "file:///c:/workspace/foo/bar.rego",
+		},
+		"root file": {
+			relativePath:     "policy.rego",
+			workspaceRootURI: "file:///workspace/",
+			want:             "file:///workspace/policy.rego",
+		},
+	}
+
+	for label, tc := range testCases {
+		t.Run(label, func(t *testing.T) {
+			t.Parallel()
+
+			got := FromRelativePath(clients.IdentifierGeneric, tc.relativePath, tc.workspaceRootURI)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
There was a bug here where the defn would only work when the result was another file. Now we use the same format of reference for the current buffer as we use for other modules (a path rather than a URI)

Fixes https://github.com/open-policy-agent/regal/issues/1700
