### PR TITLE
Improve fixer performance

### DIFF
--- a/pkg/fixer/fixes/nowhitespacecomment.go
+++ b/pkg/fixer/fixes/nowhitespacecomment.go
@@ -20,7 +20,7 @@ func (n *NoWhitespaceComment) Fix(fc *FixCandidate, opts *RuntimeOptions) ([]Fix
 	fixed := false
 
 	for _, loc := range opts.Locations {
-		if loc.Row > len(lines) || loc.Column > len(lines[loc.Row-1]) || loc.Column < 1 {
+		if loc.Row < 1 || loc.Column < 1 || loc.Row > len(lines) || loc.Column > len(lines[loc.Row-1]) {
 			continue
 		}
 

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -388,6 +388,10 @@ func (l Linter) Lint(ctx context.Context) (report.Report, error) {
 		l.stopTimer(regalmetrics.RegalFilterIgnoredModules)
 	}
 
+	if len(l.inputPaths) == 0 && l.inputModules == nil && len(l.overriddenAggregates) == 0 {
+		return report.Report{}, errors.New("nothing provided to lint")
+	}
+
 	regoReport, err := l.lint(ctx, input)
 	if err != nil {
 		return report.Report{}, fmt.Errorf("failed to lint using Rego rules: %w", err)
@@ -531,10 +535,6 @@ func (l Linter) notPrepared() Linter {
 }
 
 func (l Linter) validate(conf *config.Config) error {
-	if len(l.inputPaths) == 0 && l.inputModules == nil && len(l.overriddenAggregates) == 0 {
-		return errors.New("nothing provided to lint")
-	}
-
 	if l.customRuleError != nil {
 		return fmt.Errorf("failed to load custom rules: %w", l.customRuleError)
 	}


### PR DESCRIPTION
By `Prepare`ing the linter before repeated use.

```
150116720 ns/op  101567417 B/op   2359322 allocs/op // Before
132816578 ns/op   89093239 B/op   2068892 allocs/op // After
```

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->