### PR TITLE
docs: Correct sidebar labels

### DIFF
--- a/docs/adopters.md.yaml
+++ b/docs/adopters.md.yaml
@@ -1,1 +1,2 @@
 sidebar_position: 13
+sidebar_label: Adopters

--- a/docs/architecture.md.yaml
+++ b/docs/architecture.md.yaml
@@ -1,1 +1,2 @@
 sidebar_position: 4
+sidebar_label: Architecture

--- a/docs/configuration/capabilities.md.yaml
+++ b/docs/configuration/capabilities.md.yaml
@@ -1,1 +1,2 @@
 sidebar_position: 5
+sidebar_label: Capabilities

--- a/docs/configuration/ignore-rules.md
+++ b/docs/configuration/ignore-rules.md
@@ -124,7 +124,7 @@ The format of an ignore directive is `regal ignore:<rule-name>,<rule-name>...`, 
 rule to ignore. Multiple rules may be added to the same ignore directive, separated by commas.
 
 Note that at this point in time, Regal only considers the same line or the line following the ignore directive, i.e. it
-does not apply to entire blocks of code (like rules, functions or even packages). See [configuration](#configuration)
+does not apply to entire blocks of code (like rules, functions or even packages). See [configuration](./)
 if you want to ignore certain rules altogether.
 
 ## Ignoring Rules via CLI Flags

--- a/docs/configuration/ignore-rules.md.yaml
+++ b/docs/configuration/ignore-rules.md.yaml
@@ -1,1 +1,2 @@
 sidebar_position: 6
+sidebar_label: Ignoring Rules

--- a/docs/configuration/index.md.yaml
+++ b/docs/configuration/index.md.yaml
@@ -1,1 +1,2 @@
 sidebar_position: 4
+sidebar_label: Configuration

--- a/docs/configuration/project-roots.md.yaml
+++ b/docs/configuration/project-roots.md.yaml
@@ -1,1 +1,2 @@
 sidebar_position: 7
+sidebar_label: Project Roots

--- a/docs/custom-rules/index.md.yaml
+++ b/docs/custom-rules/index.md.yaml
@@ -1,1 +1,2 @@
 sidebar_position: 5
+sidebar_label: Custom Rules

--- a/docs/custom-rules/roast.md.yaml
+++ b/docs/custom-rules/roast.md.yaml
@@ -1,1 +1,2 @@
 sidebar_position: 2
+sidebar_label: Roast

--- a/docs/debug-adapter.md.yaml
+++ b/docs/debug-adapter.md.yaml
@@ -1,1 +1,2 @@
 sidebar_position: 10
+sidebar_label: Debugging Rego

--- a/docs/editor-support.md.yaml
+++ b/docs/editor-support.md.yaml
@@ -1,1 +1,2 @@
 sidebar_position: 7
+sidebar_label: Editor Support

--- a/docs/fixing.md.yaml
+++ b/docs/fixing.md.yaml
@@ -1,1 +1,2 @@
 sidebar_position: 3
+sidebar_label: Fixing Violations

--- a/docs/language-server.md.yaml
+++ b/docs/language-server.md.yaml
@@ -1,1 +1,2 @@
 sidebar_position: 9
+sidebar_label: Language Server

--- a/docs/pre-commit-hooks.md.yaml
+++ b/docs/pre-commit-hooks.md.yaml
@@ -1,1 +1,2 @@
 sidebar_position: 6
+sidebar_label: Pre-Commit Hooks

--- a/docs/readme-sections/website-intro.md
+++ b/docs/readme-sections/website-intro.md
@@ -7,7 +7,7 @@ title: Introduction
 <!-- markdownlint-disable MD033 -->
 <head>
 <!-- markdownlint-disable MD033 -->
-  <title>Introduction | Regal</head>
+  <title>Introduction | Regal</title>
 </head>
 
 <!-- markdownlint-disable MD041 -->

--- a/docs/remote-features.md.yaml
+++ b/docs/remote-features.md.yaml
@@ -1,1 +1,2 @@
 sidebar_position: 11
+sidebar_label: Remote Features

--- a/docs/rules/bugs/index.md.yaml
+++ b/docs/rules/bugs/index.md.yaml
@@ -1,2 +1,3 @@
 title: Bugs
+sidebar_label: Bugs
 sidebar_position: 1

--- a/docs/rules/custom/index.md.yaml
+++ b/docs/rules/custom/index.md.yaml
@@ -1,2 +1,3 @@
 title: Custom
+sidebar_label: Custom
 sidebar_position: 7

--- a/docs/rules/idiomatic/index.md.yaml
+++ b/docs/rules/idiomatic/index.md.yaml
@@ -1,2 +1,3 @@
 title: Idiomatic
+sidebar_label: Idiomatic
 sidebar_position: 2

--- a/docs/rules/imports/index.md.yaml
+++ b/docs/rules/imports/index.md.yaml
@@ -1,2 +1,3 @@
 title: Imports
+sidebar_label: Imports
 sidebar_position: 3

--- a/docs/rules/index.md.yaml
+++ b/docs/rules/index.md.yaml
@@ -1,2 +1,3 @@
 title: Rules
+sidebar_label: Rules
 sidebar_position: 2

--- a/docs/rules/performance/index.md.yaml
+++ b/docs/rules/performance/index.md.yaml
@@ -1,2 +1,3 @@
 title: Performance
+sidebar_label: Performance
 sidebar_position: 4

--- a/docs/rules/style/index.md.yaml
+++ b/docs/rules/style/index.md.yaml
@@ -1,2 +1,3 @@
 title: Style
+sidebar_label: Style
 sidebar_position: 5

--- a/docs/rules/testing/index.md.yaml
+++ b/docs/rules/testing/index.md.yaml
@@ -1,2 +1,3 @@
 title: Testing
+sidebar_label: Testing
 sidebar_position: 6


### PR DESCRIPTION
There was an issue in using <title> tags, and sidebar labels seem to be needed now.

The issue:
<img width="427" height="1027" alt="Screenshot 2025-11-10 at 16 51 49" src="https://github.com/user-attachments/assets/027d04ac-7cbe-4ed7-8c21-d858dc95ad44" />

