### PR TITLE
Move `chained-rule-body` to `custom` category

### DIFF
--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -57,6 +57,8 @@ rules:
     zero-arity-function:
       level: error
   custom:
+    chained-rule-body:
+      level: ignore
     disallow-rego-v1:
       level: ignore
     forbidden-function-call:
@@ -155,8 +157,6 @@ rules:
       level: error
   style:
     avoid-get-and-list-prefix:
-      level: error
-    chained-rule-body:
       level: error
     comprehension-term-assignment:
       level: error

--- a/bundle/regal/rules/custom/chained-rule-body/chained_rule_body.rego
+++ b/bundle/regal/rules/custom/chained-rule-body/chained_rule_body.rego
@@ -1,6 +1,6 @@
 # METADATA
 # description: Avoid chaining rule bodies
-package regal.rules.style["chained-rule-body"]
+package regal.rules.custom["chained-rule-body"]
 
 import data.regal.ast
 import data.regal.result

--- a/bundle/regal/rules/custom/chained-rule-body/chained_rule_body_test.rego
+++ b/bundle/regal/rules/custom/chained-rule-body/chained_rule_body_test.rego
@@ -1,9 +1,9 @@
-package regal.rules.style["chained-rule-body_test"]
+package regal.rules.custom["chained-rule-body_test"]
 
 import data.regal.ast
 import data.regal.config
 
-import data.regal.rules.style["chained-rule-body"] as rule
+import data.regal.rules.custom["chained-rule-body"] as rule
 
 test_fail_chained_incremental_definition if {
 	module := ast.policy(`rule if {
@@ -14,7 +14,7 @@ test_fail_chained_incremental_definition if {
 	r := rule.report with input as module
 
 	r == {{
-		"category": "style",
+		"category": "custom",
 		"description": "Avoid chaining rule bodies",
 		"level": "error",
 		"location": {
@@ -28,7 +28,7 @@ test_fail_chained_incremental_definition if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/chained-rule-body", "style"),
+			"ref": config.docs.resolve_url("$baseUrl/$category/chained-rule-body", "custom"),
 		}],
 		"title": "chained-rule-body",
 	}}

--- a/docs/rules/custom/chained-rule-body.md
+++ b/docs/rules/custom/chained-rule-body.md
@@ -2,7 +2,7 @@
 
 **Summary**: Avoid chaining rule bodies
 
-**Category**: Style
+**Category**: Custom
 
 **Avoid**
 ```rego
@@ -37,8 +37,7 @@ understood by people new to Rego.
 ## Exceptions
 
 The `opa fmt` command will automatically "unchain" chained rule bodies, so if you have enabled the [opa-fmt](opa-fmt)
-rule, you may safely configure the level of this rule to `ignore`. While we normally don't include style rules covered
-by `opa fmt`, this one is peculiar enough that we felt it was worthy of an exception.
+rule (as it is by default), there's no point in enabling this rule.
 
 ## Configuration Options
 
@@ -46,8 +45,12 @@ This linter rule provides the following configuration options:
 
 ```yaml
 rules:
-  style:
+  custom:
     chained-rule-body:
+      # note that all rules in the "custom" category are disabled by default
+      # (i.e. level "ignore") as some configuration needs to be provided by
+      # the user (i.e. you!) in order for them to be useful.
+      #
       # one of "error", "warning", "ignore"
       level: error
 ```
@@ -55,4 +58,4 @@ rules:
 ## Related Resources
 
 - OPA Docs: [Incremental Definitions](https://www.openpolicyagent.org/docs/policy-language/#incremental-definitions)
-- GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/style/chained-rule-body/chained_rule_body.rego)
+- GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/custom/chained-rule-body/chained_rule_body.rego)

--- a/e2e/testdata/violations/most_violations.rego
+++ b/e2e/testdata/violations/most_violations.rego
@@ -206,12 +206,6 @@ x := y if {
 
 use_assignment = "oparator"
 
-chained_rule_body if {
-	input.x
-} {
-	input.y
-}
-
 rule_length if {
 	input.x1
 	input.x2

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -408,8 +408,8 @@ func TestLintMergedConfigUsesProvidedDefaults(t *testing.T) {
 	}
 
 	// other rule in style should have the default level for the category
-	if mergedConfig.Rules["style"]["chained-rule-body"].Level != "error" {
-		t.Errorf("expected level to be 'error', got %q", mergedConfig.Rules["style"]["chained-rule-body"].Level)
+	if mergedConfig.Rules["style"]["pointless-reassignment"].Level != "error" {
+		t.Errorf("expected level to be 'error', got %q", mergedConfig.Rules["style"]["pointless-reassignment"].Level)
 	}
 
 	// rule in bugs should have the default level for the category


### PR DESCRIPTION
As this is effectively covered by the `opa-fmt` rule already, there's little point in having this enabled by default. For that reason moving this to the `custom` category.