### PR TITLE
Various performance improvements

### DIFF
--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -18,13 +17,11 @@ func init() {
 		Long:   "Show capabilities for Regal",
 		RunE: func(*cobra.Command, []string) error {
 			bs, err := json.MarshalIndent(io.Capabilities(), "", "  ")
-			if err != nil {
-				return fmt.Errorf("failed marshalling capabilities: %w", err)
+			if err == nil {
+				_, err = os.Stdout.Write(append(bs, '\n'))
 			}
 
-			fmt.Fprintln(os.Stdout, string(bs))
-
-			return nil
+			return err
 		},
 	}
 

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -62,12 +62,5 @@ func parse(args []string) error {
 		return err
 	}
 
-	output, err := encoding.JSON().MarshalIndent(enhancedAST, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	_, err = os.Stdout.Write(output)
-
-	return err
+	return encoding.NewIndentEncoder(os.Stdout, "", "  ").Encode(enhancedAST)
 }

--- a/internal/capabilities/capabilities.go
+++ b/internal/capabilities/capabilities.go
@@ -221,9 +221,7 @@ func semverSort(stringVersions []string) {
 	}
 
 	if len(invalid) > 0 {
-		slices.Sort(invalid)
-		slices.Reverse(invalid)
-		copy(stringVersions[len(versions):], invalid)
+		copy(stringVersions[len(versions):], util.Reversed(util.Sorted(invalid)))
 	}
 }
 

--- a/internal/io/files/filter/filter.go
+++ b/internal/io/files/filter/filter.go
@@ -23,7 +23,7 @@ func Directories(_ string, info os.DirEntry) bool {
 	return info.IsDir()
 }
 
