### PR TITLE
Implement completionItem/resolve handler

### DIFF
--- a/bundle/regal/lsp/completion/main.rego
+++ b/bundle/regal/lsp/completion/main.rego
@@ -18,6 +18,18 @@ import data.regal.util
 result["response"] := {
 	"items": items,
 	"isIncomplete": true,
+} if {
+	input.method == "textDocument/completion"
+}
+
+# METADATA
+# schemas:
+#   - input: {}
+result["response"] := data.regal.lsp.completion.resolvers[input.params.data.resolver].resolve if {
+	input.method == "completionItem/resolve"
+} else := input.params if {
+	# if there was nothing to resolve, return the input as-is
+	input.method == "completionItem/resolve"
 }
 
 # METADATA

--- a/bundle/regal/lsp/completion/providers/builtins/builtins.rego
+++ b/bundle/regal/lsp/completion/providers/builtins/builtins.rego
@@ -4,7 +4,6 @@ package regal.lsp.completion.providers.builtins
 
 import data.regal.lsp.completion.kind
 import data.regal.lsp.completion.location
-import data.regal.lsp.template
 
 # METADATA
 # description: suggest built-in functions matching typed ref
@@ -29,6 +28,6 @@ items contains item if {
 		"kind": kind.function,
 		"detail": "built-in function",
 		"textEdit": {"range": location.word_range(ref, input.params.position), "newText": builtin.name},
-		"documentation": {"kind": "markdown", "value": template.render_for_builtin(builtin)},
+		"data": {"resolver": "builtins"},
 	}
 }

