### PR TITLE
Various small fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,13 @@
     // This is better handled by Regal's selection ranges implementation
     "editor.smartSelect.selectLeadingAndTrailingWhitespace": false,
     "editor.smartSelect.selectSubwords": false
-  }
+  },
+  // Enable to have values displayed inline during debugging
+  // The default value is "auto", which consults the language extension on whethher
+  // to have this enabled or not. And since the extension currently doesn't do anything
+  // on its own to support this, we need to explicitly enable it here if we want this.
+  // Long term, the extension + Regal should provide support for this, as it'll also
+  // result in a better experience when we can be more selective about what to show,
+  // and how.
+  "debug.inlineValues": "on"
 }

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -169,8 +169,8 @@ func WithCreateRecursive(path string, fn func(f *os.File) error) error {
 	return fn(file)
 }
 
-// FindInputPath consults the filesystem and returns the input.json or input.yaml closes to the
-// file provided as arguments.
+// FindInputPath consults the filesystem and returns the location of the input.json
+// or input.yaml closest to the file provided.
 func FindInputPath(file string, workspacePath string) string {
 	relative := strings.TrimPrefix(file, workspacePath)
 	components := strings.Split(filepath.Dir(relative), string(os.PathSeparator))

--- a/internal/lsp/eval_test.go
+++ b/internal/lsp/eval_test.go
@@ -106,16 +106,19 @@ func TestFindInputPath(t *testing.T) {
 				t.Fatalf("did not expect to find input.%s", tc.fileExt)
 			}
 
-			createWithContent(t, tmpDir+"/workspace/foo/bar/input."+tc.fileExt, tc.fileContent)
+			inputPath := filepath.Join(workspacePath, "foo", "bar", "input."+tc.fileExt)
+			createWithContent(t, inputPath, tc.fileContent)
 
-			if path, exp := rio.FindInputPath(file, workspacePath), workspacePath+"/foo/bar/input."+tc.fileExt; path != exp {
+			if path, exp := rio.FindInputPath(file, workspacePath), inputPath; path != exp {
 				t.Errorf(`expected input at %s, got %s`, exp, path)
 			}
 
-			testutil.MustRemove(t, tmpDir+"/workspace/foo/bar/input."+tc.fileExt)
-			createWithContent(t, tmpDir+"/workspace/input."+tc.fileExt, tc.fileContent)
+			testutil.MustRemove(t, inputPath)
 
-			if path, exp := rio.FindInputPath(file, workspacePath), workspacePath+"/input."+tc.fileExt; path != exp {
+			workspaceInputPath := filepath.Join(workspacePath, "input."+tc.fileExt)
+			createWithContent(t, workspaceInputPath, tc.fileContent)
+
+			if path, exp := rio.FindInputPath(file, workspacePath), workspaceInputPath; path != exp {
 				t.Errorf(`expected input at %s, got %s`, exp, path)
 			}
 		})
@@ -141,18 +144,30 @@ func TestFindInput(t *testing.T) {
 				t.Fatalf("did not expect to find input.%s", tc.fileType)
 			}
 
-			createWithContent(t, tmpDir+"/workspace/foo/bar/input."+tc.fileType, tc.fileContent)
+			inputPath := filepath.Join(workspacePath, "foo", "bar", "input."+tc.fileType)
+
+			createWithContent(t, inputPath, tc.fileContent)
 
 			path, content := rio.FindInput(file, workspacePath)
-			if path != workspacePath+"/foo/bar/input."+tc.fileType || !maps.Equal(content, map[string]any{"x": true}) {
-				t.Errorf(`expected input {"x": true} at, got %s`, content)
+			if path != inputPath {
+				t.Errorf(`expected input at %s, got %s`, inputPath, path)
 			}
 
-			testutil.MustRemove(t, tmpDir+"/workspace/foo/bar/input."+tc.fileType)
-			createWithContent(t, tmpDir+"/workspace/input."+tc.fileType, tc.fileContent)
+			if !maps.Equal(content, map[string]any{"x": true}) {
+				t.Errorf(`expected input {"x": true}, got %s`, content)
+			}
+
+			testutil.MustRemove(t, inputPath)
+
+			workspaceInputPath := filepath.Join(workspacePath, "input."+tc.fileType)
+			createWithContent(t, workspaceInputPath, tc.fileContent)
 
 			path, content = rio.FindInput(file, workspacePath)
-			if path != workspacePath+"/input."+tc.fileType || !maps.Equal(content, map[string]any{"x": true}) {
+			if path != workspaceInputPath {
+				t.Errorf(`expected input at %s, got %s`, workspaceInputPath, path)
+			}
+
+			if !maps.Equal(content, map[string]any{"x": true}) {
 				t.Errorf(`expected input {"x": true} at, got %s`, content)
 			}
 		})

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -438,7 +438,7 @@ func TestLintWithPrintHook(t *testing.T) {
 func TestLintWithAggregateRule(t *testing.T) {
 	t.Parallel()
 
-	policies := make(map[string]string)
+	policies := make(map[string]string, 2)
 	policies["foo.rego"] = `package foo
 		import data.bar
 


### PR DESCRIPTION
- Add debugging configuration to enable inlineValues in project
- Don't use hardcoded "/" in eval test paths (as that won't work on Windows)
- More efficient input creation in aggregate lint step

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->