### PR TITLE
fix: Updated example for prefer-equals-comparison edge case to not include false positive

### DIFF
--- a/pkg/fixer/fixes/preferequalscomparison_test.go
+++ b/pkg/fixer/fixes/preferequalscomparison_test.go
@@ -129,29 +129,15 @@ test_rule {
 				Filename: "test.rego",
 				Contents: `package test
 
-apples := [
-	{"name": "Red"},
-	{"name": "Green"}
-]
-
-var1 := "Red"
-
-some_var := {var1 | var1 = apples[_].name}
+is_get := true if input.request.method = "GET"
 `,
 			},
 			contentAfterFix: `package test
 
-apples := [
-	{"name": "Red"},
-	{"name": "Green"}
-]
-
-var1 := "Red"
-
-some_var := {var1 | var1 == apples[_].name}
+is_get := true if input.request.method == "GET"
 `,
 			fixExpected:    true,
-			runtimeOptions: &RuntimeOptions{Locations: []report.Location{{Row: 10, Column: 21}}},
+			runtimeOptions: &RuntimeOptions{Locations: []report.Location{{Row: 3, Column: 40}}},
 		},
 	}
 	for testName, tc := range testCases {


### PR DESCRIPTION
Because issue #1826 was addressed, this example is no longer a proper one to test, and as such, was removed in favor of a better one to test this edge case.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->