-// Filenames filters files by their exact name, not counting the path.
+// Filenames filters files by their exact name, not including the path.
 func Filenames(names ...string) Func {
 	return func(_ string, info os.DirEntry) bool {
 		return slices.ContainsFunc(names, func(name string) bool {
@@ -34,9 +34,9 @@ func Filenames(names ...string) Func {
 
 // Suffixes filters any path that has a suffix matching any of the provided suffixes.
 func Suffixes(suffixes ...string) Func {
-	return func(_ string, info os.DirEntry) bool {
+	return func(path string, _ os.DirEntry) bool {
 		return slices.ContainsFunc(suffixes, func(suffix string) bool {
-			return strings.HasSuffix(info.Name(), suffix)
+			return strings.HasSuffix(path, suffix)
 		})
 	}
 }
@@ -49,6 +49,10 @@ func Not(filter Func) Func {
 	}
 }
 
-func RegoTests(_ string, info os.DirEntry) bool {
-	return strings.HasSuffix(info.Name(), "_test.rego") && info.Name() != "todo_test.rego"
+func RegoTests(path string, info os.DirEntry) bool {
+	return strings.HasSuffix(path, "_test.rego") && info.Name() != "todo_test.rego"
+}
+
+func NotRego(path string, _ os.DirEntry) bool {
+	return !strings.HasSuffix(path, ".rego")
 }

--- a/internal/lsp/documentsymbol/documentsymbol.go
+++ b/internal/lsp/documentsymbol/documentsymbol.go
@@ -92,16 +92,17 @@ func All(contents string, module *ast.Module, builtins map[string]*ast.Builtin) 
 }
 
 func locationToRange(location *ast.Location) types.Range {
-	lines := bytes.Split(location.Text, []byte("\n"))
-	numLines := len(lines)
 	startLine := util.SafeIntToUint(location.Row - 1)
+	numLines := bytes.Count(location.Text, []byte{'\n'}) + 1
 
 	endLine := startLine
-	if numLines != 1 {
+	if numLines > 1 {
 		endLine += util.SafeIntToUint(numLines - 1)
 	}
 
-	return types.RangeBetween(startLine, location.Col-1, endLine, len(lines[numLines-1]))
+	endLineContent := util.LineContents(location.Text, endLine-startLine)
+
+	return types.RangeBetween(startLine, location.Col-1, endLine, len(endLineContent))
 }
 
 func toWorkspaceSymbol(docSym types.DocumentSymbol, docURL string) types.WorkspaceSymbol {

--- a/internal/lsp/lint.go
+++ b/internal/lsp/lint.go
@@ -72,12 +72,10 @@ func updateParse(ctx context.Context, opts updateParseOpts) (bool, error) {
 		return false, fmt.Errorf("failed to get file contents for uri %q", opts.FileURI)
 	}
 
-	lines := strings.Split(content, "\n")
-	numLines := len(lines)
-
 	options := rparse.ParserOptions()
 	options.RegoVersion = opts.RegoVersion
 
+	numLines := strings.Count(content, "\n") + 1
 	presentedFileName := uri.ToRelativePath(opts.FileURI, opts.WorkspaceRootURI)
 
 	module, err := rparse.ModuleWithOpts(presentedFileName, content, options)
@@ -125,6 +123,7 @@ func updateParse(ctx context.Context, opts updateParseOpts) (bool, error) {
 		}
 	}
 
+	lines := strings.Split(content, "\n")
 	diags := make([]types.Diagnostic, 0, len(astErrors))
 
 	for _, astError := range astErrors {

--- a/internal/roast/encoding/array.go
+++ b/internal/roast/encoding/array.go
@@ -19,17 +19,13 @@ func (*arrayCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 
 	stream.WriteArrayStart()
 
-	i := 0
-
-	arr.Foreach(func(term *ast.Term) {
+	for i := range arr.Len() {
 		if i > 0 {
 			stream.WriteMore()
 		}
 
-		stream.WriteVal(term)
-
-		i++
-	})
+		stream.WriteVal(arr.Elem(i))
+	}
 
 	stream.WriteArrayEnd()
 }

--- a/internal/roast/encoding/head_test.go
+++ b/internal/roast/encoding/head_test.go
@@ -14,37 +14,12 @@ func TestRuleHeadEncoding(t *testing.T) {
 	head := ast.Head{
 		Name: "omitted",
 		Reference: ast.Ref{
-			{
-				Value: ast.Var("foo"),
-				Location: &ast.Location{
-					Row:  1,
-					Col:  1,
-					Text: []byte("foo"),
-				},
-			},
-			{
-				Value: ast.String("bar"),
-				Location: &ast.Location{
-					Row:  1,
-					Col:  5, // following "foo."
-					Text: []byte("bar"),
-				},
-			},
+			{Value: ast.Var("foo"), Location: &ast.Location{Row: 1, Col: 1, Text: []byte("foo")}},
+			{Value: ast.String("bar"), Location: &ast.Location{Row: 1, Col: 5, Text: []byte("bar")}},
 		},
-		Value: &ast.Term{
-			Value: ast.Boolean(true),
-			Location: &ast.Location{
-				Row:  1,
-				Col:  12, // following "foo.bar := "
-				Text: []byte("true"),
-			},
-		},
-		Assign: true,
-		Location: &ast.Location{
-			Row:  1,
-			Col:  1,
-			Text: []byte("foo.bar := true"),
-		},
+		Value:    &ast.Term{Value: ast.Boolean(true), Location: &ast.Location{Row: 1, Col: 12, Text: []byte("true")}},
+		Assign:   true,
+		Location: &ast.Location{Row: 1, Col: 1, Text: []byte("foo.bar := true")},
 	}
 
 	bs, err := jsoniter.ConfigFastest.MarshalIndent(head, "", "  ")

--- a/internal/roast/encoding/location.go
+++ b/internal/roast/encoding/location.go
@@ -1,65 +1,23 @@
 package encoding
 
 import (
-	"bytes"
-	"strconv"
-	"strings"
-	"sync"
 	"unsafe"
 
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/open-policy-agent/opa/v1/ast"
+
+	"github.com/open-policy-agent/regal/pkg/roast/rast"
 )
 
 type locationCodec struct{}
-
-var newLine = []byte("\n")
-
-var sbPool = sync.Pool{
-	New: func() any {
-		return new(strings.Builder)
-	},
-}
 
 func (*locationCodec) IsEmpty(_ unsafe.Pointer) bool {
 	return false
 }
 
 func (*locationCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
-	location := *((*ast.Location)(ptr))
+	location := (*ast.Location)(ptr)
 
-	var endRow, endCol int
-	if location.Text == nil {
-		endRow = location.Row
-		endCol = location.Col
-	} else {
-		lines := bytes.Split(location.Text, newLine)
-
-		numLines := len(lines)
-
-		endRow = location.Row + numLines - 1
-
-		if numLines == 1 {
-			endCol = location.Col + len(location.Text)
-		} else {
-			lastLine := lines[numLines-1]
-			endCol = len(lastLine) + 1
-		}
-	}
-
-	sb := sbPool.Get().(*strings.Builder) //nolint:forcetypeassert
-
-	sb.WriteString(strconv.Itoa(location.Row))
-	sb.WriteByte(':')
-	sb.WriteString(strconv.Itoa(location.Col))
-	sb.WriteByte(':')
-	sb.WriteString(strconv.Itoa(endRow))
-	sb.WriteByte(':')
-	sb.WriteString(strconv.Itoa(endCol))
-
-	stream.WriteString(sb.String())
-
-	sb.Reset()
-	sbPool.Put(sb)
+	stream.SetBuffer(append(rast.AppendLocation(append(stream.Buffer(), '"'), location), '"'))
 }

--- a/internal/roast/encoding/location_test.go
+++ b/internal/roast/encoding/location_test.go
@@ -16,41 +16,28 @@ func TestLocation(t *testing.T) {
 		name     string
 		location ast.Location
 		expected string
-	}{
-		{
-			name: "multiple lines",
-			location: ast.Location{
-				Row:  5,
-				Col:  2,
-				Text: []byte("allow if {\n	input.foo == true\n}"),
-			},
-			expected: "5:2:7:2",
-		},
-		{
-			name: "single line",
-			location: ast.Location{
-				Row:  1,
-				Col:  1,
-				Text: []byte("package example"),
-			},
-			expected: "1:1:1:16",
-		},
-	}
-
-	json := jsoniter.ConfigFastest
+	}{{
+		name:     "multiple lines",
+		location: ast.Location{Row: 5, Col: 2, Text: []byte("allow if {\n	input.foo == true\n}")},
+		expected: "5:2:7:2",
+	}, {
+		name:     "single line",
+		location: ast.Location{Row: 1, Col: 1, Text: []byte("package example")},
+		expected: "1:1:1:16",
+	}}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			stream := json.BorrowStream(nil)
-			defer json.ReturnStream(stream)
-
+			stream := jsoniter.ConfigFastest.BorrowStream(nil)
 			stream.WriteVal(tc.location)
 
 			if string(stream.Buffer()) != fmt.Sprintf("\"%s\"", tc.expected) {
 				t.Fatalf("expected %s but got %s", tc.expected, string(stream.Buffer()))
 			}
+
+			jsoniter.ConfigFastest.ReturnStream(stream)
 		})
 	}
 }
@@ -60,10 +47,7 @@ func TestLocationHeadValue(t *testing.T) {
 	// e.g. the end column would be presented as before the start column.
 	t.Parallel()
 
-	module := ast.MustParseModule("package foo.bar\n\nrule := true")
-	json := jsoniter.ConfigFastest
-
-	out, err := json.MarshalIndent(module, "", "  ")
+	out, err := jsoniter.ConfigFastest.MarshalIndent(ast.MustParseModule("package foo.bar\n\nrule := true"), "", "  ")
 	if err != nil {
 		t.Fatalf("failed to marshal module: %v", err)
 	}

--- a/internal/roast/encoding/module_test.go
+++ b/internal/roast/encoding/module_test.go
@@ -228,8 +228,7 @@ func TestSerializedModuleSize(t *testing.T) {
 	}
 }
 
-// BenchmarkSerializeModule-16    	    3361	    354640 ns/op	  216756 B/op	    9773 allocs/op
-
+// 285329 ns/op	  125555 B/op	    3094 allocs/op
 func BenchmarkSerializeModule(b *testing.B) {
 	policy := mustReadTestFile(b, "testdata/policy.rego")
 	module := ast.MustParseModuleWithOpts(string(policy), ast.ParserOptions{ProcessAnnotation: true})

--- a/internal/roast/transforms/module/module_test.go
+++ b/internal/roast/transforms/module/module_test.go
@@ -63,8 +63,8 @@ setcomp := {x | some x in input}
 	}
 }
 
-// BenchmarkModuleToValue/ToValue-12            26172     45026 ns/op   65514 B/op    1804 allocs/op
-// BenchmarkModuleToValue/RoundTrip-12           9379    120571 ns/op  168927 B/op    4148 allocs/op
+// BenchmarkModuleToValue/ToValue-16         	   25171	     46355 ns/op	   65489 B/op	    1802 allocs/op
+// BenchmarkModuleToValue/RoundTrip-16       	   10000	    119018 ns/op	  166038 B/op	    3924 allocs/op
 func BenchmarkModuleToValue(b *testing.B) {
 	policy := `# METADATA
 # title: p p p

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,9 +1,11 @@
 package util
 
 import (
+	"bytes"
 	"cmp"
 	"errors"
 	"fmt"
+	"iter"
 	"math"
 	"net"
 	"os"
@@ -329,4 +331,30 @@ func Reversed[T any](s []T) []T {
 	slices.Reverse(s)
 
 	return s
+}
+
+// LineContents returns the contents on line lineNum (0-indexed) from document.
+// This function assumes the lineNum is known to be contained within the document,.
+func LineContents(document []byte, lineNum uint) []byte {
+	for i, line := range Lines(document) {
+		if i == lineNum {
+			return bytes.TrimSuffix(line, []byte{'\n'})
+		}
+	}
+
+	return nil
+}
+
+// Lines works like [bytes.Lines] but yields both the line number (0-indexed) and the line contents.
+func Lines(s []byte) iter.Seq2[uint, []byte] {
+	return func(yield func(uint, []byte) bool) {
+		var lineNum uint
+		for line := range bytes.Lines(s) {
+			if !yield(lineNum, line) {
+				return
+			}
+
+			lineNum++
+		}
+	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -366,12 +366,12 @@ func AllRegoVersions(root string, conf *Config) (map[string]ast.RegoVersion, err
 	}
 
 	for _, dir := range manifestLocations {
-		f, err := os.ReadFile(filepath.Join(root, dir, ".manifest"))
+		b, err := os.ReadFile(filepath.Join(root, dir, ".manifest"))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read manifest file: %w", err)
 		}
 
-		manifest, err := encoding.JSONUnmarshalTo[bundle.Manifest](f)
+		manifest, err := encoding.JSONUnmarshalTo[bundle.Manifest](b)
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal manifest file: %w", err)
 		}

--- a/pkg/config/filter.go
+++ b/pkg/config/filter.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/gobwas/glob"
 
-	"github.com/open-policy-agent/opa/v1/bundle"
-
 	"github.com/open-policy-agent/regal/internal/io/files"
 	"github.com/open-policy-agent/regal/internal/io/files/filter"
 	"github.com/open-policy-agent/regal/internal/util"
@@ -16,14 +14,14 @@ import (
 
 func FilterIgnoredPaths(paths, ignore []string, checkExists bool, pathPrefix string) (filtered []string, err error) {
 	// - special case for stdin, return as is
-	if len(paths) == 1 && paths[0] == "-" || !checkExists && len(ignore) == 0 {
+	if len(paths) == 0 || len(paths) == 1 && paths[0] == "-" || !checkExists && len(ignore) == 0 {
 		return paths, nil
 	}
 
 	if checkExists {
 		for _, path := range paths {
 			filtered, err = files.DefaultWalkReducer(path, filtered).
-				WithFilters(filter.Not(filter.Suffixes(bundle.RegoExt))).
+				WithFilters(filter.NotRego).
 				WithStatBeforeWalk(true).
 				Reduce(files.PathAppendReducer)
 			if err != nil {
@@ -31,8 +29,7 @@ func FilterIgnoredPaths(paths, ignore []string, checkExists bool, pathPrefix str
 			}
 		}
 
-		// Use forward slash since all paths are normalized to forward slashes for glob matching
-		return filterPaths(filtered, ignore, util.EnsureSuffix(pathPrefix, "/"))
+		paths = filtered
 	}
 
 	// Use forward slash since all paths are normalized to forward slashes for glob matching
@@ -40,21 +37,17 @@ func FilterIgnoredPaths(paths, ignore []string, checkExists bool, pathPrefix str
 }
 
 func filterPaths(policyPaths []string, ignore []string, pathPrefix string) ([]string, error) {
+	patterns, err := compilePatterns(ignore)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile ignore patterns: %w", err)
+	}
+
 	filtered := make([]string, 0, len(policyPaths))
 
 outer:
 	for _, f := range policyPaths {
-		for _, pattern := range ignore {
-			if pattern == "" {
-				continue
-			}
-
-			excluded, err := excludeFile(pattern, f, pathPrefix)
-			if err != nil {
-				return nil, fmt.Errorf("failed to check for exclusion using pattern %s: %w", pattern, err)
-			}
-
-			if excluded {
+		for _, pattern := range patterns {
+			if excludeFile(pattern, f, pathPrefix) {
 				continue outer
 			}
 		}
@@ -67,59 +60,61 @@ outer:
 
 // excludeFile imitates the pattern matching of .gitignore files
 // See `exclusion.rego` for details on the implementation.
-func excludeFile(pattern, filename, pathPrefix string) (bool, error) {
-	n := len(pattern)
-
+func excludeFile(pattern glob.Glob, filename, pathPrefix string) bool {
 	// Normalize path separators to forward slashes for consistent glob matching
 	filename = filepath.ToSlash(filename)
-
 	if pathPrefix != "" {
-		pathPrefix = filepath.ToSlash(pathPrefix)
-		filename = strings.TrimPrefix(filename, pathPrefix)
-		// Remove leading slash if present after trimming prefix
-		filename = strings.TrimPrefix(filename, "/")
+		filename = strings.TrimPrefix(strings.TrimPrefix(filename, filepath.ToSlash(pathPrefix)), "/")
 	}
 
-	// Internal slashes means path is relative to root, otherwise it can
-	// appear anywhere in the directory (--> **/)
-	if !strings.Contains(pattern[:n-1], "/") {
-		pattern = "**/" + pattern
-	}
+	return pattern.Match(filename)
+}
 
-	// Leading slash?
-	pattern = strings.TrimPrefix(pattern, "/")
+func compilePatterns(patterns []string) ([]glob.Glob, error) {
+	compiled := make([]glob.Glob, 0, len(patterns))
 
-	// Leading double-star?
-	ps := []string{pattern}
-	if noPrefix, ok := strings.CutPrefix(pattern, "**/"); ok {
-		ps = append(ps, noPrefix)
-	}
+	for _, pattern := range patterns {
+		if pattern == "" {
+			continue
+		}
 
-	var ps1 []string
+		n := len(pattern)
+		// Internal slashes means path is relative to root, otherwise it can
+		// appear anywhere in the directory (--> **/)
+		if !strings.Contains(pattern[:n-1], "/") {
+			pattern = "**/" + pattern
+		}
 
-	// trailing slash?
-	for _, p := range ps {
-		switch {
-		case strings.HasSuffix(p, "/"):
-			ps1 = append(ps1, p+"**")
-		case !strings.HasSuffix(p, "**"):
-			ps1 = append(ps1, p, p+"/**")
-		default:
-			ps1 = append(ps1, p)
+		pattern = strings.TrimPrefix(pattern, "/")
+
+		ps := []string{pattern}
+		if noPrefix, ok := strings.CutPrefix(pattern, "**/"); ok {
+			ps = append(ps, noPrefix)
+		}
+
+		var ps1 []string
+
+		for _, p := range ps {
+			switch {
+			case strings.HasSuffix(p, "/"):
+				ps1 = append(ps1, p+"**")
+			case !strings.HasSuffix(p, "**") && !strings.HasSuffix(p, ".rego"):
+				ps1 = append(ps1, p, p+"/**")
+			default:
+				ps1 = append(ps1, p)
+			}
+		}
+
+		// Loop through patterns and return true on first match
+		for _, p := range ps1 {
+			g, err := glob.Compile(p, '/')
+			if err != nil {
+				return nil, fmt.Errorf("failed to compile pattern %s: %w", p, err)
+			}
+
+			compiled = append(compiled, g)
 		}
 	}
 
-	// Loop through patterns and return true on first match
-	for _, p := range ps1 {
-		g, err := glob.Compile(p, '/')
-		if err != nil {
-			return false, fmt.Errorf("failed to compile pattern %s: %w", p, err)
-		}
-
-		if g.Match(filename) {
-			return true, nil
-		}
-	}
-
-	return false, nil
+	return compiled, nil
 }

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -374,12 +374,7 @@ func (l Linter) Lint(ctx context.Context) (report.Report, error) {
 	if l.inputModules != nil {
 		l.startTimer(regalmetrics.RegalFilterIgnoredModules)
 
-		filteredPaths, err := config.FilterIgnoredPaths(
-			l.inputModules.FileNames,
-			ignore,
-			false,
-			l.pathPrefix,
-		)
+		filteredPaths, err := config.FilterIgnoredPaths(l.inputModules.FileNames, ignore, false, l.pathPrefix)
 		if err != nil {
 			return report.Report{}, fmt.Errorf("failed to filter paths: %w", err)
 		}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -144,7 +144,7 @@ func (a Aggregate) IndexKey() string {
 		return ""
 	}
 
-	return fmt.Sprintf("%s/%s", cat, title)
+	return cat + "/" + title
 }
 
 func (r *Report) AddProfileEntries(prof map[string]ProfileEntry) {

--- a/pkg/roast/encoding/json.go
+++ b/pkg/roast/encoding/json.go
@@ -1,6 +1,7 @@
 package encoding
 
 import (
+	"io"
 	"log"
 
 	jsoniter "github.com/json-iterator/go"
@@ -71,4 +72,12 @@ func MustJSONRoundTripTo[T any](from any) T {
 	}
 
 	return to
+}
+
+// NewIndentEncoder creates a new JSON encoder with the specified prefix and indent, encoding to w.
+func NewIndentEncoder(w io.Writer, prefix, indent string) *jsoniter.Encoder {
+	enc := JSON().NewEncoder(w)
+	enc.SetIndent(prefix, indent)
+
+	return enc
 }

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"sync"
 
@@ -50,13 +49,6 @@ func InputFromPaths(paths []string, prefix string, versionsMap map[string]ast.Re
 	numPaths := len(paths)
 	if numPaths == 1 && paths[0] == "-" {
 		return inputFromStdin()
-	}
-
-	var versionedDirs []string
-	if len(versionsMap) > 0 {
-		// Sort directories by length, so that the most specific path is found first
-		versionedDirs = util.KeysSorted(versionsMap)
-		slices.Reverse(versionedDirs)
 	}
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
- Much faster file filtering by avoiding recompiling ignore patterns, and function literal allocation in Rego filter
- Avoid using .Split function where possible
- Unify how ast.Location is serialized, and make it as fast as possible
- Add more helpers for retrieving lines in text

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->