### PR TITLE
Fix: Track fixable violation count separate from violation set

### DIFF
--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -103,7 +103,6 @@ func NewJUnitReporter(out io.Writer) JUnitReporter {
 // Publish prints a pretty report to the configured output.
 func (tr PrettyReporter) Publish(_ context.Context, r report.Report) error {
 	table := buildPrettyViolationsTable(r.Violations)
-
 	numsWarning, numsError := 0, 0
 
 	for i := range r.Violations {
@@ -162,10 +161,13 @@ func (tr PrettyReporter) Publish(_ context.Context, r report.Report) error {
 	f := fixer.NewFixer().RegisterFixes(fixes.NewDefaultFixes()...)
 
 	fixableViolations := util.NewSet[string]()
+	fixableCount := 0
 
 	for i := range r.Violations {
 		if fix, ok := f.GetFixForName(r.Violations[i].Title); ok {
 			fixableViolations.Add(fix.Name())
+
+			fixableCount++
 		}
 	}
 
@@ -177,7 +179,7 @@ func (tr PrettyReporter) Publish(_ context.Context, r report.Report) error {
 Hint: %d/%d violations can be automatically fixed (%s)
       Run regal fix --help for more details.
 `,
-			fixableViolations.Size(),
+			fixableCount,
 			r.Summary.NumViolations,
 			strings.Join(violationKeys, ", "),
 		)


### PR DESCRIPTION
Addresses issue #1813 where the fixable violation count was incorrect. Now correctly tracks violation count separate from the set of violations!

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->