### PR TITLE
Rename: encoding/util -> encoding/write

### DIFF
--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -57,6 +57,7 @@ func parse(args []string) error {
 		return err
 	}
 
+	//nolint:staticcheck
 	enhancedAST, err := rp.PrepareAST(filename, content, module)
 	if err != nil {
 		return err

--- a/internal/capabilities/capabilities_integration_test.go
+++ b/internal/capabilities/capabilities_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package capabilities
 

--- a/internal/lsp/race_off.go
+++ b/internal/lsp/race_off.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package lsp
 

--- a/internal/lsp/race_on.go
+++ b/internal/lsp/race_on.go
@@ -1,5 +1,4 @@
 //go:build race
-// +build race
 
 package lsp
 

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -677,6 +677,7 @@ func (l *LanguageServer) StartCommandWorker(ctx context.Context) { //nolint:main
 				// used as the input rather than the contents of input.json/yaml. This is a development feature for
 				// working on rules (built-in or custom), allowing querying the AST of the module directly.
 				if len(module.Comments) > 0 && regalEvalUseAsInputComment.Match(module.Comments[0].Text) {
+					//nolint:staticcheck
 					inputMap, err = rparse.PrepareAST(l.toRelativePath(args.Target), contents, module)
 					if err != nil {
 						l.log.Message("failed to prepare module: %s", err)

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -93,6 +93,7 @@ func Module(filename, policy string) (*ast.Module, error) {
 }
 
 // PrepareAST prepares the AST to be used as linter input.
+//
 // Deprecated: New code should use the `transform` package from roast, as this avoids an
 // expensive intermediate step in module -> ast.Value conversions.
 func PrepareAST(name string, content string, module *ast.Module) (preparedAST map[string]any, err error) {

--- a/internal/roast/encoding/annotations.go
+++ b/internal/roast/encoding/annotations.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
-	"github.com/open-policy-agent/regal/internal/roast/encoding/util"
+	"github.com/open-policy-agent/regal/internal/roast/encoding/write"
 )
 
 type annotationsCodec struct{}
@@ -19,40 +19,40 @@ func (*annotationsCodec) IsEmpty(_ unsafe.Pointer) bool {
 func (*annotationsCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	a := *((*ast.Annotations)(ptr))
 
-	util.ObjectStart(stream, a.Location)
-	util.WriteString(stream, strScope, a.Scope)
+	write.ObjectStart(stream, a.Location)
+	write.String(stream, strScope, a.Scope)
 
 	if a.Title != "" {
-		util.WriteString(stream, strTitle, a.Title)
+		write.String(stream, strTitle, a.Title)
 	}
 
 	if a.Description != "" {
-		util.WriteString(stream, strDescription, a.Description)
+		write.String(stream, strDescription, a.Description)
 	}
 
 	if a.Entrypoint {
-		util.WriteBool(stream, strEntrypoint, a.Entrypoint)
+		write.Bool(stream, strEntrypoint, a.Entrypoint)
 	}
 
 	if len(a.Organizations) > 0 {
-		util.WriteValsArrayAttr(stream, strOrganizations, a.Organizations)
+		write.ValsArrayAttr(stream, strOrganizations, a.Organizations)
 	}
 
 	if len(a.RelatedResources) > 0 {
-		util.WriteValsArrayAttr(stream, strRelatedResources, a.RelatedResources)
+		write.ValsArrayAttr(stream, strRelatedResources, a.RelatedResources)
 	}
 
 	if len(a.Authors) > 0 {
-		util.WriteValsArrayAttr(stream, strAuthors, a.Authors)
+		write.ValsArrayAttr(stream, strAuthors, a.Authors)
 	}
 
 	if len(a.Schemas) > 0 {
-		util.WriteValsArrayAttr(stream, strSchemas, a.Schemas)
+		write.ValsArrayAttr(stream, strSchemas, a.Schemas)
 	}
 
 	if len(a.Custom) > 0 {
-		util.WriteObject(stream, strCustom, a.Custom)
+		write.Object(stream, strCustom, a.Custom)
 	}
 
-	util.ObjectEnd(stream)
+	write.ObjectEnd(stream)
 }

--- a/internal/roast/encoding/body.go
+++ b/internal/roast/encoding/body.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
-	"github.com/open-policy-agent/regal/internal/roast/encoding/util"
+	"github.com/open-policy-agent/regal/internal/roast/encoding/write"
 )
 
 type bodyCodec struct{}
@@ -19,5 +19,5 @@ func (*bodyCodec) IsEmpty(_ unsafe.Pointer) bool {
 func (*bodyCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	body := *((*ast.Body)(ptr))
 
-	util.WriteValsArray(stream, body)
+	write.ValsArray(stream, body)
 }

--- a/internal/roast/encoding/comment.go
+++ b/internal/roast/encoding/comment.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
-	"github.com/open-policy-agent/regal/internal/roast/encoding/util"
+	"github.com/open-policy-agent/regal/internal/roast/encoding/write"
 )
 
 type commentCodec struct{}
@@ -20,7 +20,7 @@ func (*commentCodec) IsEmpty(_ unsafe.Pointer) bool {
 func (*commentCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	comment := *((*ast.Comment)(ptr))
 
-	util.ObjectStart(stream, comment.Location)
+	write.ObjectStart(stream, comment.Location)
 
 	stream.WriteObjectField(strText)
 	stream.WriteString(base64.StdEncoding.EncodeToString(comment.Text))

--- a/internal/roast/encoding/every.go
+++ b/internal/roast/encoding/every.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
-	"github.com/open-policy-agent/regal/internal/roast/encoding/util"
+	"github.com/open-policy-agent/regal/internal/roast/encoding/write"
 )
 
 type everyCodec struct{}
@@ -19,10 +19,10 @@ func (*everyCodec) IsEmpty(_ unsafe.Pointer) bool {
 func (*everyCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	every := *((*ast.Every)(ptr))
 
-	util.ObjectStart(stream, every.Location)
-	util.WriteVal(stream, strKey, every.Key)
-	util.WriteVal(stream, strValue, every.Value)
-	util.WriteVal(stream, strDomain, every.Domain)
-	util.WriteVal(stream, strBody, every.Body)
-	util.ObjectEnd(stream)
+	write.ObjectStart(stream, every.Location)
+	write.Val(stream, strKey, every.Key)
+	write.Val(stream, strValue, every.Value)
+	write.Val(stream, strDomain, every.Domain)
+	write.Val(stream, strBody, every.Body)
+	write.ObjectEnd(stream)
 }

--- a/internal/roast/encoding/expr.go
+++ b/internal/roast/encoding/expr.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
-	"github.com/open-policy-agent/regal/internal/roast/encoding/util"
+	"github.com/open-policy-agent/regal/internal/roast/encoding/write"
 )
 
 type exprCodec struct{}
@@ -19,18 +19,18 @@ func (*exprCodec) IsEmpty(_ unsafe.Pointer) bool {
 func (*exprCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	expr := *((*ast.Expr)(ptr))
 
-	util.ObjectStart(stream, expr.Location)
+	write.ObjectStart(stream, expr.Location)
 
 	if expr.Negated {
-		util.WriteBool(stream, strNegated, expr.Negated)
+		write.Bool(stream, strNegated, expr.Negated)
 	}
 
 	if expr.Generated {
-		util.WriteBool(stream, strGenerated, expr.Generated)
+		write.Bool(stream, strGenerated, expr.Generated)
 	}
 
 	if len(expr.With) > 0 {
-		util.WriteValsArrayAttr(stream, strWith, expr.With)
+		write.ValsArrayAttr(stream, strWith, expr.With)
 	}
 
 	if expr.Terms != nil {
@@ -40,7 +40,7 @@ func (*exprCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 		case *ast.Term:
 			stream.WriteVal(t)
 		case []*ast.Term:
-			util.WriteValsArray(stream, t)
+			write.ValsArray(stream, t)
 		case *ast.SomeDecl:
 			stream.WriteVal(t)
 		case *ast.Every:
@@ -48,5 +48,5 @@ func (*exprCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 		}
 	}
 
-	util.ObjectEnd(stream)
+	write.ObjectEnd(stream)
 }

--- a/internal/roast/encoding/head.go
+++ b/internal/roast/encoding/head.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
-	"github.com/open-policy-agent/regal/internal/roast/encoding/util"
+	"github.com/open-policy-agent/regal/internal/roast/encoding/write"
 )
 
 type headCodec struct{}
@@ -19,22 +19,22 @@ func (*headCodec) IsEmpty(_ unsafe.Pointer) bool {
 func (*headCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	head := *((*ast.Head)(ptr))
 
-	util.ObjectStart(stream, head.Location)
+	write.ObjectStart(stream, head.Location)
 
 	if head.Reference != nil {
-		util.WriteVal(stream, strRef, head.Reference)
+		write.Val(stream, strRef, head.Reference)
 	}
 
 	if len(head.Args) > 0 {
-		util.WriteValsArrayAttr(stream, strArgs, head.Args)
+		write.ValsArrayAttr(stream, strArgs, head.Args)
 	}
 
 	if head.Assign {
-		util.WriteBool(stream, strAssign, head.Assign)
+		write.Bool(stream, strAssign, head.Assign)
 	}
 
 	if head.Key != nil {
-		util.WriteVal(stream, strKey, head.Key)
+		write.Val(stream, strKey, head.Key)
 	}
 
 	if head.Value != nil {
@@ -45,8 +45,8 @@ func (*headCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 			}
 		}
 
-		util.WriteVal(stream, strValue, head.Value)
+		write.Val(stream, strValue, head.Value)
 	}
 
-	util.ObjectEnd(stream)
+	write.ObjectEnd(stream)
 }

--- a/internal/roast/encoding/import.go
+++ b/internal/roast/encoding/import.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
-	"github.com/open-policy-agent/regal/internal/roast/encoding/util"
+	"github.com/open-policy-agent/regal/internal/roast/encoding/write"
 )
 
 type importCodec struct{}
@@ -19,15 +19,15 @@ func (*importCodec) IsEmpty(_ unsafe.Pointer) bool {
 func (*importCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	imp := *((*ast.Import)(ptr))
 
-	util.ObjectStart(stream, imp.Location)
+	write.ObjectStart(stream, imp.Location)
 
 	if imp.Path != nil {
-		util.WriteVal(stream, strPath, imp.Path)
+		write.Val(stream, strPath, imp.Path)
 
 		if imp.Alias != "" {
-			util.WriteVal(stream, strAlias, imp.Alias)
+			write.Val(stream, strAlias, imp.Alias)
 		}
 	}
 
-	util.ObjectEnd(stream)
+	write.ObjectEnd(stream)
 }

--- a/internal/roast/encoding/module.go
+++ b/internal/roast/encoding/module.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
-	encutil "github.com/open-policy-agent/regal/internal/roast/encoding/util"
+	encutil "github.com/open-policy-agent/regal/internal/roast/encoding/write"
 	"github.com/open-policy-agent/regal/internal/util"
 )
 
@@ -27,20 +27,20 @@ func (*moduleCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 			stream.Attachment = util.Filter(mod.Annotations, notDocumentOrRuleScope)
 		}
 
-		encutil.WriteVal(stream, strPackage, mod.Package)
+		encutil.Val(stream, strPackage, mod.Package)
 		stream.Attachment = nil
 	}
 
 	if len(mod.Imports) > 0 {
-		encutil.WriteValsArrayAttr(stream, strImports, mod.Imports)
+		encutil.ValsArrayAttr(stream, strImports, mod.Imports)
 	}
 
 	if len(mod.Rules) > 0 {
-		encutil.WriteValsArrayAttr(stream, strRules, mod.Rules)
+		encutil.ValsArrayAttr(stream, strRules, mod.Rules)
 	}
 
 	if len(mod.Comments) > 0 {
-		encutil.WriteValsArrayAttr(stream, strComments, mod.Comments)
+		encutil.ValsArrayAttr(stream, strComments, mod.Comments)
 	}
 
 	encutil.ObjectEnd(stream)

--- a/internal/roast/encoding/objectcomprehension.go
+++ b/internal/roast/encoding/objectcomprehension.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
-	"github.com/open-policy-agent/regal/internal/roast/encoding/util"
+	"github.com/open-policy-agent/regal/internal/roast/encoding/write"
 )
 
 type objectComprehensionCodec struct{}
@@ -19,9 +19,9 @@ func (*objectComprehensionCodec) IsEmpty(_ unsafe.Pointer) bool {
 func (*objectComprehensionCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	oc := *((*ast.ObjectComprehension)(ptr))
 
-	util.ObjectStart(stream, nil)
-	util.WriteVal(stream, strKey, oc.Key)
-	util.WriteVal(stream, strValue, oc.Value)
-	util.WriteVal(stream, strBody, oc.Body)
-	util.ObjectEnd(stream)
+	write.ObjectStart(stream, nil)
+	write.Val(stream, strKey, oc.Key)
+	write.Val(stream, strValue, oc.Value)
+	write.Val(stream, strBody, oc.Body)
+	write.ObjectEnd(stream)
 }

--- a/internal/roast/encoding/package.go
+++ b/internal/roast/encoding/package.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
-	"github.com/open-policy-agent/regal/internal/roast/encoding/util"
+	"github.com/open-policy-agent/regal/internal/roast/encoding/write"
 )
 
 type packageCodec struct{}
@@ -19,7 +19,7 @@ func (*packageCodec) IsEmpty(_ unsafe.Pointer) bool {
 func (*packageCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	pkg := *((*ast.Package)(ptr))
 
-	util.ObjectStart(stream, pkg.Location)
+	write.ObjectStart(stream, pkg.Location)
 
 	if pkg.Path != nil {
 		// Make a copy to avoid data race
@@ -29,12 +29,12 @@ func (*packageCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 		// Omit location of "data" part of path, at it isn't present in code
 		pathCopy[0].Location = nil
 
-		util.WriteVal(stream, strPath, pathCopy)
+		write.Val(stream, strPath, pathCopy)
 	}
 
 	if stream.Attachment != nil {
-		util.WriteVal(stream, strAnnotations, stream.Attachment)
+		write.Val(stream, strAnnotations, stream.Attachment)
 	}
 
-	util.ObjectEnd(stream)
+	write.ObjectEnd(stream)
 }

--- a/internal/roast/encoding/ref.go
+++ b/internal/roast/encoding/ref.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
-	"github.com/open-policy-agent/regal/internal/roast/encoding/util"
+	"github.com/open-policy-agent/regal/internal/roast/encoding/write"
 )
 
 type refCodec struct{}
@@ -21,5 +21,5 @@ func (*refCodec) IsEmpty(ptr unsafe.Pointer) bool {
 func (*refCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	ref := *((*ast.Ref)(ptr))
 
-	util.WriteValsArray(stream, ref)
+	write.ValsArray(stream, ref)
 }

--- a/internal/roast/encoding/rule.go
+++ b/internal/roast/encoding/rule.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
-	"github.com/open-policy-agent/regal/internal/roast/encoding/util"
+	"github.com/open-policy-agent/regal/internal/roast/encoding/write"
 	"github.com/open-policy-agent/regal/pkg/roast/rast"
 )
 
@@ -20,27 +20,27 @@ func (*ruleCodec) IsEmpty(_ unsafe.Pointer) bool {
 func (*ruleCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	rule := *((*ast.Rule)(ptr))
 
-	util.ObjectStart(stream, rule.Location)
+	write.ObjectStart(stream, rule.Location)
 
 	if len(rule.Annotations) > 0 {
-		util.WriteValsArrayAttr(stream, strAnnotations, rule.Annotations)
+		write.ValsArrayAttr(stream, strAnnotations, rule.Annotations)
 	}
 
 	if rule.Default {
-		util.WriteBool(stream, strDefault, rule.Default)
+		write.Bool(stream, strDefault, rule.Default)
 	}
 
 	if rule.Head != nil {
-		util.WriteVal(stream, strHead, rule.Head)
+		write.Val(stream, strHead, rule.Head)
 	}
 
 	if !rast.IsBodyGenerated(&rule) {
-		util.WriteVal(stream, strBody, rule.Body)
+		write.Val(stream, strBody, rule.Body)
 	}
 
 	if rule.Else != nil {
-		util.WriteVal(stream, strElse, rule.Else)
+		write.Val(stream, strElse, rule.Else)
 	}
 
-	util.ObjectEnd(stream)
+	write.ObjectEnd(stream)
 }

--- a/internal/roast/encoding/set.go
+++ b/internal/roast/encoding/set.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
-	"github.com/open-policy-agent/regal/internal/roast/encoding/util"
+	"github.com/open-policy-agent/regal/internal/roast/encoding/write"
 )
 
 type setCodec struct{}
@@ -28,5 +28,5 @@ type set struct {
 func (*setCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	s := *((*set)(ptr))
 
-	util.WriteValsArray(stream, s.keys)
+	write.ValsArray(stream, s.keys)
 }

--- a/internal/roast/encoding/somedecl.go
+++ b/internal/roast/encoding/somedecl.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
-	"github.com/open-policy-agent/regal/internal/roast/encoding/util"
+	"github.com/open-policy-agent/regal/internal/roast/encoding/write"
 )
 
 type someDeclCodec struct{}
@@ -19,7 +19,7 @@ func (*someDeclCodec) IsEmpty(_ unsafe.Pointer) bool {
 func (*someDeclCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	some := *((*ast.SomeDecl)(ptr))
 
-	util.ObjectStart(stream, some.Location)
-	util.WriteValsArrayAttr(stream, strSymbols, some.Symbols)
-	util.ObjectEnd(stream)
+	write.ObjectStart(stream, some.Location)
+	write.ValsArrayAttr(stream, strSymbols, some.Symbols)
+	write.ObjectEnd(stream)
 }

--- a/internal/roast/encoding/term.go
+++ b/internal/roast/encoding/term.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
-	"github.com/open-policy-agent/regal/internal/roast/encoding/util"
+	"github.com/open-policy-agent/regal/internal/roast/encoding/write"
 )
 
 type termCodec struct{}
@@ -19,12 +19,12 @@ func (*termCodec) IsEmpty(_ unsafe.Pointer) bool {
 func (*termCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	term := *((*ast.Term)(ptr))
 
-	util.ObjectStart(stream, term.Location)
+	write.ObjectStart(stream, term.Location)
 
 	if term.Value != nil {
-		util.WriteString(stream, strType, ast.ValueName(term.Value))
-		util.WriteVal(stream, strValue, term.Value)
+		write.String(stream, strType, ast.ValueName(term.Value))
+		write.Val(stream, strValue, term.Value)
 	}
 
-	util.ObjectEnd(stream)
+	write.ObjectEnd(stream)
 }

--- a/internal/roast/encoding/with.go
+++ b/internal/roast/encoding/with.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
-	"github.com/open-policy-agent/regal/internal/roast/encoding/util"
+	"github.com/open-policy-agent/regal/internal/roast/encoding/write"
 )
 
 type withCodec struct{}
@@ -19,8 +19,8 @@ func (*withCodec) IsEmpty(_ unsafe.Pointer) bool {
 func (*withCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	with := *((*ast.With)(ptr))
 
-	util.ObjectStart(stream, with.Location)
-	util.WriteVal(stream, strTarget, with.Target)
-	util.WriteVal(stream, strValue, with.Value)
-	util.ObjectEnd(stream)
+	write.ObjectStart(stream, with.Location)
+	write.Val(stream, strTarget, with.Target)
+	write.Val(stream, strValue, with.Value)
+	write.ObjectEnd(stream)
 }

--- a/internal/roast/encoding/write/streams.go
+++ b/internal/roast/encoding/write/streams.go
@@ -1,4 +1,4 @@
-package util
+package write
 
 import (
 	"bytes"
@@ -8,7 +8,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/ast"
 )
 
-func WriteValsArray[T any](stream *jsoniter.Stream, vals []T) {
+func ValsArray[T any](stream *jsoniter.Stream, vals []T) {
 	stream.WriteArrayStart()
 
 	for i, val := range vals {
@@ -22,13 +22,13 @@ func WriteValsArray[T any](stream *jsoniter.Stream, vals []T) {
 	stream.WriteArrayEnd()
 }
 
-func WriteValsArrayAttr[T any](stream *jsoniter.Stream, name string, vals []T) {
+func ValsArrayAttr[T any](stream *jsoniter.Stream, name string, vals []T) {
 	stream.WriteObjectField(name)
-	WriteValsArray(stream, vals)
+	ValsArray(stream, vals)
 	stream.WriteMore()
 }
 
-func WriteObject[V any](stream *jsoniter.Stream, name string, obj map[string]V) {
+func Object[V any](stream *jsoniter.Stream, name string, obj map[string]V) {
 	stream.WriteObjectField(name)
 	stream.WriteObjectStart()
 
@@ -49,19 +49,19 @@ func WriteObject[V any](stream *jsoniter.Stream, name string, obj map[string]V) 
 	stream.WriteMore()
 }
 
-func WriteVal(stream *jsoniter.Stream, field string, val any) {
+func Val(stream *jsoniter.Stream, field string, val any) {
 	stream.WriteObjectField(field)
 	stream.WriteVal(val)
 	stream.WriteMore()
 }
 
-func WriteString(stream *jsoniter.Stream, field string, val string) {
+func String(stream *jsoniter.Stream, field string, val string) {
 	stream.WriteObjectField(field)
 	stream.WriteString(val)
 	stream.WriteMore()
 }
 
-func WriteBool(stream *jsoniter.Stream, field string, val bool) {
+func Bool(stream *jsoniter.Stream, field string, val bool) {
 	stream.WriteObjectField(field)
 	stream.WriteBool(val)
 	stream.WriteMore()
@@ -71,7 +71,7 @@ func ObjectStart(stream *jsoniter.Stream, loc *ast.Location) {
 	stream.WriteObjectStart()
 
 	if loc != nil {
-		WriteVal(stream, "location", loc)
+		Val(stream, "location", loc)
 	}
 }
 

--- a/pkg/builtins/builtins.go
+++ b/pkg/builtins/builtins.go
@@ -90,6 +90,7 @@ func RegalIsFormatted(_ rego.BuiltinContext, input *ast.Term, options *ast.Term)
 	}
 
 	regoVersion := ast.RegoV1
+
 	if versionTerm := optionsObj.Get(regoVersionTerm); versionTerm != nil {
 		if v, ok := versionTerm.Value.(ast.String); ok && v == "v0" {
 			regoVersion = ast.RegoV0

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -139,11 +139,15 @@ func (tr PrettyReporter) Publish(_ context.Context, r report.Report) error {
 
 	if r.Summary.RulesSkipped > 0 {
 		footer += fmt.Sprintf(" %d %s skipped:\n", r.Summary.RulesSkipped, pluralize("rule", r.Summary.RulesSkipped))
+		sb := &strings.Builder{}
+
 		for _, notice := range r.Notices {
 			if notice.Severity != "none" {
-				footer += fmt.Sprintf("- %s: %s\n", notice.Title, notice.Description)
+				fmt.Fprintf(sb, "- %s: %s\n", notice.Title, notice.Description)
 			}
 		}
+
+		footer += sb.String()
 	}
 
 	_, err := fmt.Fprintln(tr.out, table+footer)


### PR DESCRIPTION
It was annoying having more than one `util` package in Regal, as completion providers would randomly suggest on or the other. The new name better describes the purpose anyway. Also fix some new issues reported by golangci-lint linters.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->