### PR TITLE
Fix incorrect behavior in pointless-import

### DIFF
--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -183,12 +183,6 @@ is_output_var(rule, var) if {
 }
 
 # METADATA
-# description: as the name implies, answers whether provided value is a ref
-# scope: document
-is_ref(value) if value.type == "ref"
-is_ref(value) if value[0].type == "ref"
-
-# METADATA
 # description: |
 #   returns an array of all rule indices, as strings. this will be needed until
 #   https://github.com/open-policy-agent/opa/issues/6736 is fixed
@@ -234,6 +228,18 @@ ref_value_equal(v1, v2) if {
 		part.value == v2[i].value
 	}
 }
+
+# METADATA
+# description: |
+#   returns a new ref value made by extending terms1 with terms2,
+#   where the first term of terms2 transformed to string
+extend_ref_terms(terms1, terms2) := array.concat(
+	terms1,
+	array.concat(
+		[object.union(terms2[0], {"type": "string"})],
+		array.slice(terms2, 1, 100),
+	),
+)
 
 # METADATA
 # description: |

--- a/bundle/regal/ast/ast_test.rego
+++ b/bundle/regal/ast/ast_test.rego
@@ -215,14 +215,6 @@ x._z := false
 	{ast.ref_to_string(rule.head.ref) | some rule in public} == {"foo", "x.y"}
 }
 
-# only for coverage — we don't currently use is_ref as it's much too
-# expensive to call in a hot path https://github.com/open-policy-agent/opa/issues/7266
-# but as it's part of the "public API", we'll keep it around
-test_is_ref if {
-	ast.is_ref({"type": "ref", "value": "foo"})
-	ast.is_ref([{"type": "ref", "value": "foo"}])
-}
-
 test_var_in_head[case] if {
 	name := "foo"
 

--- a/bundle/regal/rules/imports/pointless-import/pointless_import.rego
+++ b/bundle/regal/rules/imports/pointless-import/pointless_import.rego
@@ -5,17 +5,31 @@ package regal.rules.imports["pointless-import"]
 import data.regal.ast
 import data.regal.result
 
+# METADATA
+# description: report pointless imports of own package or rules defined in the same module
+# scope: document
+
+# METADATA
+# description: report pointless imports of own package
 report contains violation if {
-	plen := count(input.package.path)
 	path := input.imports[_].path
-	ilen := count(path.value)
 
-	# allow package a.b to import a.b.c.d.e but not a.b or a.b.c
-	ilen - plen < 2
-
-	same := array.slice(path.value, 0, plen)
-
-	ast.ref_value_equal(input.package.path, same)
+	ast.ref_value_equal(input.package.path, path.value)
 
 	violation := result.fail(rego.metadata.chain(), result.location(path))
+}
+
+# METADATA
+# description: report pointless imports of rule paths defined in the same module
+report contains violation if {
+	rule_paths := {path |
+		rref := input.rules[_].head.ref
+		path := ast.extend_ref_terms(input.package.path, rref)
+	}
+	imp_path := input.imports[_].path
+
+	some rule_path in rule_paths
+	ast.is_terms_subset(imp_path.value, rule_path)
+
+	violation := result.fail(rego.metadata.chain(), result.location(imp_path))
 }

--- a/bundle/regal/rules/imports/pointless-import/pointless_import_test.rego
+++ b/bundle/regal/rules/imports/pointless-import/pointless_import_test.rego
@@ -30,8 +30,17 @@ test_fail_pointless_import_of_same_package if {
 	}}
 }
 
-test_fail_pointless_import_of_rule_in_same_package if {
-	r := rule.report with input as ast.policy("import data.policy")
+test_success_external_ref_not_flagged if {
+	r := rule.report with input as ast.policy("import data.policy.a.b.c")
+
+	r == set()
+}
+
+test_success_ref_defined_in_module_flagged if {
+	r := rule.report with input as ast.policy(`import data.policy.a.b.c
+	
+	a.b.c := 1
+	`)
 
 	r == {{
 		"category": "imports",
@@ -39,24 +48,45 @@ test_fail_pointless_import_of_rule_in_same_package if {
 		"level": "error",
 		"location": {
 			"col": 8,
+			"row": 3,
 			"end": {
-				"col": 19,
+				"col": 25,
 				"row": 3,
 			},
 			"file": "policy.rego",
-			"row": 3,
-			"text": "import data.policy",
+			"text": "import data.policy.a.b.c",
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/pointless-import", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/pointless-import",
 		}],
 		"title": "pointless-import",
 	}}
 }
 
-test_success_somewhat_pointless_import_but_longer_ref_not_flagged if {
-	r := rule.report with input as ast.policy("import data.policy.a.b.c.d.e")
+test_success_ref_prefix_defined_in_module_flagged if {
+	r := rule.report with input as ast.policy(`import data.policy.a.b
+	
+	a.b.c := 1`)
 
-	r == set()
+	r == {{
+		"category": "imports",
+		"description": "Importing own package is pointless",
+		"level": "error",
+		"location": {
+			"col": 8,
+			"row": 3,
+			"end": {
+				"col": 23,
+				"row": 3,
+			},
+			"file": "policy.rego",
+			"text": "import data.policy.a.b",
+		},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/pointless-import",
+		}],
+		"title": "pointless-import",
+	}}
 }

--- a/docs/rules/imports/pointless-import.md
+++ b/docs/rules/imports/pointless-import.md
@@ -13,6 +13,10 @@ import data.policy
 
 # pointless, as rules in own package can be referenced without the import
 import data.policy.rule
+
+rule if {
+    # ..conditions..
+}
 ```
 
 **Prefer**
@@ -22,20 +26,8 @@ package policy
 
 ## Rationale
 
-There's no point importing the own package, or rules from the same package, as both can be referenced just as well
+There's no point importing the own package, or rules from the same module, as both can be referenced just as well
 without the import.
-
-## Exceptions
-
-While it may not be the best way use a reference from the same package, longer references than the package, or the
-package plus a rule, are at least not pointless, and as such not flagged by this rule.
-
-```rego
-package policy
-
-# this is allowed, but consider using the reference directly rather than importing it
-import data.policy.a.b.c
-```
 
 ## Configuration Options
 


### PR DESCRIPTION
The intention was to flag imports of own package, and imports of paths defined in the same **module**, not the same package (i.e. across files), which is now what this rule does.

Credits to @sascha-cariad for reporting this, and in a very detailed way!

Fixes #1728

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->