### PR TITLE
Minor Fixes to Contributing Docs

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,8 +9,9 @@ want to read that before diving into the code!
 
 The following tools are required to build, test and lint Regal:
 
+- [OPA](https://www.openpolicyagent.org/docs#1-download-opa) installed
 - The latest version of [Go](https://go.dev/doc/install)
-- The [golangci-lint](https://golangci-lint.run/usage/install/#local-installation) linter
+- The [golangci-lint](https://golangci-lint.run/docs/welcome/install/#local-installation) linter
 - [Node](https://nodejs.org/en) in order to run the following tools:
   - The [markdownlint](https://github.com/DavidAnson/markdownlint) linter
   - [dprint](https://github.com/dprint/dprint) for checking JSON, YAML, etc


### PR DESCRIPTION
Added OPA installation as a Regal prerequisite, and fixed golangci-lint link.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->