### PR TITLE
build: run windows in matrix with other jobs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,9 @@ jobs:
           - runner: macos-14
             name: macos-arm64
             static: true
+          - runner: windows-latest
+            name: windows
+            static: true
     runs-on: ${{ matrix.os.runner }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -122,19 +125,3 @@ jobs:
           files: ./coverage.json
           name: regal
           token: ${{ secrets.CODECOV_TOKEN }} # required
-  build-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
-        with:
-          go-version-file: go.mod
-      - uses: open-policy-agent/setup-opa@950f159a49aa91f9323f36f1de81c7f6b5de9576 # v2.3.0
-        with:
-          version: latest
-          static: ${{ matrix.os.static }}
-      # TODO: windows tests are failing, but we should still run the build & tests for inspection
-      - run: go build
-      - run: go test ./...
-      - run: go test -tags e2e ./e2e
-        continue-on-error: true

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -145,6 +145,7 @@ func TestLintV0WithRegoV1ImportViolations(t *testing.T) {
 	regal("lint",
 		"--format", "json",
 		"--config-file", cwd("testdata/configs/v0-with-import-rego-v1.yaml"), cwd("testdata/v0/")).
+		skip(onCondition(runtime.GOOS == "windows", "skipping on Windows")).
 		expectExitCode(3).
 		expectStdout(unmarshalsTo(&rep)).
 		verify(t)


### PR DESCRIPTION
We have made enough improvements to the windows test performance such that this is possible now.