--- a/bundle/regal/lsp/completion/providers/builtins/builtins_test.rego
+++ b/bundle/regal/lsp/completion/providers/builtins/builtins_test.rego
@@ -3,7 +3,7 @@ package regal.lsp.completion.providers.builtins_test
 import data.regal.lsp.completion.providers.builtins
 
 test_simple_builtin_completion if {
-	items := builtins.items with data.workspace.builtins as _builtins with input as {
+	items := builtins.items with input as {
 		"params": {
 			"textDocument": {"uri": "file:///p.rego"},
 			"position": {"line": 3, "character": 10},
@@ -16,14 +16,11 @@ test_simple_builtin_completion if {
 			"}",
 		]}},
 	}
+		with data.workspace.builtins as _builtins
 
 	items == {
 		{
 			"detail": "built-in function",
-			"documentation": {
-				"kind": "markdown",
-				"value": "### [count](https://www.openpolicyagent.org/docs/policy-reference/#builtin-aggregates-count)\n\n```rego\nn := count(collection)\n```\n\nCount takes a collection or string and returns the number of elements (or characters) in it.\n\n#### Arguments\n\n- `collection` any: the set/array/object/string to be counted\n\nReturns `n` of type `number`: the count of elements, key/val pairs, or characters, respectively.\n",
-			},
 			"kind": 3,
 			"label": "count",
 			"textEdit": {
@@ -33,13 +30,10 @@ test_simple_builtin_completion if {
 					"start": {"character": 9, "line": 3},
 				},
 			},
+			"data": {"resolver": "builtins"},
 		},
 		{
 			"detail": "built-in function",
-			"documentation": {
-				"kind": "markdown",
-				"value": "### [crypto.hmac.md5](https://www.openpolicyagent.org/docs/policy-reference/#builtin-crypto.hmac.md5-crypto-hmac-md5)\n\n```rego\ny := crypto.hmac.md5(x, key)\n```\n\nReturns a string representing the MD5 HMAC of the input message using the input key.\n\n#### Arguments\n\n- `x` string: input string\n- `key` string: key to use\n\nReturns `y` of type `string`: MD5-HMAC of `x`\n",
-			},
 			"kind": 3,
 			"label": "crypto.hmac.md5",
 			"textEdit": {
@@ -49,12 +43,13 @@ test_simple_builtin_completion if {
 					"start": {"character": 9, "line": 3},
 				},
 			},
+			"data": {"resolver": "builtins"},
 		},
 	}
 }
 
 test_simple_builtin_completion_single_match if {
-	items := builtins.items with data.workspace.builtins as _builtins with input as {
+	items := builtins.items with input as {
 		"params": {
 			"textDocument": {"uri": "file:///p.rego"},
 			"position": {"line": 3, "character": 11},
@@ -67,13 +62,10 @@ test_simple_builtin_completion_single_match if {
 			"}",
 		]}},
 	}
+		with data.workspace.builtins as _builtins
 
 	items == {{
 		"detail": "built-in function",
-		"documentation": {
-			"kind": "markdown",
-			"value": "### [count](https://www.openpolicyagent.org/docs/policy-reference/#builtin-aggregates-count)\n\n```rego\nn := count(collection)\n```\n\nCount takes a collection or string and returns the number of elements (or characters) in it.\n\n#### Arguments\n\n- `collection` any: the set/array/object/string to be counted\n\nReturns `n` of type `number`: the count of elements, key/val pairs, or characters, respectively.\n",
-		},
 		"kind": 3,
 		"label": "count",
 		"textEdit": {
@@ -83,11 +75,12 @@ test_simple_builtin_completion_single_match if {
 				"start": {"character": 9, "line": 3},
 			},
 		},
+		"data": {"resolver": "builtins"},
 	}}
 }
 
 test_simple_builtin_completion_single_match_longer_ref if {
-	items := builtins.items with data.workspace.builtins as _builtins with input as {
+	items := builtins.items with input as {
 		"params": {
 			"textDocument": {"uri": "file:///p.rego"},
 			"position": {"line": 3, "character": 17},
@@ -100,13 +93,10 @@ test_simple_builtin_completion_single_match_longer_ref if {
 			"}",
 		]}},
 	}
+		with data.workspace.builtins as _builtins
 
 	items == {{
 		"detail": "built-in function",
-		"documentation": {
-			"kind": "markdown",
-			"value": "### [crypto.hmac.md5](https://www.openpolicyagent.org/docs/policy-reference/#builtin-crypto.hmac.md5-crypto-hmac-md5)\n\n```rego\ny := crypto.hmac.md5(x, key)\n```\n\nReturns a string representing the MD5 HMAC of the input message using the input key.\n\n#### Arguments\n\n- `x` string: input string\n- `key` string: key to use\n\nReturns `y` of type `string`: MD5-HMAC of `x`\n",
-		},
 		"kind": 3,
 		"label": "crypto.hmac.md5",
 		"textEdit": {
@@ -116,6 +106,7 @@ test_simple_builtin_completion_single_match_longer_ref if {
 				"start": {"character": 9, "line": 3},
 			},
 		},
+		"data": {"resolver": "builtins"},
 	}}
 }
 
@@ -158,7 +149,7 @@ test_no_completion_of_infix_builtin if {
 }
 
 test_no_completion_in_default_rule if {
-	items := builtins.items with data.workspace.builtins as _builtins with input as {
+	items := builtins.items with input as {
 		"params": {
 			"textDocument": {"uri": "file:///p.rego"},
 			"position": {"line": 2, "character": 16},
@@ -169,6 +160,7 @@ test_no_completion_in_default_rule if {
 			"default foo := c",
 		]}},
 	}
+		with data.workspace.builtins as _builtins
 
 	count(items) == 0
 }

--- a/bundle/regal/lsp/completion/providers/input/input.rego
+++ b/bundle/regal/lsp/completion/providers/input/input.rego
@@ -29,20 +29,6 @@ items contains item if {
 			"range": location.word_range(word, input.params.position),
 			"newText": "input",
 		},
-		"documentation": {
-			"kind": "markdown",
-			"value": _doc,
-		},
+		"data": {"resolver": "input"},
 	}
 }
-
-_doc := `# input
-
-'input' refers to the input document being evaluated.
-It is a special keyword that allows you to access the data sent to OPA at evaluation time.
-
-To see more examples of how to use 'input', check out the
-[policy language documentation](https://www.openpolicyagent.org/docs/policy-language/).
-
-You can also experiment with input in the [Rego Playground](https://play.openpolicyagent.org/).
-`

