### PR TITLE
Add `prefer-value-in-head` option to count interpolated string as scalar

### DIFF
--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -27,6 +27,7 @@ rules:
     prefer-value-in-head:
       level: error
       only-scalars: true
+      include-interpolated: true
   style:
     line-length:
       level: error

--- a/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head.rego
+++ b/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head.rego
@@ -17,7 +17,7 @@ report contains violation if {
 	terms[1].type == "var"
 	terms[1].value == var
 
-	not _scalar_fail(terms[2].type, ast.scalar_types)
+	not _scalar_fail(terms[2].type, _scalar_types)
 	not _excepted_var_name(var)
 
 	violation := result.fail(rego.metadata.chain(), result.location(terms[2]))
@@ -36,3 +36,6 @@ _scalar_fail(term_type, scalar_types) if {
 }
 
 _excepted_var_name(name) if name in config.rules.custom["prefer-value-in-head"]["except-var-names"]
+
+_scalar_types contains type if some type in ast.scalar_types
+_scalar_types contains "templatestring" if config.rules.custom["prefer-value-in-head"]["include-interpolated"] == true

--- a/docs/rules/custom/prefer-value-in-head.md
+++ b/docs/rules/custom/prefer-value-in-head.md
@@ -5,6 +5,7 @@
 **Category**: Custom
 
 **Avoid**
+
 ```rego
 package policy
 
@@ -20,6 +21,7 @@ deny contains message if {
 ```
 
 **Prefer**
+
 ```rego
 package policy
 
@@ -58,6 +60,9 @@ deny contains message if {
 }
 ```
 
+The `include-interpolated` configuration option may be used to count interpolated strings as a scalar (string) values,
+which will have Regal recommend moving them to the head even when `only-scalars` is set to `true`.
+
 ## Configuration Options
 
 This linter rule provides the following configuration options:
@@ -74,10 +79,13 @@ rules:
       # whether to only suggest moving scalar values (strings, numbers, booleans, null)
       # to the head, and not expressions or functions
       only-scalars: false
+      # when set to true, counts interpolated strings as a scalar value, and will suggest
+      # moving them to the head even when `only-scalars` is true
+      include-interpolated: false
       # variable names to exempt from the rule (by default, none)
       except-var-names:
-      - report
-      - violation
+        - report
+        - violation
 ```
 
 ## Related Resources


### PR DESCRIPTION
I noticed in some rule I worked on that Regal didn't flag this, which was right given that interpolated strings aren't exactly scalar values. But I _do_ want to have Regal recommend moving them to the head assignment when possible, while keeping the `only-scalars` option set as `true`. This PR adds a new `include-interpolated` option to allow this precisely, and makes it enabled in our own settings.
