### PR TITLE
Remove go-semver dependency, plus various fixes

### DIFF
--- a/build/do.rq
+++ b/build/do.rq
@@ -157,7 +157,7 @@ binary_present if {
 
 test if {
 	run("go test ./...")
-	run("go run main.go test bundle")
+	run("go run main.go test --timeout 1s bundle")
 }
 
 e2e if {

--- a/bundle/regal/lsp/signaturehelp/signaturehelp_test.rego
+++ b/bundle/regal/lsp/signaturehelp/signaturehelp_test.rego
@@ -1,7 +1,5 @@
 package regal.lsp.signaturehelp_test
 
-import rego.v1
-
 import data.regal.lsp.signaturehelp as sh
 
 test_result if {

--- a/bundle/regal/main/main.rego
+++ b/bundle/regal/main/main.rego
@@ -35,6 +35,17 @@ lint.aggregate.violations := aggregate_report if "aggregate" in input.regal.oper
 _file_name_relative_to_root(filename, "/") := trim_prefix(filename, "/")
 _file_name_relative_to_root(filename, root) := trim_prefix(filename, concat("", [root, "/"])) if root != "/"
 
+# METADATA
+# description: |
+#   set of all rules not disabled by configuration
+#   note that this only accounts for rules disabled entirely, not for specific files, or via flags
+enabled_rules[category][title] if {
+	some category, title
+	config.rules[category][title]
+
+	not config.ignored_rule(category, title)
+}
+
 _rules_to_run[category] contains title if {
 	relative_filename := _file_name_relative_to_root(input.regal.file.name, config.path_prefix)
 	not config.ignored_globally(relative_filename)

--- a/bundle/regal/main/main_test.rego
+++ b/bundle/regal/main/main_test.rego
@@ -285,8 +285,6 @@ test_force_exclude_file_config if {
 test_lint_from_stdin_disables_rules_depending_on_filename_creates_notices if {
 	policy := `package p
 
-import rego.v1
-
 camelCase := "yes"
 
 test_camelcase if {

--- a/bundle/regal/rules/bugs/impossible-not/impossible_not_test.rego
+++ b/bundle/regal/rules/bugs/impossible-not/impossible_not_test.rego
@@ -7,14 +7,10 @@ import data.regal.rules.bugs["impossible-not"] as rule
 test_fail_multivalue_not_reference_same_package if {
 	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
 
-	import rego.v1
-
 	partial contains "foo"
 	`)
 
 	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", `package foo
-
-	import rego.v1
 
 	test_foo if {
 		not partial
@@ -25,10 +21,10 @@ test_fail_multivalue_not_reference_same_package if {
 	r == expected_with_location({
 		"col": 7,
 		"file": "p2.rego",
-		"row": 6,
+		"row": 4,
 		"end": {
 			"col": 14,
-			"row": 6,
+			"row": 4,
 		},
 		"text": "not partial",
 	})
@@ -62,14 +58,10 @@ test_fail_multivalue_not_reference_same_package_nested_expression if {
 test_fail_multivalue_not_reference_different_package_using_direct_reference if {
 	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
 
-	import rego.v1
-
 	partial contains "foo"
 	`)
 
 	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", `package bar
-
-	import rego.v1
 
 	test_foo if {
 		not data.foo.partial
@@ -80,10 +72,10 @@ test_fail_multivalue_not_reference_different_package_using_direct_reference if {
 	r == expected_with_location({
 		"col": 7,
 		"file": "p2.rego",
-		"row": 6,
+		"row": 4,
 		"end": {
 			"col": 11,
-			"row": 6,
+			"row": 4,
 		},
 		"text": "not data.foo.partial",
 	})
@@ -92,16 +84,12 @@ test_fail_multivalue_not_reference_different_package_using_direct_reference if {
 test_fail_multivalue_not_reference_different_package_using_import if {
 	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
 
-	import rego.v1
-
 	partial contains "foo"
 
 	another contains "bar"
 	`)
 
 	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", `package bar
-
-	import rego.v1
 
 	import data.foo
 
@@ -114,10 +102,10 @@ test_fail_multivalue_not_reference_different_package_using_import if {
 	r == expected_with_location({
 		"col": 7,
 		"file": "p2.rego",
-		"row": 8,
+		"row": 6,
 		"end": {
 			"col": 10,
-			"row": 8,
+			"row": 6,
 		},
 		"text": "not foo.partial",
 	})
@@ -126,14 +114,10 @@ test_fail_multivalue_not_reference_different_package_using_import if {
 test_success_multivalue_not_reference_invalidated_by_local_var if {
 	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
 
-	import rego.v1
-
 	partial contains "foo"
 	`)
 
 	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", `package bar
-
-	import rego.v1
 
 	import data.foo
 
@@ -150,14 +134,10 @@ test_success_multivalue_not_reference_invalidated_by_local_var if {
 test_success_multivalue_not_reference_invalidated_by_function_argument if {
 	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
 
-	import rego.v1
-
 	partial contains "foo"
 	`)
 
 	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", `package bar
-
-	import rego.v1
 
 	import data.foo
 
@@ -173,8 +153,6 @@ test_success_multivalue_not_reference_invalidated_by_function_argument if {
 test_success_multivalue_not_reference_in_same_file_not_reported_in_aggregate_report if {
 	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
 
-	import rego.v1
-
 	partial contains "foo"
 
 	test_partial if {
@@ -189,8 +167,6 @@ test_success_multivalue_not_reference_in_same_file_not_reported_in_aggregate_rep
 test_fail_multivalue_not_reference_in_same_file_reported_in_normal_report if {
 	module := regal.parse_module("p1.rego", `package foo
 
-	import rego.v1
-
 	partial contains "foo"
 
 	test_partial if {
@@ -204,16 +180,15 @@ test_fail_multivalue_not_reference_in_same_file_reported_in_normal_report if {
 		"file": "p1.rego",
 		"end": {
 			"col": 14,
-			"row": 8,
+			"row": 6,
 		},
-		"row": 8, "text": "not partial",
+		"row": 6,
+		"text": "not partial",
 	})
 }
 
 test_success_multivalue_ref_head_rule_not_accounted_for if {
 	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
-
-	import rego.v1
 
 	my.partial[rule] contains "foo" if {
 		some rule in input

--- a/bundle/regal/rules/imports/unresolved-import/unresolved_import_test.rego
+++ b/bundle/regal/rules/imports/unresolved-import/unresolved_import_test.rego
@@ -110,7 +110,6 @@ test_success_map_rule_resolves if {
 	`)
 
 	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", `package bar
-	import rego.v1
 
 	x[y] := z if {
 		some y in input.ys
@@ -128,7 +127,6 @@ test_success_map_rule_may_resolve_so_allow if {
 	`)
 
 	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", `package bar
-	import rego.v1
 
 	x[y] := z if {
 		some y in input.ys
@@ -146,7 +144,6 @@ test_success_general_ref_head_rule_may_resolve_so_allow if {
 	`)
 
 	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", `package bar
-	import rego.v1
 
 	x[y].z[foo] := z if {
 		some y in input.ys

--- a/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package_test.rego
+++ b/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package_test.rego
@@ -157,16 +157,14 @@ test_rule_violation_if_repetition_ref_head_rule if {
 	r := rule.report with input as regal.parse_module("example.rego", `
 	package policy
 
-	import rego.v1
-
 	policy.decision contains "nope"
 	`)
 
 	r == {object.union(base_result, {"location": {
 		"col": 2,
 		"file": "example.rego",
-		"row": 6,
-		"end": {"col": 8, "row": 6},
+		"row": 4,
+		"end": {"col": 8, "row": 4},
 		"text": "\tpolicy.decision contains \"nope\"",
 	}})}
 }

--- a/bundle/regal/rules/testing/test-outside-test-package/test_outside_test_package_test.rego
+++ b/bundle/regal/rules/testing/test-outside-test-package/test_outside_test_package_test.rego
@@ -5,7 +5,7 @@ import data.regal.config
 import data.regal.rules.testing["test-outside-test-package"] as rule
 
 test_fail_test_outside_test_package if {
-	r := rule.report with input as ast.with_rego_v1(`test_foo if { false }`) with input.regal.file.name as "p_test.rego"
+	r := rule.report with input as ast.policy(`test_foo if { false }`) with input.regal.file.name as "p_test.rego"
 
 	r == {{
 		"category": "testing",
@@ -18,8 +18,8 @@ test_fail_test_outside_test_package if {
 		"location": {
 			"col": 1,
 			"file": "p_test.rego",
-			"row": 5,
-			"end": {"col": 9, "row": 5},
+			"row": 3,
+			"end": {"col": 9, "row": 3},
 			"text": `test_foo if { false }`,
 		},
 		"level": "error",
@@ -29,8 +29,6 @@ test_fail_test_outside_test_package if {
 test_success_test_inside_test_package if {
 	ast := regal.parse_module("foo_test.rego", `
 	package foo_test
-
-	import rego.v1
 
 	test_foo if { false }
 	`)
@@ -42,8 +40,6 @@ test_success_test_inside_test_package_named_just_test if {
 	ast := regal.parse_module("test.rego", `
 	package test
 
-	import rego.v1
-
 	test_foo if { false }
 	`)
 	result := rule.report with input as ast
@@ -54,8 +50,6 @@ test_success_test_inside_test_package_named_just_test if {
 test_success_test_prefixed_function if {
 	ast := regal.parse_module("foo_test.rego", `
 	package foo
-
-	import rego.v1
 
 	test_foo(x) if { x == 1 }
 	`)

--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -221,9 +221,8 @@ func fix(args []string, params *fixParams) (err error) {
 		return fmt.Errorf("failed to filter ignored paths: %w", err)
 	}
 
-	slices.Sort(filtered)
 	// TODO: Figure out why filtered returns duplicates in the first place
-	filtered = slices.Compact(filtered)
+	filtered = slices.Compact(util.Sorted(filtered))
 
 	// convert the filtered paths to absolute paths before fixing to
 	// support accurate root matching.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.25.0
 require (
 	dario.cat/mergo v1.0.2
 	github.com/arl/statsviz v0.7.2
-	github.com/coreos/go-semver v0.3.1
 	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-git/go-git/v5 v5.16.3

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,6 @@ github.com/clipperhouse/uax29/v2 v2.3.0 h1:SNdx9DVUqMoBuBoW3iLOj4FQv3dN5mDtuqwuh
 github.com/clipperhouse/uax29/v2 v2.3.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
-github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
-github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyphar/filepath-securejoin v0.5.0 h1:hIAhkRBMQ8nIeuVwcAoymp7MY4oherZdAxD+m0u9zaw=
@@ -350,8 +348,6 @@ github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXV
 github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/vektah/gqlparser/v2 v2.5.30 h1:EqLwGAFLIzt1wpx1IPpY67DwUujF1OfzgEyDsLrN6kE=
 github.com/vektah/gqlparser/v2 v2.5.30/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
-github.com/vektah/gqlparser/v2 v2.5.31 h1:YhWGA1mfTjID7qJhd1+Vxhpk5HTgydrGU9IgkWBTJ7k=
-github.com/vektah/gqlparser/v2 v2.5.31/go.mod h1:c1I28gSOVNzlfc4WuDlqU7voQnsqI6OG2amkBAFmgts=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/internal/capabilities/capabilities.go
+++ b/internal/capabilities/capabilities.go
@@ -11,26 +11,26 @@ import (
 	"path"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
-
-	"github.com/coreos/go-semver/semver"
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
 	"github.com/open-policy-agent/regal/internal/capabilities/embedded"
 	"github.com/open-policy-agent/regal/internal/io"
+	"github.com/open-policy-agent/regal/internal/semver"
 	"github.com/open-policy-agent/regal/internal/util"
 )
 
 const (
 	engineOPA  = "opa"
 	engineEOPA = "eopa"
-
 	DefaultURL = "regal:///capabilities/default"
 )
 
-var driveLetterPattern = regexp.MustCompile(`^\/[a-zA-Z]:`)
+var (
+	client             = &http.Client{}
+	driveLetterPattern = regexp.MustCompile(`^\/[a-zA-Z]:`)
+)
 
 // Lookup attempts to retrieve capabilities from the requested RFC3986
 // compliant URL.
@@ -65,9 +65,7 @@ func Lookup(ctx context.Context, rawURL string) (*ast.Capabilities, error) {
 // URL to avoid a needless round-trip through a string.
 func LookupURL(ctx context.Context, parsedURL *url.URL) (*ast.Capabilities, error) {
 	switch parsedURL.Scheme {
-	case "http":
-		return lookupWebURL(ctx, parsedURL)
-	case "https":
+	case "http", "https":
 		return lookupWebURL(ctx, parsedURL)
 	case "file":
 		return lookupFileURL(parsedURL)
@@ -79,55 +77,50 @@ func LookupURL(ctx context.Context, parsedURL *url.URL) (*ast.Capabilities, erro
 }
 
 func lookupEmbeddedURL(parsedURL *url.URL) (*ast.Capabilities, error) {
+	var file, version string
 	// We need to consider the individual path elements of the URL. It
 	// would arguably be more elegant to do this with regex and named
 	// capture groups, but I trust the stdlib URL and path splitting
 	// implementations more.
-	elems := make([]string, 0)
 	dir := path.Clean(parsedURL.Path)
 
-	var file string
-
+	elems := make([]string, 0, strings.Count(dir, "/")+1)
 	for dir != "" {
 		// leading and trailing / symbols confuse path.Split()
 		dir, file = path.Split(strings.Trim(dir, "/"))
 		elems = append(elems, file)
 	}
 
-	slices.Reverse(elems)
-
-	if len(elems) < 1 {
+	numElems := len(elems)
+	if numElems < 1 {
 		return nil, fmt.Errorf("regal URL '%s' has an empty path", parsedURL.String())
 	}
+
+	slices.Reverse(elems)
 
 	// The capabilities element should always be present so that if we want
 	// to make other regal:// URLs later for other purposes, we don't cross
 	// contaminate different subsystems.
 	if elems[0] != "capabilities" {
-		return nil, fmt.Errorf(
-			"regal URL '%s' does not have 'capabilities' as it's first path element "+
-				"- did you mean to try to load capabilities from this URL?",
+		return nil, fmt.Errorf("regal URL '%s' does not have 'capabilities' as it's first path element "+
+			"- did you mean to try to load capabilities from this URL?",
 			parsedURL.String(),
 		)
 	}
 
-	if len(elems) > 3 {
-		return nil, fmt.Errorf(
-			"regal URL '%s' is malformed (too many path elements), "+
-				"expected regal://capabilities/{engine}[/{version}]",
+	if numElems > 3 {
+		return nil, fmt.Errorf("regal URL '%s' is malformed (too many path elements), "+
+			"expected regal://capabilities/{engine}[/{version}]",
 			parsedURL.String(),
 		)
 	}
 
 	if elems[1] == "default" {
-		return ast.CapabilitiesForThisVersion(), nil
+		return io.Capabilities(), nil
 	}
 
 	engine := elems[1]
-
-	var version string
-
-	if len(elems) == 3 {
+	if numElems == 3 {
 		version = elems[2]
 	} else {
 		// look up latest version if the caller did not explicitly
@@ -151,19 +144,16 @@ func lookupEmbeddedURL(parsedURL *url.URL) (*ast.Capabilities, error) {
 
 		versionsForEngine, ok := versionsList[engine]
 		if !ok {
-			return nil, fmt.Errorf(
-				"while processing regal URL '%s', failed to determine "+
-					"the latest version for engine '%s': engine not found in embedded database",
+			return nil, fmt.Errorf("while processing regal URL '%s', failed to determine "+
+				"the latest version for engine '%s': engine not found in embedded database",
 				parsedURL.String(),
 				engine,
 			)
 		}
 
 		if len(versionsForEngine) < 1 {
-			return nil, fmt.Errorf(
-				"while processing regal URL '%s', failed to determine the "+
-					"latest version for engine '%s': engine found in embedded "+
-					"database but has no versions associated with it",
+			return nil, fmt.Errorf("while processing regal URL '%s', failed to determine the latest version for engine"+
+				" '%s': engine found in embedded database but has no versions associated with it",
 				parsedURL.String(),
 				engine,
 			)
@@ -201,8 +191,6 @@ func lookupWebURL(ctx context.Context, parsedURL *url.URL) (*ast.Capabilities, e
 		return nil, fmt.Errorf("failed to create HTTP request for URL '%s': %w", parsedURL.String(), err)
 	}
 
-	client := &http.Client{}
-
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get URL '%s': %w", parsedURL.String(), err)
@@ -212,67 +200,31 @@ func lookupWebURL(ctx context.Context, parsedURL *url.URL) (*ast.Capabilities, e
 	return util.Wrap(ast.LoadCapabilitiesJSON(resp.Body))("failed to load capabilities")
 }
 
-// semverSort uses the semver library to perform the string comparisons during
-// sorting, but cleanly handles invalid semver strings without panicing or
-// throwing an error.
+// semverSort sorts versions according to semver in descending order. Invalid
+// semver strings are sorted lexicographically after all valid semver strings.
 func semverSort(stringVersions []string) {
-	// For performance, we'll memoize conversion of strings to semver
-	// versions.
-	vCache := make(map[string]*semver.Version)
+	versions := make([]semver.Version, 0, len(stringVersions))
+	invalid := make([]string, 0)
 
-	sort.Slice(stringVersions, func(i, j int) bool {
-		iStr := stringVersions[i]
-		jStr := stringVersions[j]
-
-		iValid := true
-		jValid := true
-
-		iVers, ok := vCache[iStr]
-		if !ok {
-			var err error
-
-			iVers, err = semver.NewVersion(iStr)
-			if err != nil {
-				iValid = false
-			} else {
-				vCache[iStr] = iVers
-			}
+	for _, strVer := range stringVersions {
+		if v, err := semver.Parse(strVer); err == nil {
+			versions = append(versions, v)
+		} else {
+			invalid = append(invalid, strVer)
 		}
+	}
 
-		jVers, ok := vCache[jStr]
-		if !ok {
-			var err error
+	slices.SortStableFunc(versions, (semver.Version).Compare)
 
-			jVers, err = semver.NewVersion(jStr)
-			if err != nil {
-				jValid = false
-			} else {
-				vCache[jStr] = jVers
-			}
-		}
+	for i, v := range util.Reversed(versions) {
+		stringVersions[i] = v.String()
+	}
 
-		if iValid && jValid {
-			return iVers.LessThan(*jVers)
-		}
-
-		// When i is valid semver and j is not, i always sorts first.
-		if iValid && !jValid {
-			return false
-		}
-
-		if !iValid && jValid {
-			return true
-		}
-
-		// If neither string is valid semver, fall back to normal
-		// string comparison.
-		return iStr < jStr
-	})
-
-	// This sort sorts ascending, but we want descending. I can't figure
-	// out how to get sort.Reverse() and sort.Slice() to play nice, and
-	// these lists will generally be small anyway.
-	slices.Reverse(stringVersions)
+	if len(invalid) > 0 {
+		slices.Sort(invalid)
+		slices.Reverse(invalid)
+		copy(stringVersions[len(versions):], invalid)
+	}
 }
 
 // List returns a map with keys being Rego engine types, and values being lists

--- a/internal/capabilities/capabilities_test.go
+++ b/internal/capabilities/capabilities_test.go
@@ -67,14 +67,16 @@ func TestSemverSort(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		// Note that this actually sorts the input in-place, which is
-		// fine since we won't re-visit the same test case twice.
-		semverSort(c.input)
+		t.Run(c.note, func(t *testing.T) {
+			t.Parallel()
 
-		for j, x := range c.expect {
-			if x != c.input[j] {
-				t.Errorf("index=%d actual='%s' expected='%s'", j, c.input[j], x)
+			semverSort(c.input)
+
+			for j, x := range c.expect {
+				if x != c.input[j] {
+					t.Errorf("index=%d actual='%s' expected='%s'", j, c.input[j], x)
+				}
 			}
-		}
+		})
 	}
 }

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -70,6 +70,7 @@ func LoadRegalBundleFS(fs fs.FS) (*bundle.Bundle, error) {
 		WithSkipBundleVerification(true).
 		WithProcessAnnotations(true).
 		WithLazyLoadingMode(false). // NB(sr): This is OPA's default, unless when using bundle plugins
+		WithRegoVersion(ast.RegoV1).
 		WithBundleName("regal").
 		Read()
 	if err != nil {

--- a/internal/lsp/completions/refs/defined_test.go
+++ b/internal/lsp/completions/refs/defined_test.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/open-policy-agent/opa/v1/ast"
-
 	"github.com/open-policy-agent/regal/internal/lsp/rego"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	rparse "github.com/open-policy-agent/regal/internal/parse"
@@ -35,8 +33,7 @@ func TestForModule_Package(t *testing.T) {
 package example
 `)
 
-	bis := rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion())
-
+	bis := rego.BuiltinsForDefaultCapabilities()
 	items := DefinedInModule(mod, bis)
 
 	expectedRefs := map[string]types.Ref{
@@ -124,7 +121,7 @@ deny contains "strings" if true
 
 pi := 3.14
 `)
-	bis := rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion())
+	bis := rego.BuiltinsForDefaultCapabilities()
 	items := DefinedInModule(mod, bis)
 
 	expectedRefs := map[string]types.Ref{

--- a/internal/lsp/documentsymbol/documentsymbol_test.go
+++ b/internal/lsp/documentsymbol/documentsymbol_test.go
@@ -60,8 +60,7 @@ func TestDocumentSymbols(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			bis := rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion())
-
+			bis := rego.BuiltinsForDefaultCapabilities()
 			syms := documentsymbol.All(tc.policy, module, bis)
 
 			pkg := syms[0]

--- a/internal/lsp/eval_test.go
+++ b/internal/lsp/eval_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	rparse "github.com/open-policy-agent/regal/internal/parse"
 	"github.com/open-policy-agent/regal/internal/testutil"
+	"github.com/open-policy-agent/regal/internal/util"
 )
 
 func TestEvalWorkspacePath(t *testing.T) {
@@ -73,16 +74,9 @@ func TestEvalWorkspacePathInternalData(t *testing.T) {
 
 	res := testutil.Must(ls.EvalInWorkspace(t.Context(), "object.keys(data.internal)", map[string]any{}))(t)
 	val := testutil.MustBe[[]any](t, res.Value)
+	act := util.Sorted(testutil.Must(util.AnySliceTo[string](val))(t))
 
-	act := make([]string, 0, len(val))
-	for _, v := range val {
-		act = append(act, testutil.MustBe[string](t, v))
-	}
-
-	slices.Sort(act)
-
-	exp := []string{"capabilities", "combined_config"}
-	if !slices.Equal(exp, act) {
+	if exp := []string{"capabilities", "combined_config"}; !slices.Equal(exp, act) {
 		t.Fatalf("expected %v, got %v", exp, act)
 	}
 }

--- a/internal/lsp/handle_text_document_code_action_test.go
+++ b/internal/lsp/handle_text_document_code_action_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/open-policy-agent/regal/pkg/roast/encoding"
 )
 
+const ruleNameUseAssignmentOperator = "use-assignment-operator"
+
 func TestHandleTextDocumentCodeAction(t *testing.T) {
 	t.Parallel()
 

--- a/internal/lsp/inlayhint/inlayhint_test.go
+++ b/internal/lsp/inlayhint/inlayhint_test.go
@@ -17,10 +17,7 @@ func TestGetInlayHintsAstCall(t *testing.T) {
 
 	r := json.filter({}, [])`
 
-	module := ast.MustParseModule(policy)
-
-	bis := rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion())
-	inlayHints := inlayhint.FromModule(module, bis)
+	inlayHints := inlayhint.FromModule(ast.MustParseModule(policy), rego.BuiltinsForDefaultCapabilities())
 
 	if len(inlayHints) != 2 {
 		t.Fatalf("Expected 2 inlay hints, got %d", len(inlayHints))
@@ -65,11 +62,7 @@ func TestGetInlayHintsAstTerms(t *testing.T) {
 		is_string("yes")
 	}`
 
-	module := ast.MustParseModule(policy)
-
-	bis := rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion())
-
-	inlayHints := inlayhint.FromModule(module, bis)
+	inlayHints := inlayhint.FromModule(ast.MustParseModule(policy), rego.BuiltinsForDefaultCapabilities())
 
 	if len(inlayHints) != 1 {
 		t.Fatalf("Expected 1 inlay hints, got %d", len(inlayHints))

--- a/internal/lsp/rego/builtins.go
+++ b/internal/lsp/rego/builtins.go
@@ -2,9 +2,16 @@ package rego
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/open-policy-agent/opa/v1/ast"
+
+	"github.com/open-policy-agent/regal/internal/io"
 )
+
+var BuiltinsForDefaultCapabilities = sync.OnceValue(func() map[string]*ast.Builtin {
+	return BuiltinsForCapabilities(io.Capabilities())
+})
 
 // BuiltinsForCapabilities returns a list of builtins from the provided capabilities.
 func BuiltinsForCapabilities(capabilities *ast.Capabilities) map[string]*ast.Builtin {
@@ -16,15 +23,14 @@ func BuiltinsForCapabilities(capabilities *ast.Capabilities) map[string]*ast.Bui
 	return m
 }
 
-func BuiltinCategory(builtin *ast.Builtin) (category string) {
+func BuiltinCategory(builtin *ast.Builtin) string {
 	if len(builtin.Categories) == 0 {
-		category = builtin.Name
 		if i := strings.Index(builtin.Name, "."); i > -1 {
-			category = builtin.Name[:i]
+			return builtin.Name[:i]
 		}
-	} else {
-		category = builtin.Categories[0]
+
+		return builtin.Name
 	}
 
-	return category
+	return builtin.Categories[0]
 }

--- a/internal/lsp/sendfilediagnostics_test.go
+++ b/internal/lsp/sendfilediagnostics_test.go
@@ -60,9 +60,7 @@ func TestSendFileDiagnosticsEmptyArrays(t *testing.T) {
 				ls.cache.SetFileDiagnostics(fileURI, tc.lintErrors)
 			}
 
-			if err := ls.sendFileDiagnostics(t.Context(), fileURI); err != nil {
-				t.Fatalf("sendFileDiagnostics failed: %v", err)
-			}
+			ls.sendFileDiagnostics(t.Context(), fileURI)
 
 			select {
 			case diag := <-receivedDiagnostics:

--- a/internal/lsp/server_aggregates_test.go
+++ b/internal/lsp/server_aggregates_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	"github.com/open-policy-agent/regal/internal/testutil"
+	"github.com/open-policy-agent/regal/internal/util"
 	"github.com/open-policy-agent/regal/pkg/report"
 )
 
@@ -261,33 +262,29 @@ import data.quz
 			if aggregateData, ok := entry["aggregate_data"].(map[string]any); ok {
 				if importsList, ok := aggregateData["imports"].([]any); ok {
 					for _, imp := range importsList {
-						if item, ok := imp.([]any); ok {
-							if pathList, ok := item[0].([]any); ok {
-								pathParts := []string{}
+						item := testutil.MustBe[[]any](t, imp)
+						if pathList, ok := item[0].([]any); ok {
+							pathParts := []string{}
 
-								for _, p := range pathList {
-									if pathStr, ok := p.(string); ok {
-										pathParts = append(pathParts, pathStr)
-									}
+							for _, p := range pathList {
+								if pathStr, ok := p.(string); ok {
+									pathParts = append(pathParts, pathStr)
 								}
-
-								imports = append(imports, strings.Join(pathParts, "."))
 							}
+
+							imports = append(imports, strings.Join(pathParts, "."))
 						}
 					}
 				}
 			}
 		}
 
-		slices.Sort(imports)
-
-		return imports
+		return util.Sorted(imports)
 	}
 
 	imports := determineImports(ls.cache.GetFileAggregates())
-
-	if exp, got := []string{"baz", "quz"}, imports; !slices.Equal(exp, got) {
-		t.Fatalf("global state imports unexpected, got %v exp %v", got, exp)
+	if exp := []string{"baz", "quz"}; !slices.Equal(exp, imports) {
+		t.Fatalf("global state imports unexpected, got %v exp %v", imports, exp)
 	}
 
 	// 2. check the aggregates for a file are updated after an update

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -24,7 +24,6 @@ import (
 
 const (
 	mainRegoFileName = "/main.rego"
-	fileURIScheme    = "file://"
 	// defaultTimeout is set based on the investigation done as part of
 	// https://github.com/open-policy-agent/regal/issues/931. 20 seconds is 10x the
 	// maximum time observed for an operation to complete.
@@ -116,13 +115,11 @@ func createPublishDiagnosticsHandler(t *testing.T, out io.Writer, messages messa
 				violations[i] = item.Code
 			}
 
-			slices.Sort(violations)
-
 			fileBase := filepath.Base(params.URI)
 			fmt.Fprintln(out, "createPublishDiagnosticsHandler: queue", fileBase, len(messages[fileBase]))
 
 			select {
-			case messages[fileBase] <- violations:
+			case messages[fileBase] <- util.Sorted(violations):
 			case <-time.After(1 * time.Second):
 				t.Fatalf("timeout writing to messages channel for %s", fileBase)
 			}

--- a/internal/roast/transforms/value.go
+++ b/internal/roast/transforms/value.go
@@ -21,11 +21,10 @@ func AnyToValue(x any) (ast.Value, error) {
 	case nil:
 		return ast.NullValue, nil
 	case bool:
-		return ast.InternedTerm(x).Value, nil
+		return ast.InternedValue(x), nil
 	case float64:
-		ix := int(x)
-		if x == float64(ix) {
-			return ast.InternedTerm(ix).Value, nil
+		if ix := int(x); x == float64(ix) {
+			return ast.InternedValue(ix), nil
 		}
 
 		return ast.Number(strconv.FormatFloat(x, 'g', -1, 64)), nil
@@ -36,7 +35,7 @@ func AnyToValue(x any) (ast.Value, error) {
 
 		return ast.Number(x), nil
 	case string:
-		return ast.InternedTerm(x).Value, nil
+		return ast.InternedValue(x), nil
 	case []string:
 		if len(x) == 0 {
 			return ast.InternedEmptyArrayValue, nil
@@ -45,7 +44,7 @@ func AnyToValue(x any) (ast.Value, error) {
 		r := util.NewPtrSlice[ast.Term](len(x))
 
 		for i, s := range x {
-			r[i].Value = ast.InternedTerm(s).Value
+			r[i].Value = ast.InternedValue(s)
 		}
 
 		return ast.NewArray(r...), nil
@@ -75,7 +74,7 @@ func AnyToValue(x any) (ast.Value, error) {
 		idx := 0
 
 		for k, v := range x {
-			kvs[idx].Value = ast.InternedTerm(k).Value
+			kvs[idx].Value = ast.InternedValue(k)
 
 			v, err := AnyToValue(v)
 			if err != nil {

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -1,0 +1,231 @@
+package semver
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// reMetaIdentifier matches pre-release and metadata identifiers against the spec requirements.
+var reMetaIdentifier = regexp.MustCompile(`^[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*$`)
+
+// Version represents a parsed SemVer.
+type Version struct {
+	Major      int64
+	Minor      int64
+	Patch      int64
+	PreRelease string `json:"PreRelease,omitempty"`
+	Metadata   string `json:"Metadata,omitempty"`
+}
+
+// Parse constructs new semver Version from version string.
+func Parse(version string) (v Version, err error) {
+	version = strings.TrimPrefix(version, "v")
+
+	version, v.Metadata = cut(version, '+')
+	if v.Metadata != "" && !reMetaIdentifier.MatchString(v.Metadata) {
+		return v, fmt.Errorf("invalid metadata identifier: %s", v.Metadata)
+	}
+
+	version, v.PreRelease = cut(version, '-')
+	if v.PreRelease != "" && !reMetaIdentifier.MatchString(v.PreRelease) {
+		return v, fmt.Errorf("invalid pre-release identifier: %s", v.PreRelease)
+	}
+
+	if strings.Count(version, ".") != 2 {
+		return v, fmt.Errorf("%s should contain major, minor, and patch versions", version)
+	}
+
+	major, after := cut(version, '.')
+	if v.Major, err = strconv.ParseInt(major, 10, 64); err != nil {
+		return v, err
+	}
+
+	minor, after := cut(after, '.')
+	if v.Minor, err = strconv.ParseInt(minor, 10, 64); err != nil {
+		return v, err
+	}
+
+	if v.Patch, err = strconv.ParseInt(after, 10, 64); err != nil {
+		return v, err
+	}
+
+	return v, nil
+}
+
+// MustParse is like Parse but panics if the version string is invalid instead of returning an error.
+func MustParse(version string) Version {
+	v, err := Parse(version)
+	if err != nil {
+		panic(err)
+	}
+
+	return v
+}
+
+// AppendText appends the textual representation of the version to b and returns the extended buffer.
+// This method conforms to the encoding.TextAppender interface, and is useful for serializing the Version
+// without allocating, provided the caller has pre-allocated sufficient space in b.
+func (v Version) AppendText(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, 0, length(v))
+	}
+
+	b = append(strconv.AppendInt(b, v.Major, 10), '.')
+	b = append(strconv.AppendInt(b, v.Minor, 10), '.')
+	b = strconv.AppendInt(b, v.Patch, 10)
+
+	if v.PreRelease != "" {
+		b = append(append(b, '-'), v.PreRelease...)
+	}
+
+	if v.Metadata != "" {
+		b = append(append(b, '+'), v.Metadata...)
+	}
+
+	return b, nil
+}
+
+// String returns the string representation of the version.
+func (v Version) String() string {
+	bs := make([]byte, 0, length(v))
+	bs, _ = v.AppendText(bs)
+
+	return string(bs)
+}
+
+// Compare tests if v is less than, equal to, or greater than other, returning -1, 0, or +1 respectively.
+// Comparison is based on the SemVer specification (https://semver.org/#spec-item-11).
+func (v Version) Compare(other Version) int {
+	if v.Major > other.Major {
+		return 1
+	} else if v.Major < other.Major {
+		return -1
+	}
+
+	if v.Minor > other.Minor {
+		return 1
+	} else if v.Minor < other.Minor {
+		return -1
+	}
+
+	if v.Patch > other.Patch {
+		return 1
+	} else if v.Patch < other.Patch {
+		return -1
+	}
+
+	if v.PreRelease == other.PreRelease {
+		return 0
+	}
+
+	// if two versions are otherwise equal it is the one without a pre-release that is greater
+	if v.PreRelease == "" && other.PreRelease != "" {
+		return 1
+	}
+
+	if other.PreRelease == "" && v.PreRelease != "" {
+		return -1
+	}
+
+	a, afterA := cut(v.PreRelease, '.')
+	b, afterB := cut(other.PreRelease, '.')
+
+	for {
+		if a == "" && b != "" {
+			return -1
+		}
+
+		if a != "" && b == "" {
+			return 1
+		}
+
+		aIsInt := isAllDecimals(a)
+		bIsInt := isAllDecimals(b)
+
+		// numeric identifiers have lower precedence than non-numeric
+		if aIsInt && !bIsInt {
+			return -1
+		} else if !aIsInt && bIsInt {
+			return 1
+		}
+
+		if aIsInt && bIsInt {
+			aInt, _ := strconv.Atoi(a)
+			bInt, _ := strconv.Atoi(b)
+
+			if aInt > bInt {
+				return 1
+			} else if aInt < bInt {
+				return -1
+			}
+		} else {
+			// string comparison
+			if a > b {
+				return 1
+			} else if a < b {
+				return -1
+			}
+		}
+
+		// a larger set of pre-release fields has a higher precedence than a
+		// smaller set, if all of the preceding identifiers are equal.
+		if afterA != "" && afterB == "" {
+			return 1
+		} else if afterA == "" && afterB != "" {
+			return -1
+		}
+
+		a, afterA = cut(afterA, '.')
+		b, afterB = cut(afterB, '.')
+	}
+}
+
+func isAllDecimals(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+
+	return s != ""
+}
+
+// length allows calculating the length of the version for pre-allocation.
+func length(v Version) int {
+	n := numDigitsInt64(v.Major) + numDigitsInt64(v.Minor) + numDigitsInt64(v.Patch) + 2
+	if v.PreRelease != "" {
+		n += len(v.PreRelease) + 1
+	}
+
+	if v.Metadata != "" {
+		n += len(v.Metadata) + 1
+	}
+
+	return n
+}
+
+// cut is a *slightly* faster version of strings.Cut only accepting
+// single byte separators, and skipping the boolean return value.
+func cut(s string, sep byte) (before, after string) {
+	if i := strings.IndexByte(s, sep); i >= 0 {
+		return s[:i], s[i+1:]
+	}
+
+	return s, ""
+}
+
+// TODO: remove in favor of util.NumDigitsInt64 from OPA, when available.
+func numDigitsInt64(n int64) int {
+	if n == 0 {
+		return 1
+	}
+
+	if n < 0 {
+		n = -n
+	}
+
+	return int(math.Log10(float64(n))) + 1
+}

--- a/internal/semver/semver_test.go
+++ b/internal/semver/semver_test.go
@@ -1,0 +1,214 @@
+package semver_test
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/regal/internal/semver"
+)
+
+type (
+	fixture struct {
+		greater string
+		lesser  string
+	}
+
+	compareFixture struct {
+		greater semver.Version
+		lesser  semver.Version
+	}
+)
+
+// test fixtures and comparison tests originally from: https://github.com/coreos/go-semver
+var (
+	fixtures = []fixture{
+		{"0.0.0", "0.0.0-foo"},
+		{"0.0.1", "0.0.0"},
+		{"1.0.0", "0.9.9"},
+		{"0.10.0", "0.9.0"},
+		{"0.99.0", "0.10.0"},
+		{"2.0.0", "1.2.3"},
+		{"0.0.0", "0.0.0-foo"},
+		{"0.0.1", "0.0.0"},
+		{"1.0.0", "0.9.9"},
+		{"0.10.0", "0.9.0"},
+		{"0.99.0", "0.10.0"},
+		{"2.0.0", "1.2.3"},
+		{"0.0.0", "0.0.0-foo"},
+		{"0.0.1", "0.0.0"},
+		{"1.0.0", "0.9.9"},
+		{"0.10.0", "0.9.0"},
+		{"0.99.0", "0.10.0"},
+		{"2.0.0", "1.2.3"},
+		{"1.2.3", "1.2.3-asdf"},
+		{"1.2.3", "1.2.3-4"},
+		{"1.2.3", "1.2.3-4-foo"},
+		{"1.2.3-5-foo", "1.2.3-5"},
+		{"1.2.3-5", "1.2.3-4"},
+		{"1.2.3-5-foo", "1.2.3-5-Foo"},
+		{"3.0.0", "2.7.2+asdf"},
+		{"3.0.0+foobar", "2.7.2"},
+		{"1.2.3-a.10", "1.2.3-a.5"},
+		{"1.2.3-a.b", "1.2.3-a.5"},
+		{"1.2.3-a.b", "1.2.3-a"},
+		{"1.2.3-a.b.c.10.d.5", "1.2.3-a.b.c.5.d.100"},
+		{"1.0.0", "1.0.0-rc.1"},
+		{"1.0.0-rc.2", "1.0.0-rc.1"},
+		{"1.0.0-rc.1", "1.0.0-beta.11"},
+		{"1.0.0-beta.11", "1.0.0-beta.2"},
+		{"1.0.0-beta.2", "1.0.0-beta"},
+		{"1.0.0-beta", "1.0.0-alpha.beta"},
+		{"1.0.0-alpha.beta", "1.0.0-alpha.1"},
+		{"1.0.0-alpha.1", "1.0.0-alpha"},
+		{"1.2.3-rc.1-1-1hash", "1.2.3-rc.2"},
+	}
+
+	equalFixtures = []string{
+		"0.0.0",
+		"1.2.3",
+		"1.2.3-rc.1",
+		"1.2.3+build.123",
+		"1.2.3-rc.1+build.123",
+		"1.2.3-rc.1+build.123.444",
+	}
+)
+
+func TestCompareEqual(t *testing.T) {
+	t.Parallel()
+
+	for _, v := range equalFixtures {
+		a := semver.MustParse(v)
+		o := a
+
+		if a.Compare(o) != 0 {
+			t.Errorf("Expected %s to be equal to %s", a, o)
+		}
+	}
+}
+
+func TestCompare(t *testing.T) {
+	t.Parallel()
+
+	for _, v := range fixtures {
+		gt := semver.MustParse(v.greater)
+		lt := semver.MustParse(v.lesser)
+
+		if gt.Compare(lt) <= 0 {
+			t.Errorf("%s should be greater than %s", gt, lt)
+		}
+
+		if lt.Compare(gt) > 0 {
+			t.Errorf("%s should not be greater than %s", lt, gt)
+		}
+	}
+}
+
+func TestBadInput(t *testing.T) {
+	t.Parallel()
+
+	bad := []string{
+		"1.2",
+		"1.2.3x",
+		"0x1.3.4",
+		"-1.2.3",
+		"1.2.3.4",
+		"0.88.0-11_e4e5dcabb",
+		"0.88.0+11_e4e5dcabb",
+	}
+	for _, b := range bad {
+		if _, err := semver.Parse(b); err == nil {
+			t.Error("Improperly accepted value: ", b)
+		}
+	}
+}
+
+func BenchmarkCompare(b *testing.B) {
+	versionFixtures := make([]compareFixture, 0, len(fixtures))
+	for _, v := range fixtures {
+		versionFixtures = append(versionFixtures, compareFixture{
+			greater: semver.MustParse(v.greater),
+			lesser:  semver.MustParse(v.lesser),
+		})
+	}
+
+	for b.Loop() {
+		for _, v := range versionFixtures {
+			if v.greater.Compare(v.lesser) <= 0 {
+				b.Fatalf("%s should be greater than %s", v.greater, v.lesser)
+			}
+
+			if v.lesser.Compare(v.greater) > 0 {
+				b.Fatalf("%s should not be greater than %s", v.lesser, v.greater)
+			}
+		}
+	}
+}
+
+func BenchmarkCompareEqual(b *testing.B) {
+	versionFixtures := make([]semver.Version, 0, len(equalFixtures))
+	for _, v := range equalFixtures {
+		versionFixtures = append(versionFixtures, semver.MustParse(v))
+	}
+
+	for b.Loop() {
+		for _, v := range versionFixtures {
+			o := v
+			if v.Compare(o) != 0 {
+				b.Fatalf("Expected %s to be equal to %s", v, o)
+			}
+		}
+	}
+}
+
+func BenchmarkString(b *testing.B) {
+	v := semver.MustParse("1.2.3-alpha.1+build.123")
+
+	for b.Loop() {
+		if s := v.String(); s != "1.2.3-alpha.1+build.123" {
+			b.Fatalf("unexpected version string: %s", s)
+		}
+	}
+}
+
+func BenchmarkAppendText(b *testing.B) {
+	v := semver.MustParse("1.2.3-alpha.1+build.123")
+
+	for b.Loop() {
+		_, err := v.AppendText(nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkAppendTextPreAllocated(b *testing.B) {
+	v, err := semver.Parse("1.2.3-alpha.1+build.123")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	buf := make([]byte, 0, 32)
+
+	for b.Loop() {
+		if buf, err = v.AppendText(buf); err != nil {
+			b.Fatal(err)
+		}
+
+		if string(buf) != "1.2.3-alpha.1+build.123" {
+			b.Fatal("unexpected version string")
+		}
+
+		buf = buf[:0]
+	}
+}
+
+func BenchmarkParseSimple(b *testing.B) {
+	for b.Loop() {
+		semver.MustParse("1.2.3")
+	}
+}
+
+func BenchmarkParsePrereleaseAndMetadata(b *testing.B) {
+	for b.Loop() {
+		semver.MustParse("1.2.3-alpha.1+build.123")
+	}
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"math"
@@ -297,4 +298,35 @@ func Zero[T any]() T {
 	var zero T
 
 	return zero
+}
+
+// AnySliceTo converts a slice of any to a slice of T, returning an error if any element cannot be casted.
+func AnySliceTo[T any](in []any) ([]T, error) {
+	out := make([]T, 0, len(in))
+
+	for _, item := range in {
+		casted, ok := item.(T)
+		if !ok {
+			return nil, fmt.Errorf("expected %T, got %T", casted, item)
+		}
+
+		out = append(out, casted)
+	}
+
+	return out, nil
+}
+
+// Sorted sorts s in place using slices.Sort and returns it
+// Can be convenient for use in return values, map definitions, chaining, etc.
+func Sorted[T cmp.Ordered](s []T) []T {
+	slices.Sort(s)
+
+	return s
+}
+
+// Reversed reverses s in place using slices.Reverse and returns it.
+func Reversed[T any](s []T) []T {
+	slices.Reverse(s)
+
+	return s
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/ast"
@@ -131,4 +132,27 @@ func BenchmarkFilter(b *testing.B) {
 			_ = Filter(strings, pred)
 		}
 	})
+}
+
+// No allocations
+func BenchmarkSorted(b *testing.B) {
+	unsorted := []string{
+		"the", "quick", "brown", "fox", "jumped", "over", "the", "lazy", "dog",
+		"foo", "bar", "baz", "qux", "quux", "corge", "grault", "garply", "waldo", "fred", "plugh", "xyzzy", "thud",
+		"x", "y", "z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j",
+	}
+	sorted := []string{
+		"a", "b", "bar", "baz", "brown", "c", "corge", "d", "dog", "e", "f", "foo", "fox", "fred", "g", "garply",
+		"grault", "h", "i", "j", "jumped", "lazy", "over", "plugh", "quick", "quux", "qux", "the", "the", "thud",
+		"waldo", "x", "xyzzy", "y", "z",
+	}
+
+	var got []string
+	for b.Loop() {
+		got = Sorted(unsorted)
+	}
+
+	if !slices.Equal(got, sorted) {
+		b.Fatalf("expected %v, got %v", sorted, got)
+	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -302,9 +302,7 @@ func FindBundleRootDirectories(path string) ([]string, error) {
 		return nil, fmt.Errorf("failed to walk path: %w", err)
 	}
 
-	slices.Sort(foundBundleRoots)
-
-	return slices.Compact(foundBundleRoots), nil
+	return slices.Compact(util.Sorted(foundBundleRoots)), nil
 }
 
 // TODO: this doesn't properly handle .regal.yaml??

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -13,6 +13,7 @@ import (
 	outil "github.com/open-policy-agent/opa/v1/util"
 	"github.com/open-policy-agent/opa/v1/util/test"
 
+	"github.com/open-policy-agent/regal/internal/io"
 	"github.com/open-policy-agent/regal/internal/testutil"
 	"github.com/open-policy-agent/regal/internal/util"
 )
@@ -371,7 +372,7 @@ func TestUnmarshalConfigDefaultCapabilities(t *testing.T) {
 	t.Parallel()
 
 	conf := testutil.MustUnmarshalYAML[Config](t, []byte("rules: {}\n"))
-	caps := ast.CapabilitiesForThisVersion()
+	caps := io.Capabilities()
 
 	if exp, got := len(caps.Builtins), len(conf.Capabilities.Builtins); exp != got {
 		t.Errorf("expected %d builtins, got %d", exp, got)

--- a/pkg/config/filter_test.go
+++ b/pkg/config/filter_test.go
@@ -99,7 +99,7 @@ func TestFilterIgnoredPaths(t *testing.T) {
 			slices.Sort(filtered)
 			slices.Sort(tc.expected)
 
-			if !cmp.Equal(filtered, tc.expected) {
+			if !slices.Equal(filtered, tc.expected) {
 				t.Errorf("filtered paths mismatch (-want +got):\n%s", cmp.Diff(tc.expected, filtered))
 			}
 		})

--- a/pkg/fixer/fixer.go
+++ b/pkg/fixer/fixer.go
@@ -177,7 +177,7 @@ func (f *Fixer) applyLinterFixes(
 	fp fileprovider.FileProvider,
 	fixReport *Report,
 ) error {
-	enabledRules, err := l.DetermineEnabledRules(ctx)
+	enabledRules, _, err := l.DetermineEnabledRules(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to determine enabled rules: %w", err)
 	}

--- a/pkg/fixer/reporter.go
+++ b/pkg/fixer/reporter.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"slices"
 
 	"github.com/open-policy-agent/opa/v1/util"
 
+	rutil "github.com/open-policy-agent/regal/internal/util"
 	"github.com/open-policy-agent/regal/pkg/fixer/fixes"
 )
 
@@ -62,11 +62,9 @@ func (r *PrettyReporter) ReportConflicts(fixReport *Report) error {
 			fmt.Fprintln(r.outputWriter, "In project root:", rootKey)
 
 			for _, file := range conflictingFiles {
-				conflicts := fixReport.conflictsSourceFile[rootKey][file]
-				slices.Sort(conflicts)
-
 				fmt.Fprintln(r.outputWriter, "Cannot overwrite existing file:", relOrDefault(rootKey, file, file))
 
+				conflicts := rutil.Sorted(fixReport.conflictsSourceFile[rootKey][file])
 				for _, oldPath := range conflicts {
 					fmt.Fprintln(r.outputWriter, "-", relOrDefault(rootKey, oldPath, oldPath))
 				}
@@ -92,18 +90,14 @@ func (r *PrettyReporter) ReportConflicts(fixReport *Report) error {
 				continue
 			}
 
-			conflictingFiles := util.KeysSorted(cs)
-
 			fmt.Fprintln(r.outputWriter, "In project root:", rootKey)
 
+			conflictingFiles := util.KeysSorted(cs)
 			for _, file := range conflictingFiles {
 				fmt.Fprintln(r.outputWriter, "Cannot move multiple files to:", relOrDefault(rootKey, file, file))
 
 				// get the old paths from the movedFiles since that includes all the files moved, not just the conflicting ones
-				oldPaths := fixReport.movedFiles[file]
-				slices.Sort(oldPaths)
-
-				for _, oldPath := range oldPaths {
+				for _, oldPath := range rutil.Sorted(fixReport.movedFiles[file]) {
 					fmt.Fprintln(r.outputWriter, "-", relOrDefault(rootKey, oldPath, oldPath))
 				}
 			}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -2,7 +2,7 @@ package report
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/open-policy-agent/opa/v1/rego"
 
@@ -168,13 +168,12 @@ func (r *Report) AddProfileEntries(prof map[string]ProfileEntry) {
 
 func (r *Report) AggregateProfileToSortedProfile(numResults int) {
 	r.Profile = make([]ProfileEntry, 0, len(r.AggregateProfile))
-
 	for loc := range r.AggregateProfile {
 		r.Profile = append(r.Profile, r.AggregateProfile[loc])
 	}
 
-	sort.Slice(r.Profile, func(i, j int) bool {
-		return r.Profile[i].TotalTimeNs > r.Profile[j].TotalTimeNs
+	slices.SortFunc(r.Profile, func(a, b ProfileEntry) int {
+		return int(b.TotalTimeNs - a.TotalTimeNs)
 	})
 
 	if numResults <= 0 || numResults > len(r.Profile) {

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"slices"
 	"strings"
 
 	"github.com/fatih/color"
@@ -167,9 +166,7 @@ func (tr PrettyReporter) Publish(_ context.Context, r report.Report) error {
 	}
 
 	if fixableViolations.Size() > 0 {
-		violationKeys := fixableViolations.Items()
-		slices.Sort(violationKeys)
-
+		violationKeys := util.Sorted(fixableViolations.Items())
 		_, err = fmt.Fprintf(
 			tr.out,
 			`
@@ -466,9 +463,7 @@ func (tr JUnitReporter) Publish(_ context.Context, r report.Report) error {
 		violationsPerFile[violation.Location.File] = append(violationsPerFile[violation.Location.File], violation)
 	}
 
-	slices.Sort(files)
-
-	for _, file := range files {
+	for _, file := range util.Sorted(files) {
 		testsuite := junit.Testsuite{Name: file}
 
 		for _, violation := range violationsPerFile[file] { //nolint:gocritic


### PR DESCRIPTION
- Use a single eval to get both enabled regular and aggregate rules
- Prefer to use once-initialized `io.Capabilities` over `ast.CapabilitiesForThisVersion`
- Add `rego.BuiltinsForDefaultCapabilities` for the language server
- Some light refactoring, mainly to have code use existing util methods

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->