--- a/bundle/regal/lsp/completion/providers/input/input_test.rego
+++ b/bundle/regal/lsp/completion/providers/input/input_test.rego
@@ -13,10 +13,7 @@ allow if {
 
 	items == {{
 		"detail": "input document",
-		"documentation": {
-			"kind": "markdown",
-			"value": provider._doc,
-		},
+		"data": {"resolver": "input"},
 		"kind": 14,
 		"label": "input",
 		"textEdit": {

--- a/bundle/regal/lsp/completion/resolvers/builtins/builtins.rego
+++ b/bundle/regal/lsp/completion/resolvers/builtins/builtins.rego
@@ -1,0 +1,13 @@
+# METADATA
+# description: Completion resolver for built-in function documentation
+package regal.lsp.completion.resolvers.builtins
+
+import data.regal.lsp.template
+
+# METADATA
+# description: Provides documentation for built-in functions
+# schemas:
+resolve := object.union(input.params, {"documentation": {
+	"kind": "markdown",
+	"value": template.render_for_builtin(data.workspace.builtins[input.params.label]),
+}})

--- a/bundle/regal/lsp/completion/resolvers/builtins/builtins_test.rego
+++ b/bundle/regal/lsp/completion/resolvers/builtins/builtins_test.rego
@@ -1,0 +1,91 @@
+package regal.lsp.completion.resolvers.builtins_test
+
+test_resolve_builtin_documentation if {
+	input_count := {"params": {"label": "count", "data": {"resolver": "builtins"}}}
+	result_count := data.regal.lsp.completion.resolvers.builtins.resolve with input as input_count
+		with data.workspace.builtins as _builtins
+
+	result_count == {
+		"label": "count",
+		"documentation": {
+			"kind": "markdown",
+			"value": "### [count](https://www.openpolicyagent.org/docs/policy-reference/#builtin-aggregates-count)\n\n```rego\nn := count(collection)\n```\n\nCount takes a collection or string and returns the number of elements (or characters) in it.\n\n#### Arguments\n\n- `collection` any: the set/array/object/string to be counted\n\nReturns `n` of type `number`: the count of elements, key/val pairs, or characters, respectively.\n",
+		},
+		"data": {"resolver": "builtins"},
+	}
+	input_hmac := {"params": {"label": "crypto.hmac.md5", "data": {"resolver": "builtins"}}}
+	result_hmac := data.regal.lsp.completion.resolvers.builtins.resolve with input as input_hmac
+		with data.workspace.builtins as _builtins
+
+	result_hmac == {
+		"data": {"resolver": "builtins"},
+		"documentation": {
+			"kind": "markdown",
+			"value": "### [crypto.hmac.md5](https://www.openpolicyagent.org/docs/policy-reference/#builtin-crypto.hmac.md5-crypto-hmac-md5)\n\n```rego\ny := crypto.hmac.md5(x, key)\n```\n\nReturns a string representing the MD5 HMAC of the input message using the input key.\n\n#### Arguments\n\n- `x` string: input string\n- `key` string: key to use\n\nReturns `y` of type `string`: MD5-HMAC of `x`\n",
+		},
+		"label": "crypto.hmac.md5",
+	}
+}
+
+_builtins := {
+	"count": {
+		"name": "count",
+		"description": "Count takes a collection or string and returns the number of elements (or characters) in it.",
+		"categories": ["aggregates"],
+		"decl": {
+			"args": [{
+				"description": "the set/array/object/string to be counted",
+				"name": "collection",
+				"of": [
+					{"type": "string"},
+					{
+						"dynamic": {"type": "any"},
+						"type": "array",
+					},
+					{
+						"dynamic": {
+							"key": {"type": "any"},
+							"value": {"type": "any"},
+						},
+						"type": "object",
+					},
+					{
+						"of": {"type": "any"},
+						"type": "set",
+					},
+				],
+				"type": "any",
+			}],
+			"result": {
+				"description": "the count of elements, key/val pairs, or characters, respectively.",
+				"name": "n",
+				"type": "number",
+			},
+			"type": "function",
+		},
+	},
+	"crypto.hmac.md5": {
+		"name": "crypto.hmac.md5",
+		"description": "Returns a string representing the MD5 HMAC of the input message using the input key.",
+		"decl": {
+			"args": [
+				{
+					"description": "input string",
+					"name": "x",
+					"type": "string",
+				},
+				{
+					"description": "key to use",
+					"name": "key",
+					"type": "string",
+				},
+			],
+			"result": {
+				"description": "MD5-HMAC of `x`",
+				"name": "y",
+				"type": "string",
+			},
+			"type": "function",
+		},
+	},
+}

--- a/bundle/regal/lsp/completion/resolvers/input/input.rego
+++ b/bundle/regal/lsp/completion/resolvers/input/input.rego
@@ -1,0 +1,19 @@
+# METADATA
+# description: Completion resolver for the 'input' keyword's documentation
+package regal.lsp.completion.resolvers.input
+
+# METADATA
+# description: provides documentation for the `input` keyword completion item
+resolve := object.union(input.params, {"documentation": {
+	"kind": "markdown",
+	"value": `# input
+
+'input' refers to the input document being evaluated.
+It is a special keyword that allows you to access the data sent to OPA at evaluation time.
+
+To see more examples of how to use 'input', check out the
+[policy language documentation](https://www.openpolicyagent.org/docs/policy-language/).
+
+You can also experiment with input in the [Rego Playground](https://play.openpolicyagent.org/).
+`,
+}})

--- a/bundle/regal/lsp/completion/resolvers/main.rego
+++ b/bundle/regal/lsp/completion/resolvers/main.rego
@@ -1,0 +1,10 @@
+# METADATA
+# description: |
+#   Completion resolvers for selected completion items. These help provide additional informtion, like
+#   documentation, at the time requested by the client rather than up-front together with the completion items.
+#   Less data to process and transfer up-front, means faster time until completion suggestions are shown to the user.
+# scope: subpackages
+# schemas:
+#   # override for resolvers, as params contain the original completion item
+#   - input.params: {}
+package regal.lsp.completion.resolvers

--- a/bundle/regal/lsp/main/main.rego
+++ b/bundle/regal/lsp/main/main.rego
@@ -26,3 +26,5 @@ eval := response if {
 }
 
 _handler_for(method) := lower(name) if ["textDocument", name] = split(method, "/")
+
+_handler_for("completionItem/resolve") := "completion"

--- a/internal/lsp/cache/cache.go
+++ b/internal/lsp/cache/cache.go
@@ -69,6 +69,12 @@ func (c *Cache) GetAllFiles() map[string]string {
 	return c.fileContents.Clone()
 }
 
+func (c *Cache) HasFileContents(fileURI string) bool {
+	_, ok := c.fileContents.Get(fileURI)
+
+	return ok
+}
+
 func (c *Cache) GetFileContents(fileURI string) (string, bool) {
 	return c.fileContents.Get(fileURI)
 }

--- a/internal/lsp/cache/cache_test.go
+++ b/internal/lsp/cache/cache_test.go
@@ -156,7 +156,7 @@ func TestCacheRename(t *testing.T) {
 	c.SetModule("file:///tmp/foo.rego", &ast.Module{})
 	c.Rename("file:///tmp/foo.rego", "file:///tmp/bar.rego")
 
-	if _, ok := c.GetFileContents("file:///tmp/foo.rego"); ok {
+	if ok := c.HasFileContents("file:///tmp/foo.rego"); ok {
 		t.Fatalf("expected foo.rego to be removed")
 	}
 

--- a/internal/lsp/lint.go
+++ b/internal/lsp/lint.go
@@ -206,10 +206,8 @@ func updateFileDiagnostics(ctx context.Context, opts diagnosticsRunOpts) error {
 	fileDiags := convertReportToDiagnostics(&rpt, opts.WorkspaceRootURI)
 
 	for uri := range opts.Cache.GetAllFiles() {
-		// if a file has parse errors, continue to show these until they're addressed
-		parseErrs, ok := opts.Cache.GetParseErrors(uri)
-		if ok && len(parseErrs) > 0 {
-			continue
+		if parseErrs, ok := opts.Cache.GetParseErrors(uri); ok && len(parseErrs) > 0 {
+			continue // continue to show these until addressed
 		}
 
 		// For updateFileDiagnostics, we only update the file in question.

--- a/internal/lsp/rego/rego.go
+++ b/internal/lsp/rego/rego.go
@@ -97,9 +97,9 @@ type (
 	}
 
 	Input[T any] struct {
-		Method string       `json:"method"`
-		Params T            `json:"params"`
-		Regal  RegalContext `json:"regal"`
+		Method string        `json:"method"`
+		Params T             `json:"params"`
+		Regal  *RegalContext `json:"regal"`
 	}
 
 	Result[R any] struct {
@@ -114,7 +114,7 @@ type (
 	}
 )
 
-func NewInput[T any](method string, regal RegalContext, params T) Input[T] {
+func NewInput[T any](method string, regal *RegalContext, params T) Input[T] {
 	return Input[T]{Method: method, Regal: regal, Params: params}
 }
 

--- a/internal/lsp/server_aggregates_test.go
+++ b/internal/lsp/server_aggregates_test.go
@@ -72,7 +72,7 @@ import rego.v1
 	barURI := uri.FromPath(clients.IdentifierGoTest, filepath.Join(tempDir, "bar.rego"))
 
 	if err := connClient.Notify(ctx, "textDocument/didChange", types.DidChangeTextDocumentParams{
-		TextDocument: types.TextDocumentIdentifier{
+		TextDocument: types.VersionedTextDocumentIdentifier{
 			URI: barURI,
 		},
 		ContentChanges: []types.TextDocumentContentChangeEvent{
@@ -108,7 +108,7 @@ import rego.v1
 	fooURI := uri.FromPath(clients.IdentifierGoTest, filepath.Join(tempDir, "foo.rego"))
 
 	if err := connClient.Notify(ctx, "textDocument/didChange", types.DidChangeTextDocumentParams{
-		TextDocument: types.TextDocumentIdentifier{
+		TextDocument: types.VersionedTextDocumentIdentifier{
 			URI: fooURI,
 		},
 		ContentChanges: []types.TextDocumentContentChangeEvent{
@@ -289,7 +289,7 @@ import data.quz
 
 	// 2. check the aggregates for a file are updated after an update
 	if err := connClient.Notify(ctx, "textDocument/didChange", types.DidChangeTextDocumentParams{
-		TextDocument: types.TextDocumentIdentifier{
+		TextDocument: types.VersionedTextDocumentIdentifier{
 			URI: uri.FromPath(clients.IdentifierGoTest, filepath.Join(tempDir, "bar.rego")),
 		},
 		ContentChanges: []types.TextDocumentContentChangeEvent{
@@ -388,7 +388,7 @@ import rego.v1
 	barURI := uri.FromPath(clients.IdentifierGoTest, filepath.Join(tempDir, "bar.rego"))
 
 	err = connClient.Notify(ctx, "textDocument/didChange", types.DidChangeTextDocumentParams{
-		TextDocument: types.TextDocumentIdentifier{
+		TextDocument: types.VersionedTextDocumentIdentifier{
 			URI: barURI,
 		},
 		ContentChanges: []types.TextDocumentContentChangeEvent{
@@ -430,7 +430,7 @@ import rego.v1
 
 	// update the contents of the bar.rego to bring back the violation
 	err = connClient.Notify(ctx, "textDocument/didChange", types.DidChangeTextDocumentParams{
-		TextDocument: types.TextDocumentIdentifier{
+		TextDocument: types.VersionedTextDocumentIdentifier{
 			URI: barURI,
 		},
 		ContentChanges: []types.TextDocumentContentChangeEvent{

--- a/internal/lsp/server_load_workspace_test.go
+++ b/internal/lsp/server_load_workspace_test.go
@@ -209,7 +209,7 @@ func TestLoadWorkspaceContents(t *testing.T) {
 			for _, expectedFile := range tc.expectChangedFiles {
 				for _, changedURI := range changedURIs {
 					if filepath.Base(changedURI) == expectedFile {
-						if _, found := server.cache.GetFileContents(changedURI); !found {
+						if found := server.cache.HasFileContents(changedURI); !found {
 							t.Errorf("expected file %s to be cached", expectedFile)
 						}
 

--- a/internal/lsp/server_multi_file_test.go
+++ b/internal/lsp/server_multi_file_test.go
@@ -128,7 +128,7 @@ ignore:
 	// 3. Client sends textDocument/didChange notification with new contents
 	// for authz.rego no response to the call is expected
 	if err := connClient.Notify(ctx, "textDocument/didChange", types.DidChangeTextDocumentParams{
-		TextDocument: types.TextDocumentIdentifier{
+		TextDocument: types.VersionedTextDocumentIdentifier{
 			URI: uri.FromPath(clients.IdentifierGoTest, filepath.Join(tempDir, "authz.rego")),
 		},
 		ContentChanges: []types.TextDocumentContentChangeEvent{

--- a/internal/lsp/server_single_file_test.go
+++ b/internal/lsp/server_single_file_test.go
@@ -67,7 +67,7 @@ rules:
 	// Client sends textDocument/didChange notification with new contents for main.rego
 	// no response to the call is expected
 	if err := connClient.Notify(ctx, "textDocument/didChange", types.DidChangeTextDocumentParams{
-		TextDocument: types.TextDocumentIdentifier{
+		TextDocument: types.VersionedTextDocumentIdentifier{
 			URI: mainRegoURI,
 		},
 		ContentChanges: []types.TextDocumentContentChangeEvent{
@@ -188,7 +188,7 @@ capabilities:
 	// loaded correctly, we should see a completion later after we ask for
 	// it.
 	if err := connClient.Notify(ctx, "textDocument/didChange", types.DidChangeTextDocumentParams{
-		TextDocument: types.TextDocumentIdentifier{
+		TextDocument: types.VersionedTextDocumentIdentifier{
 			URI: mainRegoURI,
 		},
 		ContentChanges: []types.TextDocumentContentChangeEvent{

--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -126,6 +126,7 @@ type (
 	}
 
 	CompletionItem struct {
+		Data            any                         `json:"data,omitempty"`
 		LabelDetails    *CompletionItemLabelDetails `json:"labelDetails,omitempty"`
 		Documentation   *MarkupContent              `json:"documentation,omitempty"`
 		TextEdit        *TextEdit                   `json:"textEdit,omitempty"`
@@ -414,8 +415,13 @@ type (
 	}
 
 	DidChangeTextDocumentParams struct {
-		TextDocument   TextDocumentIdentifier           `json:"textDocument"`
+		TextDocument   VersionedTextDocumentIdentifier  `json:"textDocument"`
 		ContentChanges []TextDocumentContentChangeEvent `json:"contentChanges"`
+	}
+
+	VersionedTextDocumentIdentifier struct {
+		Version uint   `json:"version"`
+		URI     string `json:"uri"`
 	}
 
 	TextDocumentContentChangeEvent struct {

--- a/pkg/fixer/fileprovider/cache.go
+++ b/pkg/fixer/fileprovider/cache.go
@@ -66,7 +66,7 @@ func (c *CacheFileProvider) Rename(from, to string) error {
 		return fmt.Errorf("file %s not found", from)
 	}
 
-	if _, exists := c.Cache.GetFileContents(toURI); exists {
+	if ok := c.Cache.HasFileContents(toURI); ok {
 		return RenameConflictError{From: from, To: to}
 	}
 


### PR DESCRIPTION
I was looking to fix some robustness issues in our code completion feature, but I still have more to do there. However, while logging completion requests and responses I noticed that a non-negligible amount of the data transfered was from the built-in provider and the documentation for each built-in it sends along with every built-in suggestion. These markdown documents are only visible when the user clicks to see them, which is realistically not very common (but nice when you need it). So I figured I'd make a little detour to implement our first [resolve provider](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion). These allow resolving parts of some responses on demand rather than upfront, thus saving procesing time and bytes in transfer. Not a huge win, mind you, but it's something.. and paves the way for more resolve providers in the future, as they are now rather simple to implement using only Rego.

Also:
- Add HasFileContents for easier debugging as GetFileContents
- Use VersionedTextIdentifier as per language server spec, although we don't currently use the version number for anything (but possibly logging)
