### PR TITLE
OPA v1.12.2 and full string interpolation support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,7 +63,7 @@ jobs:
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         if: matrix.os.name == 'linux'
         with:
-          version: v2.6.2
+          version: v2.7.2
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: regal-${{ matrix.os.name }}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <!-- markdownlint-disable MD041 -->
 
 [![Build Status](https://github.com/open-policy-agent/regal/workflows/Build/badge.svg)](https://github.com/open-policy-agent/regal/actions)
-![OPA v1.12.1](https://www.openpolicyagent.org/badge/v1.12.1)
+![OPA v1.12.2](https://www.openpolicyagent.org/badge/v1.12.2)
 [![codecov](https://codecov.io/github/open-policy-agent/regal/graph/badge.svg?token=EQK01YF3X3)](https://codecov.io/github/StyraInc/regal)
 [![Downloads](https://img.shields.io/github/downloads/open-policy-agent/regal/total.svg)](https://github.com/open-policy-agent/regal/releases)
 

--- a/build/capabilities.json
+++ b/build/capabilities.json
@@ -48,7 +48,8 @@
           "type": "boolean"
         },
         "type": "function"
-      }
+      },
+      "deprecated": true
     },
     {
       "name": "and",
@@ -113,7 +114,8 @@
           "type": "boolean"
         },
         "type": "function"
-      }
+      },
+      "deprecated": true
     },
     {
       "name": "array.concat",
@@ -512,7 +514,8 @@
           "type": "array"
         },
         "type": "function"
-      }
+      },
+      "deprecated": true
     },
     {
       "name": "cast_boolean",
@@ -526,7 +529,8 @@
           "type": "boolean"
         },
         "type": "function"
-      }
+      },
+      "deprecated": true
     },
     {
       "name": "cast_null",
@@ -540,7 +544,8 @@
           "type": "null"
         },
         "type": "function"
-      }
+      },
+      "deprecated": true
     },
     {
       "name": "cast_object",
@@ -562,7 +567,8 @@
           "type": "object"
         },
         "type": "function"
-      }
+      },
+      "deprecated": true
     },
     {
       "name": "cast_set",
@@ -579,7 +585,8 @@
           "type": "set"
         },
         "type": "function"
-      }
+      },
+      "deprecated": true
     },
     {
       "name": "cast_string",
@@ -593,7 +600,8 @@
           "type": "string"
         },
         "type": "function"
-      }
+      },
+      "deprecated": true
     },
     {
       "name": "ceil",
@@ -2030,6 +2038,23 @@
             "type": "array"
           }
         ],
+        "type": "function"
+      }
+    },
+    {
+      "name": "internal.template_string",
+      "decl": {
+        "args": [
+          {
+            "dynamic": {
+              "type": "any"
+            },
+            "type": "array"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
         "type": "function"
       }
     },
@@ -3807,7 +3832,8 @@
           "type": "boolean"
         },
         "type": "function"
-      }
+      },
+      "deprecated": true
     },
     {
       "name": "net.lookup_ip_addr",
@@ -4442,6 +4468,88 @@
           "type": "boolean"
         },
         "type": "function"
+      },
+      "deprecated": true
+    },
+    {
+      "name": "regal.is_formatted",
+      "decl": {
+        "args": [
+          {
+            "description": "input string to check for formatting",
+            "name": "input",
+            "type": "string"
+          },
+          {
+            "description": "formatting options",
+            "dynamic": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "name": "options",
+            "type": "object"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "regal.last",
+      "description": "Function optimized for retrieving the last element of an array.",
+      "decl": {
+        "args": [
+          {
+            "description": "performance optimized last index retrieval",
+            "dynamic": {
+              "type": "any"
+            },
+            "name": "array",
+            "type": "array"
+          }
+        ],
+        "result": {
+          "name": "element",
+          "type": "any"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "regal.parse_module",
+      "description": "Parses a Regal module similarly to rego.parse_module, but returns a RoAST representation.",
+      "decl": {
+        "args": [
+          {
+            "description": "file name to attach to AST nodes' locations",
+            "name": "filename",
+            "type": "string"
+          },
+          {
+            "description": "Rego module",
+            "name": "rego",
+            "type": "string"
+          }
+        ],
+        "result": {
+          "dynamic": {
+            "key": {
+              "type": "string"
+            },
+            "value": {
+              "type": "any"
+            }
+          },
+          "name": "output",
+          "type": "object"
+        },
+        "type": "function"
       }
     },
     {
@@ -4874,7 +4982,8 @@
           "type": "set"
         },
         "type": "function"
-      }
+      },
+      "deprecated": true
     },
     {
       "name": "sort",
@@ -6267,89 +6376,11 @@
         },
         "type": "function"
       }
-    },
-    {
-      "name": "regal.parse_module",
-      "decl": {
-        "args": [
-          {
-            "description": "file name to attach to AST nodes' locations",
-            "name": "filename",
-            "type": "string"
-          },
-          {
-            "description": "Rego module",
-            "name": "rego",
-            "type": "string"
-          }
-        ],
-        "result": {
-          "dynamic": {
-            "key": {
-              "type": "string"
-            },
-            "value": {
-              "type": "any"
-            }
-          },
-          "name": "output",
-          "type": "object"
-        },
-        "type": "function"
-      }
-    },
-    {
-      "name": "regal.last",
-      "decl": {
-        "args": [
-          {
-            "description": "performance optimized last index retrieval",
-            "dynamic": {
-              "type": "any"
-            },
-            "name": "array",
-            "type": "array"
-          }
-        ],
-        "result": {
-          "name": "element",
-          "type": "any"
-        },
-        "type": "function"
-      }
-    },
-    {
-      "name": "regal.is_formatted",
-      "decl": {
-        "args": [
-          {
-            "description": "input string to check for formatting",
-            "name": "input",
-            "type": "string"
-          },
-          {
-            "description": "formatting options",
-            "dynamic": {
-              "key": {
-                "type": "string"
-              },
-              "value": {
-                "type": "any"
-              }
-            },
-            "name": "options",
-            "type": "object"
-          }
-        ],
-        "result": {
-          "type": "boolean"
-        },
-        "type": "function"
-      }
     }
   ],
   "features": [
     "keywords_in_refs",
-    "rego_v1"
+    "rego_v1",
+    "template_strings"
   ]
 }

--- a/build/package-lock.json
+++ b/build/package-lock.json
@@ -1056,6 +1056,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/bundle/regal/ast/ast_test.rego
+++ b/bundle/regal/ast/ast_test.rego
@@ -237,3 +237,22 @@ test_var_in_head[case] if {
 
 	ast.var_in_head(head, "foo")
 }
+
+test_var_in_head_templatestring[case] if {
+	some case, head in {
+		"value": `rule := $"{x}"`,
+		"key": `rule contains $"{x}"`,
+		"term value": `rule := {"a": $"{x}"}`,
+		"term key": `rule contains { $"{x}": "a" }`,
+		"ref": `rule[$"{x}"].y if { x := 1 }`,
+	}
+
+	ast.var_in_head(ast.policy(head).rules[0].head, "x")
+}
+
+test_builtin_functions_called_in_templatestring if {
+	module := ast.policy(`r := $"{upper("a")} {lower("b")}"`)
+	names := ast.builtin_functions_called with input as module with config.capabilities as capabilities.provided
+
+	names == {"upper", "lower"}
+}

--- a/bundle/regal/ast/search.rego
+++ b/bundle/regal/ast/search.rego
@@ -69,7 +69,7 @@ has_named_var(node, name) if {
 	node.type == "var"
 	node.value == name
 } else if {
-	node.type in {"array", "object", "set", "ref"}
+	node.type in {"array", "object", "set", "ref", "templatestring"}
 
 	walk(node.value, [_, nested])
 
@@ -160,9 +160,7 @@ find_vars(node) := array.concat(
 	[var |
 		walk(node, [path, value])
 
-		last := regal.last(path)
-		last in {"terms", "symbols", "args"}
-
+		last := {"terms", "symbols", "args"}[regal.last(path)]
 		var := _find_vars(value, last)[_][_]
 	],
 	[var |
@@ -207,8 +205,7 @@ found.vars[rule_index][context] contains var if {
 
 	walk(rule[node], [path, value])
 
-	last := regal.last(path)
-	last in {"terms", "symbols", "args"}
+	last := {"terms", "symbols", "args"}[regal.last(path)]
 
 	some context, vars in _find_vars(value, last)
 	some var in vars

--- a/bundle/regal/ast/search_test.rego
+++ b/bundle/regal/ast/search_test.rego
@@ -159,3 +159,51 @@ test_find_vars_in_local_scope_complex_comprehension_term if {
 		{"location": {"col": 31, "row": 7, "text": "Yg=="}, "type": "var", "value": "b"},
 	]
 }
+
+test_found_refs_in_template_strings if {
+	refs := ast.found.refs["0"] with input as ast.policy(`r := $"{input.foo + input.bar} {data.baz}"`)
+
+	count(refs) == 4
+}
+
+test_found_calls_in_template_strings if {
+	calls := ast.found.calls["0"] with input as ast.policy("r := $`{count(split(input.ref, \".\"))}`")
+
+	count(calls) == 2
+}
+
+test_found_expressions_in_template_strings if {
+	exprs := ast.found.expressions["0"] with input as ast.policy(`r if $"{x > 10}" == "true"`)
+
+	count(exprs) == 2
+	count([1 | exprs[_].interpolated]) == 1
+}
+
+test_found_comprehensions_in_template_strings if {
+	comps := ast.found.comprehensions["0"] with input as ast.policy(`r := $"{[x | some x in input.arr]}"`)
+
+	count(comps) == 1
+}
+
+test_found_symbols_in_template_strings if {
+	syms := ast.found.symbols["0"] with input as ast.policy(`r := $"{[{x, y} |
+		some x
+		some y in input.arr
+		data.foo[a][b] == x + y
+	]}"`)
+
+	count(syms) == 2
+}
+
+test_found_vars_in_template_strings if {
+	vars := ast.found.vars["0"] with input as ast.policy(`r := $"{[{x, y, z} |
+		some x
+		some y in input.arr
+		z := x + y
+	]}"`)
+
+	count(vars.assign) == 1
+	count(vars.some) == 1
+	count(vars.somein) == 1
+	count([1 | vars[_][_]]) == 3
+}

--- a/bundle/regal/ast/testing.rego
+++ b/bundle/regal/ast/testing.rego
@@ -4,27 +4,12 @@ package regal.ast
 # description: |
 #   parses provided policy with all future keywords imported. Primarily for testing.
 #   deprecated: use ast.policy instead
-with_rego_v1(policy) := regal.parse_module("policy.rego", concat("", [
-	`package policy
-
-import rego.v1
-
-`,
-	policy,
-]))
+with_rego_v1(policy) := regal.parse_module("policy.rego", $"package policy\n\nimport rego.v1\n\n{policy}")
 
 # METADATA
 # description: parses provided policy with v0 syntax and no imports. Primarily for testing.
-with_rego_v0(policy) := regal.parse_module("policy_v0.rego", concat("", [
-	`package policy
-
-`,
-	policy,
-]))
+with_rego_v0(policy) := regal.parse_module("policy_v0.rego", $"package policy\n\n{policy}")
 
 # METADATA
 # description: parse provided snippet with a generic package declaration added
-policy(snippet) := regal.parse_module("policy.rego", concat("", [
-	"package policy\n\n",
-	snippet,
-]))
+policy(snippet) := regal.parse_module("policy.rego", $"package policy\n\n{snippet}")

--- a/bundle/regal/config/exclusion.rego
+++ b/bundle/regal/config/exclusion.rego
@@ -40,7 +40,7 @@ _patterns_compiler(patterns) := {pat |
 # mydir/p and mydir/d/ are returned as is
 _internal_slashes(pattern) := pattern if {
 	contains(trim_suffix(pattern, "/"), "/")
-} else := concat("", ["**/", pattern])
+} else := $"**/{pattern}"
 
 # **/pattern might match my/dir/pattern and pattern
 # So we branch it into itself and one with the leading **/ removed
@@ -52,11 +52,9 @@ _leading_doublestar_pattern(pattern) := {pattern, p} if {
 # If a pattern does not end with a "/", then it can both
 # - match a folder => pattern + "/**"
 # - match a file => pattern
-_trailing_slash(pattern) := {pattern, np} if {
+_trailing_slash(pattern) := {pattern, $"{pattern}/**"} if {
 	not endswith(pattern, "/")
 	not endswith(pattern, "**")
-	np := concat("", [pattern, "/**"])
-} else := {np} if {
+} else := {$"{pattern}**"} if {
 	endswith(pattern, "/")
-	np := concat("", [pattern, "**"])
 } else := {pattern}

--- a/bundle/regal/lsp/codeaction/codeaction.rego
+++ b/bundle/regal/lsp/codeaction/codeaction.rego
@@ -33,7 +33,7 @@ actions contains action if {
 		"isPreferred": true,
 		"command": {
 			"title": title,
-			"command": concat("", ["regal.fix.", diag.code]),
+			"command": $"regal.fix.{diag.code}",
 			"tooltip": title,
 			"arguments": [json.marshal(object.filter(
 				{
@@ -79,7 +79,7 @@ actions contains action if {
 	some diag in input.params.context.diagnostics
 
 	# always show the docs link
-	title := concat("", ["Show documentation for ", diag.code])
+	title := $"Show documentation for {diag.code}"
 	action := {
 		"title": title,
 		"kind": "quickfix",
@@ -104,7 +104,7 @@ actions contains action if {
 	strings.any_prefix_match("source.explore", only)
 
 	document := trim_prefix(input.params.textDocument.uri, input.regal.environment.workspace_root_uri)
-	explorer_url := concat("", [input.regal.environment.web_server_base_uri, "/explorer", document])
+	explorer_url := $"{input.regal.environment.web_server_base_uri}/explorer{document}"
 	action := {
 		"title": "Explore compiler stages for this policy",
 		"kind": "source.explore",

--- a/bundle/regal/lsp/completion/location/location.rego
+++ b/bundle/regal/lsp/completion/location/location.rego
@@ -96,7 +96,7 @@ word_at(line, col) := word if {
 		"text_after": substring(text_after, offset_after, count(text_after)),
 		"offset_before": offset_before,
 		"offset_after": offset_after,
-		"text": concat("", [word_before, word_after]),
+		"text": $"{word_before}{word_after}",
 	}
 }
 
@@ -115,7 +115,7 @@ ref_at(line, col) := word if {
 	word := {
 		"offset_before": count(word_before),
 		"offset_after": count(word_after),
-		"text": concat("", [word_before, word_after]),
+		"text": $"{word_before}{word_after}",
 	}
 }
 

--- a/bundle/regal/lsp/completion/main.rego
+++ b/bundle/regal/lsp/completion/main.rego
@@ -40,7 +40,7 @@ items contains object.union(completion, {"_regal": {"provider": provider}}) if {
 inside_comment if {
 	# avoid unmarshalling every comment location but only one that starts
 	# with the line number of the current position
-	line := sprintf("%d:", [input.params.position.line + 1])
+	line := $"{input.params.position.line + 1}:"
 
 	some comment in data.workspace.parsed[input.params.textDocument.uri].comments
 

--- a/bundle/regal/lsp/completion/providers/commonrule/commonrule.rego
+++ b/bundle/regal/lsp/completion/providers/commonrule/commonrule.rego
@@ -27,11 +27,11 @@ items contains item if {
 		"detail": "common name",
 		"documentation": {
 			"kind": "markdown",
-			"value": sprintf("%q is a common rule name", [label]),
+			"value": $`"{label}" is a common rule name`,
 		},
 		"textEdit": {
 			"range": location.from_start_of_line_to_position(input.params.position),
-			"newText": concat("", [label, " "]),
+			"newText": $"{label} ",
 		},
 	}
 }

--- a/bundle/regal/lsp/completion/providers/commonrule/commonrule_test.rego
+++ b/bundle/regal/lsp/completion/providers/commonrule/commonrule_test.rego
@@ -26,8 +26,7 @@ import rego.v1
 
 `
 	module := regal.parse_module("p.rego", policy)
-	new_policy := concat("", [policy, "d"])
-	items := provider.items with input as util.input_module_with_location(module, new_policy, {"row": 5, "col": 2})
+	items := provider.items with input as util.input_module_with_location(module, $`{policy}d`, {"row": 5, "col": 2})
 
 	expected_item(items, "deny")
 }
@@ -38,7 +37,7 @@ expected_item(items, label) if {
 		"detail": "common name",
 		"documentation": {
 			"kind": "markdown",
-			"value": sprintf("%q is a common rule name", [label]),
+			"value": $`"{label}" is a common rule name`,
 		},
 		"kind": 15,
 		"textEdit": {
@@ -52,7 +51,7 @@ expected_item(items, label) if {
 					"character": 1,
 				},
 			},
-			"newText": sprintf("%s ", [label]),
+			"newText": $"{label} ",
 		},
 	}
 

--- a/bundle/regal/lsp/completion/providers/default/default.rego
+++ b/bundle/regal/lsp/completion/providers/default/default.rego
@@ -34,12 +34,12 @@ items contains item if {
 	some name in ast.rule_and_function_names
 
 	item := {
-		"label": sprintf("default %s := <value>", [name]),
+		"label": $"default {name} := <value>",
 		"kind": kind.keyword,
-		"detail": sprintf("add default assignment for %s rule", [name]),
+		"detail": $"add default assignment for {name} rule",
 		"textEdit": {
 			"range": location.from_start_of_line_to_position(input.params.position),
-			"newText": sprintf("default %s := ", [name]),
+			"newText": $"default {name} := ",
 		},
 	}
 }

--- a/bundle/regal/lsp/completion/providers/default/default_test.rego
+++ b/bundle/regal/lsp/completion/providers/default/default_test.rego
@@ -11,7 +11,7 @@ import rego.v1
 
 `
 	module := regal.parse_module("p.rego", policy)
-	new_policy := sprintf("%s%s", [policy, "d"])
+	new_policy := $"{policy}d"
 	items := provider.items with input as util.input_module_with_location(module, new_policy, {"row": 5, "col": 2})
 
 	items == {{
@@ -40,7 +40,7 @@ deny if false
 
 `
 	module := regal.parse_module("p.rego", policy)
-	new_policy := sprintf("%s%s", [policy, "d"])
+	new_policy := $"{policy}d"
 	items := provider.items with input as util.input_module_with_location(module, new_policy, {"row": 9, "col": 2})
 
 	items == {

--- a/bundle/regal/lsp/completion/providers/input/input_test.rego
+++ b/bundle/regal/lsp/completion/providers/input/input_test.rego
@@ -36,16 +36,14 @@ allow if {
 }
 
 test_no_input_completion_on_[typed] if {
-	template := `allow if {
-	%s
-}`
-
 	some typed in ["foo.", "data.", "input."]
 
-	policy := _with_header(sprintf(template, [typed]))
+	policy := _with_header($`allow if \{
+		{typed}
+	}`)
 
-	items := provider.items with input as util.input_with_location(policy, {"row": 6, "col": 1 + count(typed)})
+	items := provider.items with input as util.input_with_location(policy, {"row": 6, "col": 2 + count(typed)})
 	items == set()
 }
 
-_with_header(policy) := concat("\n\n", ["package policy", "import rego.v1", policy])
+_with_header(policy) := $"package policy\n\n{policy}"

--- a/bundle/regal/lsp/completion/providers/inputdotjson/inputdotjson.rego
+++ b/bundle/regal/lsp/completion/providers/inputdotjson/inputdotjson.rego
@@ -31,7 +31,7 @@ items contains item if {
 		"detail": type,
 		"documentation": {
 			"kind": "markdown",
-			"value": sprintf("(inferred from [`input.json`](%s))", [input.regal.environment.input_dot_json_path]),
+			"value": $"(inferred from [`input.json`]({input.regal.environment.input_dot_json_path}))",
 		},
 		"textEdit": {
 			"range": location.word_range(word, input.params.position),
@@ -53,7 +53,7 @@ _matching_input_suggestions contains [suggestion, type] if {
 	startswith(suggestion, word.text)
 }
 
-_input_paths contains [input_path, input_type] if {
+_input_paths contains [$"input.{concat(".", path)}", type_name(value)] if {
 	walk(input.regal.environment.input_dot_json, [path, value])
 
 	count(path) > 0
@@ -62,7 +62,4 @@ _input_paths contains [input_path, input_type] if {
 	every value in path {
 		is_string(value)
 	}
-
-	input_type := type_name(value)
-	input_path := concat(".", ["input", concat(".", path)])
 }

--- a/bundle/regal/lsp/completion/providers/packagename/packagename.rego
+++ b/bundle/regal/lsp/completion/providers/packagename/packagename.rego
@@ -31,7 +31,7 @@ items contains item if {
 		"detail": "suggested package name based on directory structure",
 		"textEdit": {
 			"range": location.word_range(word, input.params.position),
-			"newText": concat("", [suggestion, "\n\n"]),
+			"newText": $"{suggestion}\n\n",
 		},
 	}
 }
@@ -70,12 +70,11 @@ _suggestions(dir, text) := [path |
 _needs_quoting(part) := regex.match(`[^a-zA-Z0-9_]`, part)
 
 _format_part(part, false) := part
-_format_part(part, true) := sprintf(`["%s"]`, [part])
+_format_part(part, true) := $`["{part}"]`
 
-_delimit_part(part, next_part) := delimited_part if {
+_delimit_part(part, next_part) := $"{part}." if {
 	next_part != []
 	not startswith(next_part[0], "[")
-	delimited_part := sprintf("%s.", [part])
 }
 
 _delimit_part(part, next_part) := part if {
@@ -83,4 +82,4 @@ _delimit_part(part, next_part) := part if {
 	startswith(next_part[0], "[")
 }
 
-_delimit_part(part, next_part) := part if next_part == []
+_delimit_part(part, []) := part

--- a/bundle/regal/lsp/completion/providers/ruleheadkeyword/ruleheadkeyword_test.rego
+++ b/bundle/regal/lsp/completion/providers/ruleheadkeyword/ruleheadkeyword_test.rego
@@ -15,7 +15,7 @@ test_keyword_completion_after_rule_name_no_prefix[label] if {
 
 	some label, completion in provider.completions
 	expected := object.union(completion, {"textEdit": {
-		"newText": sprintf("%s ", [label]),
+		"newText": $"{label} ",
 		"range": {
 			"start": {"line": 2, "character": 5},
 			"end": {"line": 2, "character": 5},

--- a/bundle/regal/lsp/completion/providers/rulename/rulename.rego
+++ b/bundle/regal/lsp/completion/providers/rulename/rulename.rego
@@ -35,7 +35,7 @@ items contains item if {
 		"detail": _kind_detail[kind],
 		"textEdit": {
 			"range": location.word_range(word, input.params.position),
-			"newText": concat("", [name, " "]),
+			"newText": $"{name} ",
 		},
 	}
 }

--- a/bundle/regal/lsp/completion/providers/rulename/rulename_test.rego
+++ b/bundle/regal/lsp/completion/providers/rulename/rulename_test.rego
@@ -5,7 +5,7 @@ import data.regal.lsp.completion.providers.rulename as provider
 test_rule_name_completion[title] if {
 	above := "package p\n\n"
 	below := "\n\nconstant := 5\n\nfunction(_) := true\n\nrule if 1 + 1 == 3\n\nrule if true\n"
-	cache := {"file:///ws/p.rego": regal.parse_module("p.rego", concat("", [above, below]))}
+	cache := {"file:///ws/p.rego": regal.parse_module("p.rego", $"{above}{below}")}
 
 	some case in [
 		{"name": "all", "typed": "", "expect": ["constant", "function", "rule"]},
@@ -14,7 +14,7 @@ test_rule_name_completion[title] if {
 		{"name": "rule", "typed": "r", "expect": ["rule"]},
 	]
 
-	title := sprintf("typing '%s' suggests: %s", [case.typed, concat(", ", case.expect)])
+	title := $"typing '{case.typed}' suggests: {concat(", ", case.expect)}"
 	items := provider.items with data.workspace.parsed as cache with input as {
 		"params": {
 			"textDocument": {"uri": "file:///ws/p.rego"},
@@ -33,7 +33,7 @@ test_rule_name_completion[title] if {
 test_rule_name_completion_only_start_of_line if {
 	above := "package p\n\n"
 	below := "\n\nconstant := 5\n\nfunction(_) := true\n\nrule if 1 + 1 == 3\n\nrule if true\n"
-	cache := {"file:///ws/p.rego": regal.parse_module("p.rego", concat("", [above, below]))}
+	cache := {"file:///ws/p.rego": regal.parse_module("p.rego", $"{above}{below}")}
 	typed := "foo r"
 	items := provider.items with data.workspace.parsed as cache with input as {
 		"params": {
@@ -49,14 +49,14 @@ test_rule_name_completion_only_start_of_line if {
 test_rule_name_completion_no_tests if {
 	above := "package p\n\n"
 	below := "\n\ntest_foo if true\n\n"
-	cache := {"file:///ws/p.rego": regal.parse_module("p.rego", concat("", [above, below]))}
+	cache := {"file:///ws/p.rego": regal.parse_module("p.rego", $"{above}{below}")}
 	typed := "t"
 	items := provider.items with data.workspace.parsed as cache with input as {
 		"params": {
 			"textDocument": {"uri": "file:///ws/p.rego"},
 			"position": {"line": 2, "character": count(typed)},
 		},
-		"regal": {"file": {"lines": split(concat("", [above, typed, below]), "\n")}},
+		"regal": {"file": {"lines": split($"{above}{typed}{below}", "\n")}},
 	}
 
 	count(items) == 0

--- a/bundle/regal/lsp/completion/providers/rulerefs/rulerefs.rego
+++ b/bundle/regal/lsp/completion/providers/rulerefs/rulerefs.rego
@@ -55,7 +55,7 @@ _other_package_refs contains ref if {
 _rule_ref_suggestions contains pkg_ref if {
 	some ref in _current_package_refs
 
-	pkg_ref := trim_prefix(ref, concat("", [_current_file_package, "."]))
+	pkg_ref := trim_prefix(ref, $"{_current_file_package}.")
 }
 
 # from imported packages
@@ -66,7 +66,7 @@ _rule_ref_suggestions contains pkg_ref if {
 	startswith(ref, imported_package)
 
 	prefix := regex.replace(imported_package, `\.[^\.]+$`, "")
-	pkg_ref := trim_prefix(ref, concat("", [prefix, "."]))
+	pkg_ref := trim_prefix(ref, $"{prefix}.")
 }
 
 # from any other package

--- a/bundle/regal/lsp/completion/providers/snippet/snippet.rego
+++ b/bundle/regal/lsp/completion/providers/snippet/snippet.rego
@@ -31,7 +31,7 @@ items contains item if {
 	strings.count(line, snippet.prefix[0]) < 2
 
 	item := {
-		"label": sprintf("%s (snippet)", [label]),
+		"label": $"{label} (snippet)",
 		"kind": kind.snippet,
 		"detail": label,
 		"textEdit": {

--- a/bundle/regal/lsp/completion/providers/snippet/snippet_test.rego
+++ b/bundle/regal/lsp/completion/providers/snippet/snippet_test.rego
@@ -185,4 +185,8 @@ test_metadata_snippet_completion if {
 	}
 }
 
-_with_header(policy) := concat("\n\n", ["package policy", "import rego.v1", policy])
+_with_header(policy) := $`package policy
+
+import rego.v1
+
+{policy}`

--- a/bundle/regal/lsp/documentlink/documentlink.rego
+++ b/bundle/regal/lsp/documentlink/documentlink.rego
@@ -40,12 +40,12 @@ items contains item if {
 	col := loc.col + pos
 
 	item := {
-		"target": concat("/", ["https://www.openpolicyagent.org/projects/regal/rules", _category_for[rule], rule]),
+		"target": $"https://www.openpolicyagent.org/projects/regal/rules/{_category_for[rule]}/{rule}",
 		"range": {
 			"start": {"line": row, "character": col},
 			"end": {"line": row, "character": col + count(rule)},
 		},
-		"tooltip": concat(" ", ["See documentation for", rule]),
+		"tooltip": $"See documentation for {rule}",
 	}
 }
 

--- a/bundle/regal/result/result.rego
+++ b/bundle/regal/result/result.rego
@@ -135,7 +135,7 @@ _related_resources(annotations, category, title) := rr if {
 	not annotations.related_resources
 	rr := [{
 		"description": "documentation",
-		"ref": sprintf("%s/%s/%s", [config.docs.base_url, category, title]),
+		"ref": $"{config.docs.base_url}/{category}/{title}",
 	}]
 }
 
@@ -183,8 +183,6 @@ _with_text(loc_obj) := loc if {
 		"file": input.regal.file.name,
 		"text": input.regal.file.lines[loc_obj.row - 1],
 	})}
-
-	loc_obj.row
 } else := {"location": loc_obj}
 
 # METADATA

--- a/bundle/regal/rules/bugs/constant-condition/constant_condition.rego
+++ b/bundle/regal/rules/bugs/constant-condition/constant_condition.rego
@@ -6,13 +6,13 @@ import data.regal.ast
 import data.regal.result
 
 # METADATA
-# description: single scalar value, like a lone `true` inside a rule body
+# description: single scalar value or templatestring, like a lone `true` inside a rule body
 # scope: rule
 report contains violation if {
 	terms := ast.found.expressions[_][_].terms
 
 	# We could include composite types too, but less comomon and more expensive to check
-	terms.type in ast.scalar_types
+	terms.type in {"boolean", "null", "number", "string", "templatestring"}
 
 	violation := result.fail(rego.metadata.chain(), result.location(terms))
 }

--- a/bundle/regal/rules/bugs/constant-condition/constant_condition_test.rego
+++ b/bundle/regal/rules/bugs/constant-condition/constant_condition_test.rego
@@ -31,6 +31,37 @@ test_fail_simple_constant_condition if {
 	}}
 }
 
+test_fail_if_template_string_constant_condition if {
+	r := rule.report with input as ast.policy(`allow if $"{input.foo == 1}"`)
+
+	r == {{
+		"category": "bugs",
+		"description": "Constant condition",
+		"location": {
+			"col": 10,
+			"file": "policy.rego",
+			"row": 3,
+			"text": `allow if $"{input.foo == 1}"`,
+			"end": {
+				"row": 3,
+				"col": 29,
+			},
+		},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/constant-condition", "bugs"),
+		}],
+		"title": "constant-condition",
+		"level": "error",
+	}}
+}
+
+test_success_emplate_string_non_constant_condition if {
+	r := rule.report with input as ast.policy(`allow if $"{input.foo}" == "bar"`)
+
+	r == set()
+}
+
 test_fail_simple_constant_condition_nested if {
 	r := rule.report with input as ast.policy(`allow if {
 		every x in [1, 2] {

--- a/bundle/regal/rules/bugs/duplicate-rule/duplicate_rule.rego
+++ b/bundle/regal/rules/bugs/duplicate-rule/duplicate_rule.rego
@@ -21,7 +21,7 @@ report contains violation if {
 	))
 }
 
-_message(locations) := sprintf("Duplicate rule found at line %d", [locations[0].row]) if count(locations) == 1
+_message(locations) := $"Duplicate rule found at line {locations[0].row}" if count(locations) == 1
 
 _message(locations) := sprintf(
 	"Duplicate rules found at lines %s",

--- a/bundle/regal/rules/bugs/not-equals-in-loop/not_equals_in_loop.rego
+++ b/bundle/regal/rules/bugs/not-equals-in-loop/not_equals_in_loop.rego
@@ -8,6 +8,7 @@ import data.regal.result
 report contains violation if {
 	some rule_index, i
 	ast.found.expressions[rule_index][i].terms[0].type == "ref"
+	not ast.found.expressions[rule_index][i].interpolated
 
 	terms := ast.found.expressions[rule_index][i].terms
 

--- a/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value.rego
+++ b/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value.rego
@@ -7,7 +7,10 @@ import data.regal.config
 import data.regal.result
 
 report contains violation if {
-	terms := ast.found.expressions[_][_].terms
+	some expr
+	terms := ast.found.expressions[_][expr].terms
+
+	not expr.interpolated
 
 	terms[0].type == "ref"
 	terms[0].value[0].type == "var"

--- a/bundle/regal/rules/bugs/unused-output-variable/unused_output_variable_test.rego
+++ b/bundle/regal/rules/bugs/unused-output-variable/unused_output_variable_test.rego
@@ -46,6 +46,31 @@ test_fail_unused_output_variable_some if {
 	}}
 }
 
+# NOTE(anders): this should be caught! don't have the time to look into this now though,
+# so just leaving this test here for someone to come back to later
+_test_fail_unused_output_variable_assignment if {
+	# regal ignore:with-outside-test-context
+	r := rule.report with input as ast.policy(`
+	fail if {
+		some y
+		x := input[y]
+		x == 0
+	}
+	`)
+
+	r == {{
+		"category": "bugs",
+		"description": "Unused output variable",
+		"level": "error",
+		"location": {"col": 14, "end": {"col": 15, "row": 6}, "file": "policy.rego", "row": 6, "text": "\t\tx := input[y]"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/unused-output-variable", "bugs"),
+		}],
+		"title": "unused-output-variable",
+	}}
+}
+
 test_success_unused_wildcard if {
 	r := rule.report with input as ast.policy("success if input[_]")
 

--- a/bundle/regal/rules/custom/naming-convention/naming_convention.rego
+++ b/bundle/regal/rules/custom/naming-convention/naming_convention.rego
@@ -15,10 +15,7 @@ report contains violation if {
 
 	violation := _with_description(
 		result.fail(rego.metadata.chain(), result.location(input.package)),
-		sprintf(
-			"Naming convention violation: package name %q does not match pattern '%s'",
-			[ast.package_name, convention.pattern],
-		),
+		_message("package", ast.package_name, convention.pattern),
 	)
 }
 
@@ -35,10 +32,7 @@ report contains violation if {
 
 	violation := _with_description(
 		result.fail(rego.metadata.chain(), result.location(rule.head)),
-		sprintf(
-			"Naming convention violation: rule name %q does not match pattern '%s'",
-			[name, convention.pattern],
-		),
+		_message("rule", name, convention.pattern),
 	)
 }
 
@@ -55,10 +49,7 @@ report contains violation if {
 
 	violation := _with_description(
 		result.fail(rego.metadata.chain(), result.location(rule.head)),
-		sprintf(
-			"Naming convention violation: function name %q does not match pattern '%s'",
-			[name, convention.pattern],
-		),
+		_message("function", name, convention.pattern),
 	)
 }
 
@@ -75,12 +66,11 @@ report contains violation if {
 
 	violation := _with_description(
 		result.fail(rego.metadata.chain(), result.location(var)),
-		sprintf(
-			"Naming convention violation: variable name %q does not match pattern '%s'",
-			[var.value, convention.pattern],
-		),
+		_message("variable", var.value, convention.pattern),
 	)
 }
+
+_message(kind, name, pattern) := $`Naming convention violation: {kind} name "{name}" does not match pattern '{pattern}'`
 
 _with_description(violation, description) := json.patch(
 	violation,

--- a/bundle/regal/rules/custom/narrow-argument/narrow_argument.rego
+++ b/bundle/regal/rules/custom/narrow-argument/narrow_argument.rego
@@ -23,10 +23,7 @@ report contains violation if {
 	))
 }
 
-_message(1, arg, narrowed) := sprintf(
-	"Argument %s only referenced as %s, value passed can be narrowed",
-	[arg, narrowed],
-)
+_message(1, arg, narrowed) := $"Argument {arg} only referenced as {narrowed}, value passed can be narrowed"
 
 _message(n, arg, narrowed) := sprintf(
 	"Argument %s always referenced by a common prefix, value passed can be narrowed to %s",

--- a/bundle/regal/rules/idiomatic/use-strings-count/use_strings_count_test.rego
+++ b/bundle/regal/rules/idiomatic/use-strings-count/use_strings_count_test.rego
@@ -6,9 +6,8 @@ import data.regal.config
 import data.regal.rules.idiomatic["use-strings-count"] as rule
 
 test_fail_can_use_strings_count if {
-	module := ast.with_rego_v1(`x := count(indexof_n("foo", "o"))`)
+	r := rule.report with input as ast.with_rego_v1(`x := count(indexof_n("foo", "o"))`)
 
-	r := rule.report with input as module
 	r == {{
 		"category": "idiomatic",
 		"description": "Use `strings.count` where possible",
@@ -30,6 +29,7 @@ test_fail_can_use_strings_count if {
 
 test_has_notice_if_unmet_capability if {
 	r := rule.notices with config.capabilities as {}
+
 	r == {{
 		"category": "idiomatic",
 		"description": "Missing capability for built-in function `strings.count`",

--- a/bundle/regal/rules/imports/circular-import/circular_import.rego
+++ b/bundle/regal/rules/imports/circular-import/circular_import.rego
@@ -50,13 +50,10 @@ aggregate_report contains violation if {
 		some loc in _package_locations[m1][m2]
 	][0]
 
-	violation := result.fail(
-		rego.metadata.chain(),
-		{
-			"description": sprintf("Circular import detected in: %s", [concat(", ", sort(g))]),
-			"location": location,
-		},
-	)
+	violation := result.fail(rego.metadata.chain(), {
+		"description": $`Circular import detected in: {concat(", ", sorted_group)}`,
+		"location": location,
+	})
 }
 
 # METADATA
@@ -70,13 +67,10 @@ aggregate_report contains violation if {
 
 	some pkg in g # this will the only package
 
-	violation := result.fail(
-		rego.metadata.chain(),
-		{
-			"description": sprintf("Circular self-dependency in: %s", [pkg]),
-			"location": [e | some e in _package_locations[pkg][pkg]][0],
-		},
-	)
+	violation := result.fail(rego.metadata.chain(), {
+		"description": $`Circular self-dependency in: {pkg}`,
+		"location": [e | some e in _package_locations[pkg][pkg]][0],
+	})
 }
 
 # METADATA
@@ -87,7 +81,7 @@ _package_locations[referenced_pkg][referencing_pkg] contains location if {
 
 	some [referenced_pkg, referenced_location] in ag_pkg.aggregate_data.refs
 
-	referencing_pkg := sprintf("data.%s", [concat(".", ag_pkg.aggregate_source.package_path)])
+	referencing_pkg := $"data.{concat(".", ag_pkg.aggregate_source.package_path)}"
 	ref_loc := util.to_location_no_text(referenced_location)
 
 	location := {
@@ -103,8 +97,7 @@ _package_locations[referenced_pkg][referencing_pkg] contains location if {
 _import_graph[pkg] contains edge if {
 	some ag_pkg in input.aggregate
 
-	pkg := sprintf("data.%s", [concat(".", ag_pkg.aggregate_source.package_path)])
-
+	pkg := $"data.{concat(".", ag_pkg.aggregate_source.package_path)}"
 	edge := ag_pkg.aggregate_data.refs[_][0]
 }
 

--- a/bundle/regal/rules/imports/ignored-import/ignored_import.rego
+++ b/bundle/regal/rules/imports/ignored-import/ignored_import.rego
@@ -28,6 +28,6 @@ report contains violation if {
 
 	violation := result.fail(rego.metadata.chain(), object.union(
 		result.location(ref),
-		{"description": sprintf("Reference ignores import of %s", [concat(".", most_specific_match)])},
+		{"description": $"Reference ignores import of {concat(".", most_specific_match)}"},
 	))
 }

--- a/bundle/regal/rules/style/comprehension-term-assignment/comprehension_term_assignment_test.rego
+++ b/bundle/regal/rules/style/comprehension-term-assignment/comprehension_term_assignment_test.rego
@@ -134,7 +134,7 @@ test_fail_object_comprehension_value_assignment_static_ref if {
 test_success_not_flagging_function_call if {
 	r := rule.report with input as ast.policy(`comp := [x |
 		some y in input
-		x := http.send({"method": "get", "url": sprintf("https://example.org/%s", [y])})
+		x := http.send({"method": "get", "url": $"https://example.org/{y}"})
 	]`)
 
 	r == set()

--- a/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package.rego
+++ b/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package.rego
@@ -14,6 +14,8 @@ import data.regal.util
 report contains violation if {
 	some rule in input.rules
 
+	ast.ref_static_to_string(rule.head.ref)
+
 	strings.any_prefix_match(ast.ref_static_to_string(rule.head.ref), _possible_offending_prefixes)
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule.head.ref[0]))

--- a/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package_test.rego
+++ b/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package_test.rego
@@ -1,19 +1,15 @@
 package regal.rules.style["rule-name-repeats-package_test"]
 
-import data.regal.config
-
 import data.regal.rules.style["rule-name-repeats-package"] as rule
-
-related_resources := [{
-	"description": "documentation",
-	"ref": config.docs.resolve_url("$baseUrl/$category/rule-name-repeats-package", "style"),
-}]
 
 base_result := {
 	"title": "rule-name-repeats-package",
 	"description": "Rule name repeats package",
 	"category": "style", "level": "error",
-	"related_resources": related_resources,
+	"related_resources": [{
+		"description": "documentation",
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/rule-name-repeats-package",
+	}],
 }
 
 test_rule_empty_if_no_repetition if {

--- a/bundle/regal/util/util_test.rego
+++ b/bundle/regal/util/util_test.rego
@@ -47,7 +47,7 @@ test_to_location_object if {
 	}
 }
 
-test_point_in_range[sprintf("%v %v", [point, range])] if {
+test_point_in_range[$"{point} {range}"] if {
 	some [point, range, want] in [
 		[[1, 2], [[0, 0], [1, 10]], true],
 		[[0, 3], [[0, 1], [0, 4]], true],

--- a/docs/custom-rules/roast.md
+++ b/docs/custom-rules/roast.md
@@ -207,6 +207,24 @@ The `name` attribute found in the OPA AST for `rules` is unreliable, as it's not
 attribute however always is. While this doesn't come with any real cost in terms of AST size or performance, consistency
 is key.
 
+### Added `interpolated` boolean attribute to template string expression nodes
+
+Expressions found in template strings (like `$"{upper(input.name)}"`) are normal expressions as far as OPA is concerned.
+While that may be true, some linter rules targeted at "normal" expressions aren't applicable for expressions found
+in template strings. Take for example the
+[unassigned-return-value](https://www.openpolicyagent.org/projects/regal/rules/bugs/unassigned-return-value) rule, which
+would normally consider an expression like `upper(input.name)` to be a bug, as the return value of the `upper` call
+never is assigned. This is not the case for expressions found in template strings, as the output of their expressions
+is used to build the interpolated string. In order to avoid traversing the module tree twice — once for regular
+expressions, and once for expressions found in template strings — the Roast format instead marks expressions
+template strings with an `interpolated` boolean attribute set to `true`. This attribute is only present for
+expressions found in template strings, and is thus either `true` or missing, never `false`.
+
+### Template string `multi_line` attribute only present when `true`
+
+Following the Roast convention of omitting boolean attributes that are `false`, the `multi_line` attribute found
+on template string nodes is only present when `true`.
+
 ### Fixed inconsistencies in the original Rego AST
 
 A few inconsistencies exist in the original AST JSON format:

--- a/docs/readme-sections/badges.md
+++ b/docs/readme-sections/badges.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable MD041 -->
 
 [![Build Status](https://github.com/open-policy-agent/regal/workflows/Build/badge.svg)](https://github.com/open-policy-agent/regal/actions)
-![OPA v1.12.1](https://www.openpolicyagent.org/badge/v1.12.1)
+![OPA v1.12.2](https://www.openpolicyagent.org/badge/v1.12.2)
 [![codecov](https://codecov.io/github/open-policy-agent/regal/graph/badge.svg?token=EQK01YF3X3)](https://codecov.io/github/StyraInc/regal)
 [![Downloads](https://img.shields.io/github/downloads/open-policy-agent/regal/total.svg)](https://github.com/open-policy-agent/regal/releases)

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/jstemmer/go-junit-report/v2 v2.1.0
 	github.com/olekukonko/tablewriter v1.1.0
-	github.com/open-policy-agent/opa v1.12.1
+	github.com/open-policy-agent/opa v1.12.2
 	github.com/owenrumney/go-sarif/v2 v2.3.3
 	github.com/pdevine/go-asciisprite v0.1.6
 	github.com/pkg/profile v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
-github.com/open-policy-agent/opa v1.12.1 h1:MWfmXuXB119O7rSOJ5GdKAaW15yBirjnLkFRBGy0EX0=
-github.com/open-policy-agent/opa v1.12.1/go.mod h1:RnDgm04GA1RjEXJvrsG9uNT/+FyBNmozcPvA2qz60M4=
+github.com/open-policy-agent/opa v1.12.2 h1:Nh60UaIBP6NKCgy45jmMHZwNYALtNR9e/hj+Lna49mc=
+github.com/open-policy-agent/opa v1.12.2/go.mod h1:RnDgm04GA1RjEXJvrsG9uNT/+FyBNmozcPvA2qz60M4=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
 github.com/owenrumney/go-sarif/v2 v2.3.3 h1:ubWDJcF5i3L/EIOER+ZyQ03IfplbSU1BLOE26uKQIIU=

--- a/internal/explorer/stages.go
+++ b/internal/explorer/stages.go
@@ -34,6 +34,7 @@ var stages = []stage{
 	{"SetModuleTree", "compile_stage_set_module_tree"},
 	{"SetRuleTree", "compile_stage_set_rule_tree"},
 	{"RewriteLocalVars", "compile_stage_rewrite_local_vars"},
+	{"RewriteTemplateStrings", "compile_stage_rewrite_template_strings"},
 	{"CheckVoidCalls", "compile_stage_check_void_calls"},
 	{"RewritePrintCalls", "compile_stage_rewrite_print_calls"},
 	{"RewriteExprTerms", "compile_stage_rewrite_expr_terms"},

--- a/internal/io/io_test.go
+++ b/internal/io/io_test.go
@@ -121,6 +121,47 @@ func TestDirCleanUpPaths(t *testing.T) {
 	}
 }
 
+func TestCapabilitiesNoDuplicateBuiltins(t *testing.T) {
+	t.Parallel()
+
+	builtinSet := util.NewSet[string]()
+
+	for _, b := range Capabilities().Builtins {
+		if builtinSet.Contains(b.Name) {
+			t.Fatalf("duplicate builtin found: %s", b.Name)
+		}
+
+		builtinSet.Add(b.Name)
+	}
+}
+
+func TestCapabilitiesIncludeRegalBuiltins(t *testing.T) {
+	t.Parallel()
+
+	expectedBuiltins := util.NewSet("regal.parse_module", "regal.last", "regal.is_formatted")
+	found := util.NewSet[string]()
+
+	for _, b := range Capabilities().Builtins {
+		if expectedBuiltins.Contains(b.Name) {
+			found.Add(b.Name)
+		}
+	}
+
+	if !expectedBuiltins.Equal(found) {
+		t.Fatalf("expected builtins %v, got %v", expectedBuiltins, found)
+	}
+}
+
+func TestOPACapabilitiesIncludeNoRegalBuiltins(t *testing.T) {
+	t.Parallel()
+
+	for _, b := range OPACapabilities().Builtins {
+		if strings.HasPrefix(b.Name, "regal.") {
+			t.Fatalf("found regal builtin in opa capabilities: %s", b.Name)
+		}
+	}
+}
+
 func BenchmarkLoadRegalBundlePath(b *testing.B) {
 	for b.Loop() {
 		_, err := LoadRegalBundlePath("../../bundle")

--- a/internal/roast/encoding/expr.go
+++ b/internal/roast/encoding/expr.go
@@ -29,6 +29,13 @@ func (*exprCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 		write.Bool(stream, strGenerated, expr.Generated)
 	}
 
+	if stream.Attachment != nil {
+		if s, ok := stream.Attachment.(string); ok && s == "interpolated" {
+			write.Bool(stream, "interpolated", true)
+			stream.Attachment = nil
+		}
+	}
+
 	if len(expr.With) > 0 {
 		write.ValsArrayAttr(stream, strWith, expr.With)
 	}

--- a/internal/roast/encoding/init.go
+++ b/internal/roast/encoding/init.go
@@ -29,6 +29,7 @@ func init() {
 	jsoniter.RegisterTypeEncoder("ast.ArrayComprehension", &arrayComprehensionCodec{})
 	jsoniter.RegisterTypeEncoder("ast.ObjectComprehension", &objectComprehensionCodec{})
 	jsoniter.RegisterTypeEncoder("ast.SetComprehension", &setComprehensionCodec{})
+	jsoniter.RegisterTypeEncoder("ast.TemplateString", &templateStringCodec{})
 
 	// special cases as these are not public — see implementation for details
 	jsoniter.RegisterTypeEncoder("ast.set", &setCodec{})

--- a/internal/roast/encoding/templatestring.go
+++ b/internal/roast/encoding/templatestring.go
@@ -1,0 +1,45 @@
+package encoding
+
+import (
+	"unsafe"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+)
+
+type templateStringCodec struct{}
+
+func (*templateStringCodec) IsEmpty(_ unsafe.Pointer) bool {
+	return false
+}
+
+func (*templateStringCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	sc := *((*ast.TemplateString)(ptr))
+
+	stream.WriteObjectStart()
+
+	if sc.MultiLine {
+		stream.WriteObjectField("multi_line")
+		stream.WriteBool(sc.MultiLine)
+		stream.WriteMore()
+	}
+
+	stream.WriteObjectField("parts")
+	stream.WriteArrayStart()
+
+	for i, part := range sc.Parts {
+		if i > 0 {
+			stream.WriteMore()
+		}
+
+		if _, ok := part.(*ast.Expr); ok {
+			stream.Attachment = "interpolated"
+		}
+
+		stream.WriteVal(part)
+	}
+
+	stream.WriteArrayEnd()
+	stream.WriteObjectEnd()
+}

--- a/internal/roast/encoding/templatestring_test.go
+++ b/internal/roast/encoding/templatestring_test.go
@@ -1,0 +1,48 @@
+package encoding
+
+import (
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+)
+
+func TestTemplateStringMarshalling(t *testing.T) {
+	t.Parallel()
+
+	templateStr := ast.TemplateString{
+		MultiLine: true,
+		Parts: []ast.Node{
+			ast.StringTerm("foo ").SetLocation(ast.NewLocation([]byte("foo "), "p.rego", 10, 1)),
+			&ast.Expr{
+				Location: ast.NewLocation([]byte("bar"), "p.rego", 10, 6),
+				Terms:    ast.VarTerm("bar").SetLocation(ast.NewLocation([]byte("bar"), "p.rego", 10, 6)),
+			},
+		},
+	}
+
+	stream := jsoniter.ConfigFastest.BorrowStream(nil)
+	stream.WriteVal(templateStr)
+
+	var m map[string]any
+	if err := jsoniter.ConfigFastest.Unmarshal(stream.Buffer(), &m); err != nil {
+		t.Fatalf("unexpected error during unmarshalling: %v", err)
+	}
+
+	// Back to JSON, with sorted keys for comparison
+	bs, err := jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(m)
+	if err != nil {
+		t.Fatalf("unexpected error during marshalling: %v", err)
+	}
+
+	expected := `{"multi_line":true,` +
+		`"parts":[` +
+		`{"location":"10:1:10:5","type":"string","value":"foo "},` +
+		`{"interpolated":true,"location":"10:6:10:9","terms":{"location":"10:6:10:9","type":"var","value":"bar"}}` +
+		`]}`
+
+	if string(bs) != expected {
+		t.Fatalf("expected marshalled template string to be:\n%s\nbut got:\n%s", expected, string(bs))
+	}
+}

--- a/internal/roast/transforms/testdata/ast.rego
+++ b/internal/roast/transforms/testdata/ast.rego
@@ -242,7 +242,7 @@ _ref_part_to_string(0, part) := part.value
 
 _ref_part_to_string(i, part) := _format_part(part) if i > 0
 
-_format_part(part) := sprintf(".%s", [part.value]) if {
+_format_part(part) := concat("", [".", part.value]) if {
 	part.type == "string"
 	regex.match(`^[a-zA-Z_][a-zA-Z1-9_]*$`, part.value)
 } else := sprintf(`["%v"]`, [part.value]) if {

--- a/pkg/builtins/regal/regal.go
+++ b/pkg/builtins/regal/regal.go
@@ -59,8 +59,6 @@ var (
 		),
 		CanSkipBctx: true,
 	}
-
-	capabilities *ast.Capabilities
 )
 
 func init() {
@@ -71,10 +69,6 @@ func init() {
 	topdown.RegisterBuiltinFunc(ParseModule.Name, RegalParseModule)
 	topdown.RegisterBuiltinFunc(Last.Name, RegalLast)
 	topdown.RegisterBuiltinFunc(IsFormatted.Name, RegalIsFormatted)
-
-	// This here only to allow the io package to import builtins without causing a cicular dependency.
-	capabilities = ast.CapabilitiesForThisVersion()
-	capabilities.Builtins = append(capabilities.Builtins, ParseModule, Last, IsFormatted)
 }
 
 // RegalParseModule regal.parse_module, like rego.parse_module but with location data included in AST.
@@ -92,7 +86,7 @@ func RegalParseModule(_ rego.BuiltinContext, operands []*ast.Term, iter func(*as
 	filenameStr := string(filenameValue)
 	policyStr := string(policyValue)
 
-	opts := ast.ParserOptions{ProcessAnnotation: true, Capabilities: capabilities}
+	opts := ast.ParserOptions{ProcessAnnotation: true}
 
 	// Allow testing Rego v0 modules. We could provide a separate builtin for this,
 	// but the need for this will likely diminish over time, so let's start simple.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -700,7 +700,7 @@ func extractDefaults(c *Config, result *marshallingIntermediary) error {
 
 // CapabilitiesForThisVersion returns the capabilities for the current OPA version Regal depends on.
 func CapabilitiesForThisVersion() *Capabilities {
-	return fromOPACapabilities(rio.OPACapabilities)
+	return fromOPACapabilities(rio.OPACapabilities())
 }
 
 func fromOPABuiltin(builtin ast.Builtin) *Builtin {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -372,7 +372,7 @@ func TestUnmarshalConfigDefaultCapabilities(t *testing.T) {
 	t.Parallel()
 
 	conf := testutil.MustUnmarshalYAML[Config](t, []byte("rules: {}\n"))
-	caps := io.OPACapabilities
+	caps := io.Capabilities()
 
 	if exp, got := len(caps.Builtins), len(conf.Capabilities.Builtins); exp != got {
 		t.Errorf("expected %d builtins, got %d", exp, got)

--- a/pkg/linter/linter_bench_test.go
+++ b/pkg/linter/linter_bench_test.go
@@ -11,9 +11,7 @@ import (
 	"github.com/open-policy-agent/regal/pkg/report"
 )
 
-// 756176916 ns/op	2614292780 B/op	53440051 allocs/op
-// 730942916 ns/op	2464477440 B/op	51673366 allocs/op
-// 728470104 ns/op	2352869984 B/op	51152483 allocs/op
+// 736486708 ns/op	2348230496 B/op	51198148 allocs/op // OPA v1.12.2
 func BenchmarkRegalLintingItself(b *testing.B) {
 	conf := testutil.Must(config.FromPath(filepath.Join("..", "..", ".regal", "config.yaml")))(b)
 
@@ -32,6 +30,7 @@ func BenchmarkRegalLintingItself(b *testing.B) {
 }
 
 // 694275500 ns/op	2568604236 B/op	52506343 allocs/op // OPA v1.10.0
+// 656495042 ns/op	2309640068 B/op	50264746 allocs/op // OPA v1.12.2
 func BenchmarkRegalLintingItselfPrepareOnce(b *testing.B) {
 	conf := testutil.Must(config.FromPath(filepath.Join("..", "..", ".regal", "config.yaml")))(b)
 
@@ -50,8 +49,8 @@ func BenchmarkRegalLintingItselfPrepareOnce(b *testing.B) {
 	testutil.AssertNumViolations(b, 0, rep)
 }
 
-// 65815866 ns/op   43852693 B/op   1025467 allocs/op // OPA v1.10.0
-// 59223982 ns/op	37109532 B/op	  921483 allocs/op
+// 65815866 ns/op   43852693 B/op    1025467 allocs/op // OPA v1.10.0
+// 64977849 ns/op   38570571 B/op     932404 allocs/op // OPA v1.12.2
 func BenchmarkOnlyPrepare(b *testing.B) {
 	conf := testutil.Must(config.FromPath(filepath.Join("..", "..", ".regal", "config.yaml")))(b)
 	linter := NewLinter().WithInputPaths([]string{"../../bundle"}).WithUserConfig(conf)
@@ -62,6 +61,7 @@ func BenchmarkOnlyPrepare(b *testing.B) {
 }
 
 // 127396828 ns/op	300739526 B/op	 5938689 allocs/op // OPA v1.10.0
+// 123784616 ns/op	284724624 B/op	 5918990 allocs/op // OPA v1.12.2
 func BenchmarkRegalNoEnabledRules(b *testing.B) {
 	linter := NewLinter().
 		WithInputPaths([]string{"../../bundle"}).
@@ -78,6 +78,7 @@ func BenchmarkRegalNoEnabledRules(b *testing.B) {
 }
 
 // 53643340 ns/op	256599746 B/op	 4910862 allocs/op // OPA v1.10.0
+// 53197442 ns/op	245969548 B/op	 4984253 allocs/op // OPA v1.12.2
 func BenchmarkRegalNoEnabledRulesPrepareOnce(b *testing.B) {
 	linter := NewLinter().
 		WithInputPaths([]string{"../../bundle"}).

--- a/pkg/roast/intern/intern.go
+++ b/pkg/roast/intern/intern.go
@@ -87,6 +87,10 @@ func init() {
 		"capabilities",
 		"system",
 		"main",
+		"templatestring",
+		"parts",
+		"multi_line",
+		"interpolated",
 
 		// Regal specific keys
 		"file",

--- a/pkg/roast/rast/rast.go
+++ b/pkg/roast/rast/rast.go
@@ -4,6 +4,7 @@ package rast
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"reflect"
 	"slices"
 	"strconv"
@@ -219,8 +220,7 @@ func toAstValue(v any) ast.Value {
 		return ast.InternedTerm(rv.Bool()).Value
 	}
 	// Fallback: string representation
-	//nolint:forbidigo
-	fmt.Println("WARNING: Unsupported type for conversion to ast.Value:", rv.Kind())
+	fmt.Fprintln(os.Stderr, "WARNING: Unsupported type for conversion to ast.Value:", rv.Kind())
 
 	return ast.String(fmt.Sprintf("%v", v))
 }


### PR DESCRIPTION
- Bump our capabilities.json to include new feature
- And the deprecated attribute on builtins
- Remove related workaround that was previously required
- Update docs on RoAST to cover the `interpolated` attribute added to template string expressions
- Update constant-condition rule to include expressions that only contain a template string
- Make `ast.ref_static_to_string` and `ast.static_ref` aware of template strings, and that they are not to be counted as static.
- Make `ast.has_named_var` take template strings into account
- Add various tests to ensure template strings are considered by helper rules and functions in the `ast` package
- Replace `sprintf` and `concat` calls all over the code base. Extremely satisfying! Although this also uncovered a few issues in OPA which required a v1.12.2 release
- RoAST serialization of template strings