### PR TITLE
Lint performance Rego refactor

### DIFF
--- a/bundle/regal/ast/ast_test.rego
+++ b/bundle/regal/ast/ast_test.rego
@@ -95,80 +95,124 @@ test_function_calls if {
 
 test_implicit_boolean_assignment if ast.implicit_boolean_assignment(ast.with_rego_v1(`a.b if true`).rules[0])
 
-test_ref_to_string if {
-	ast.ref_to_string([{"type": "var", "value": "data"}]) == `data`
-	ast.ref_to_string([{"type": "var", "value": "foo"}, {"type": "var", "value": "bar"}]) == `foo[bar]`
-	ast.ref_to_string([{"type": "var", "value": "data"}, {"type": "string", "value": "/foo/"}]) == `data["/foo/"]`
-	ast.ref_to_string([
-		{"type": "var", "value": "foo"},
-		{"type": "var", "value": "bar"},
-		{"type": "var", "value": "baz"},
-	]) == `foo[bar][baz]`
-	ast.ref_to_string([
-		{"type": "var", "value": "foo"},
-		{"type": "var", "value": "bar"},
-		{"type": "var", "value": "baz"},
-		{"type": "string", "value": "qux"},
-	]) == `foo[bar][baz].qux`
-	ast.ref_to_string([
-		{"type": "var", "value": "foo"},
-		{"type": "string", "value": "~bar~"},
-		{"type": "string", "value": "boo"},
-		{"type": "var", "value": "baz"},
-	]) == `foo["~bar~"].boo[baz]`
-	ast.ref_to_string([
-		{"type": "var", "value": "data"},
-		{"type": "string", "value": "regal"},
-		{"type": "string", "value": "lsp"},
-		{"type": "string", "value": "completion_test"},
-	]) == `data.regal.lsp.completion_test`
-	ast.ref_to_string([
-		{"type": "var", "value": "data"},
-		{"type": "string", "value": "regal"},
-		{"type": "number", "value": 1},
-	]) == `data.regal[1]`
-	ast.ref_to_string([
-		{"type": "var", "value": "data"},
-		{"type": "string", "value": "regal"},
-		{"type": "boolean", "value": true},
-	]) == `data.regal[true]`
+test_ref_to_string[exp] if {
+	some [ref, exp] in [
+		[[{"type": "var", "value": "data"}], `data`],
+		[[{"type": "var", "value": "foo"}, {"type": "var", "value": "bar"}], `foo[bar]`],
+		[[{"type": "var", "value": "data"}, {"type": "string", "value": "/foo/"}], `data["/foo/"]`],
+		[
+			[
+				{"type": "var", "value": "foo"},
+				{"type": "var", "value": "bar"},
+				{"type": "var", "value": "baz"},
+			],
+			`foo[bar][baz]`,
+		],
+		[
+			[
+				{"type": "var", "value": "foo"},
+				{"type": "var", "value": "bar"},
+				{"type": "var", "value": "baz"},
+				{"type": "string", "value": "qux"},
+			],
+			`foo[bar][baz].qux`,
+		],
+		[
+			[
+				{"type": "var", "value": "foo"},
+				{"type": "string", "value": "~bar~"},
+				{"type": "string", "value": "boo"},
+				{"type": "var", "value": "baz"},
+			],
+			`foo["~bar~"].boo[baz]`,
+		],
+		[
+			[
+				{"type": "var", "value": "data"},
+				{"type": "string", "value": "regal"},
+				{"type": "string", "value": "lsp"},
+				{"type": "string", "value": "completion_test"},
+			],
+			`data.regal.lsp.completion_test`,
+		],
+		[
+			[
+				{"type": "var", "value": "data"},
+				{"type": "string", "value": "regal"},
+				{"type": "number", "value": 1},
+			],
+			`data.regal[1]`,
+		],
+		[
+			[
+				{"type": "var", "value": "data"},
+				{"type": "string", "value": "regal"},
+				{"type": "boolean", "value": true},
+			],
+			`data.regal[true]`,
+		],
+	]
+
+	ast.ref_to_string(ref) == exp
 }
 
-test_ref_static_to_string if {
-	ast.ref_static_to_string([{"type": "var", "value": "data"}]) == `data`
-	ast.ref_static_to_string([{"type": "var", "value": "foo"}, {"type": "var", "value": "bar"}]) == `foo`
-	ast.ref_static_to_string([{"type": "var", "value": "data"}, {"type": "string", "value": "/foo/"}]) == `data["/foo/"]`
-	ast.ref_static_to_string([
-		{"type": "var", "value": "foo"},
-		{"type": "string", "value": "bar"},
-		{"type": "var", "value": "baz"},
-	]) == `foo.bar`
-	ast.ref_static_to_string([
-		{"type": "var", "value": "foo"},
-		{"type": "string", "value": "~bar~"},
-		{"type": "string", "value": "qux"},
-	]) == `foo["~bar~"].qux`
-	ast.ref_static_to_string([
-		{"type": "var", "value": "data"},
-		{"type": "string", "value": "regal"},
-		{"type": "string", "value": "lsp"},
-		{"type": "string", "value": "completion_test"},
-	]) == `data.regal.lsp.completion_test`
-	ast.ref_static_to_string([
-		{"type": "var", "value": "data"},
-		{"type": "string", "value": "regal"},
-		{"type": "number", "value": 1},
-	]) == `data.regal[1]`
-	ast.ref_static_to_string([
-		{"type": "var", "value": "data"},
-		{"type": "string", "value": "regal"},
-		{"type": "boolean", "value": true},
-	]) == `data.regal[true]`
-	ast.ref_static_to_string([
-		{"type": "var", "value": "data"},
-		{"type": "string", "value": "regal"},
-		{"type": "boolean", "value": false},
-	]) == `data.regal[false]`
+test_ref_static_to_string[exp] if {
+	some [ref, exp] in [
+		[[{"type": "var", "value": "data"}], `data`],
+		[[{"type": "var", "value": "foo"}, {"type": "var", "value": "bar"}], `foo`],
+		[[{"type": "var", "value": "data"}, {"type": "string", "value": "/foo/"}], `data["/foo/"]`],
+		[
+			[
+				{"type": "var", "value": "foo"},
+				{"type": "string", "value": "bar"},
+				{"type": "var", "value": "baz"},
+			],
+			`foo.bar`,
+		],
+		[
+			[
+				{"type": "var", "value": "foo"},
+				{"type": "string", "value": "~bar~"},
+				{"type": "string", "value": "qux"},
+			],
+			`foo["~bar~"].qux`,
+		],
+		[
+			[
+				{"type": "var", "value": "data"},
+				{"type": "string", "value": "regal"},
+				{"type": "string", "value": "lsp"},
+				{"type": "string", "value": "completion_test"},
+			],
+			`data.regal.lsp.completion_test`,
+		],
+		[
+			[
+				{"type": "var", "value": "data"},
+				{"type": "string", "value": "regal"},
+				{"type": "number", "value": 1},
+			],
+			`data.regal[1]`,
+		],
+		[
+			[
+				{"type": "var", "value": "data"},
+				{"type": "string", "value": "regal"},
+				{"type": "boolean", "value": true},
+			],
+			`data.regal[true]`,
+		],
+		[
+			[
+				{"type": "var", "value": "data"},
+				{"type": "string", "value": "regal"},
+				{"type": "boolean", "value": false},
+			],
+			`data.regal[false]`,
+		],
+	]
+
+	ast.ref_static_to_string(ref) == exp
 }
 
 test_rule_head_locations if {

--- a/bundle/regal/ast/search_test.rego
+++ b/bundle/regal/ast/search_test.rego
@@ -194,16 +194,3 @@ test_found_symbols_in_template_strings if {
 
 	count(syms) == 2
 }
-
-test_found_vars_in_template_strings if {
-	vars := ast.found.vars["0"] with input as ast.policy(`r := $"{[{x, y, z} |
-		some x
-		some y in input.arr
-		z := x + y
-	]}"`)
-
-	count(vars.assign) == 1
-	count(vars.some) == 1
-	count(vars.somein) == 1
-	count([1 | vars[_][_]]) == 3
-}

--- a/bundle/regal/lsp/completion/location/location.rego
+++ b/bundle/regal/lsp/completion/location/location.rego
@@ -119,5 +119,5 @@ ref_at(line, col) := word if {
 	}
 }
 
-_to_string(arr) := "" if count(arr) == 0
-_to_string(arr) := arr[0] if count(arr) > 0
+_to_string([]) := ""
+_to_string(arr) := arr[0] if arr != []

--- a/bundle/regal/main/main.rego
+++ b/bundle/regal/main/main.rego
@@ -105,8 +105,7 @@ report contains violation if {
 	some category, title
 	_rules_to_run[category][title]
 
-	count(object.get(prepared.notices, [category, title], [])) == 0
-
+	object.get(prepared.notices, [category, title], set()) == set()
 	some violation in data.regal.rules[category][title].report
 
 	not _ignored(violation, ast.ignore_directives)
@@ -239,7 +238,3 @@ _ignored(violation, directives) if {
 	ignored_rules := directives[util.to_location_object(violation.location).row + 1]
 	violation.title in ignored_rules
 }
-
-_null_to_empty(x) := [] if {
-	x == null
-} else := x

--- a/bundle/regal/regal.rego
+++ b/bundle/regal/regal.rego
@@ -1,9 +1,12 @@
 # METADATA
-# scope: subpackages
+# scope: package
 # authors:
 #   - The OPA community
 # related_resources:
 #   - https://www.openpolicyagent.org/projects/regal
+
+# METADATA
+# scope: subpackages
 # schemas:
 #   - input: schema.regal.ast
 package regal

--- a/bundle/regal/rules/bugs/invalid-metadata-attribute/invalid_metadata_attribute.rego
+++ b/bundle/regal/rules/bugs/invalid-metadata-attribute/invalid_metadata_attribute.rego
@@ -10,15 +10,12 @@ report contains violation if {
 
 	regex.match(`^\s*METADATA`, block[0].text)
 
-	some attribute in object.keys(yaml.unmarshal(concat("\n", [entry.text |
-		some i, entry in block
-		i > 0
-	])))
+	some attribute, _ in yaml.unmarshal(concat("\n", [entry.text | some entry in array.slice(block, 1, 100)]))
 
 	not attribute in ast.comments.metadata_attributes
 
 	violation := result.fail(rego.metadata.chain(), result.location([line |
 		some line in block
-		startswith(trim_space(line.text), concat("", [attribute, ":"]))
+		startswith(trim_space(line.text), $"{attribute}:")
 	][0]))
 }

--- a/bundle/regal/rules/bugs/top-level-iteration/top_level_iteration.rego
+++ b/bundle/regal/rules/bugs/top-level-iteration/top_level_iteration.rego
@@ -11,21 +11,20 @@ report contains violation if {
 	rule := input.rules[i]
 
 	# skip if vars in the ref head
-	count([part |
-		some i, part in rule.head.ref
-		i > 0
-		part.type == "var"
-	]) == 0
+	every term in array.slice(rule.head.ref, 1, 100) {
+		term.type != "var"
+	}
 
-	some part in array.slice(rule.head.value.value, 1, 100)
+	some term in array.slice(rule.head.value.value, 1, 100)
 
-	part.type == "var"
+	term.type == "var"
 
-	_illegal_value_ref(part.value, rule, ast.identifiers)
+	not term.value in ast.identifiers
+	not _is_arg_or_input(term.value, rule)
 
 	# this is expensive, but the preconditions should ensure that
 	# very few rules evaluate this far
-	not _var_in_body(rule, part.value)
+	not _var_in_body(rule, term.value)
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
 }
@@ -34,11 +33,6 @@ _var_in_body(rule, value) if {
 	walk(rule.body, [_, node])
 	node.type == "var"
 	node.value == value
-}
-
-_illegal_value_ref(value, rule, identifiers) if {
-	not value in identifiers
-	not _is_arg_or_input(value, rule)
 }
 
 _is_arg_or_input(value, rule) if value in ast.function_arg_names(rule)

--- a/bundle/regal/rules/custom/naming-convention/naming_convention.rego
+++ b/bundle/regal/rules/custom/naming-convention/naming_convention.rego
@@ -72,7 +72,8 @@ report contains violation if {
 
 _message(kind, name, pattern) := $`Naming convention violation: {kind} name "{name}" does not match pattern '{pattern}'`
 
-_with_description(violation, description) := json.patch(
-	violation,
-	[{"op": "replace", "path": "/description", "value": description}],
-)
+_with_description(violation, description) := json.patch(violation, [{
+	"op": "replace",
+	"path": "/description",
+	"value": description,
+}])

--- a/bundle/regal/rules/imports/unresolved-import/unresolved_import.rego
+++ b/bundle/regal/rules/imports/unresolved-import/unresolved_import.rego
@@ -73,22 +73,12 @@ _custom_regal_package_and_import(pkg_path, "regal") if {
 _to_paths(pkg_path, ref) := util.all_paths(_to_path(pkg_path, ref)) if count(ref) < 3
 _to_paths(pkg_path, ref) := [_to_path(pkg_path, p) | some p in util.all_paths(ref)] if count(ref) > 2
 
-_to_path(pkg_path, ref) := array.concat(pkg_path, [str |
-	some i, part in ref
-	str := _to_string(i, part)
-])
+_to_path(pkg_path, ref) := array.flatten([pkg_path, ref[0].value, [_to_string(part) |
+	some part in array.slice(ref, 1, 100)
+]])
 
-_to_string(0, part) := part.value
-
-_to_string(i, part) := part.value if {
-	i > 0
-	part.type == "string"
-}
-
-_to_string(i, part) := "**" if {
-	i > 0
-	part.type == "var"
-}
+_to_string(part) := part.value if part.type == "string"
+_to_string(part) := "**" if part.type == "var"
 
 _except_imports contains split(trim_prefix(str, "data."), ".") if {
 	some str in config.rules.imports["unresolved-import"]["except-imports"]

--- a/bundle/regal/rules/style/prefer-snake-case/prefer_snake_case.rego
+++ b/bundle/regal/rules/style/prefer-snake-case/prefer_snake_case.rego
@@ -7,18 +7,19 @@ import data.regal.result
 import data.regal.util
 
 report contains violation if {
+	ast.package_name != lower(ast.package_name)
+
 	some part in input.package.path
 
-	not util.is_snake_case(part.value)
+	part.value != lower(part.value)
 
 	violation := result.fail(rego.metadata.chain(), result.location(part))
 }
 
 report contains violation if {
-	some rule in input.rules
-	some part in ast.named_refs(rule.head.ref)
+	part := input.rules[_].head.ref[_]
 
-	not util.is_snake_case(part.value)
+	part.value != lower(part.value)
 
 	violation := result.fail(rego.metadata.chain(), result.location(part))
 }

--- a/bundle/regal/rules/style/rule-length/rule_length.rego
+++ b/bundle/regal/rules/style/rule-length/rule_length.rego
@@ -11,9 +11,16 @@ report contains violation if {
 
 	some rule in input.rules
 
+	is_test := startswith(rule.head.ref[0].value, "test_")
+	max_length := cfg[{false: "max-rule-length", true: "max-test-rule-length"}[is_test]]
+
 	text := util.to_location_object(rule.location).text
 
-	_line_count(cfg, text) > cfg[_max_length_property(rule.head.ref[0].value)]
+	# cheaper check first, and only account for comments if too long to begin with
+	rule_length := strings.count(text, "\n") + 1
+	rule_length > max_length
+
+	_line_count(cfg, text, rule_length) > max_length
 
 	not _no_body_exception(cfg, rule)
 
@@ -25,17 +32,13 @@ _no_body_exception(cfg, rule) if {
 	not rule.body
 }
 
-default _max_length_property(_) := "max-rule-length"
+_line_count(cfg, _, rule_length) := rule_length if cfg["count-comments"] == true
 
-_max_length_property(value) := "max-test-rule-length" if startswith(value, "test_")
-
-_line_count(cfg, text) := strings.count(text, "\n") + 1 if cfg["count-comments"] == true
-
-_line_count(cfg, text) := n if {
+_line_count(cfg, text, rule_length) := without_comments if {
 	not cfg["count-comments"]
 
-	n := count([1 |
+	without_comments := rule_length - count([1 |
 		some line in split(text, "\n")
-		not startswith(trim_space(line), "#")
+		startswith(trim_space(line), "#")
 	])
 }

--- a/bundle/regal/util/util.rego
+++ b/bundle/regal/util/util.rego
@@ -208,8 +208,8 @@ longest_prefix(coll) := [] if {
 	prefix := array.slice(arr[0], 0, _longest_dif(dif, end))
 }
 
-_longest_dif(diff, len) := len + 1 if count(diff) == 0
-_longest_dif(diff, _) := diff[0] if count(diff) > 0
+_longest_dif(diff, len) := len + 1 if diff == []
+_longest_dif(diff, _) := diff[0] if diff != []
 
 # METADATA
 # description: |

--- a/internal/roast/transforms/module/module.go
+++ b/internal/roast/transforms/module/module.go
@@ -208,7 +208,7 @@ func termValueTerm(val ast.Value) *ast.Term {
 		if v.MultiLine {
 			return ast.ObjectTerm(
 				item("parts", ast.ArrayTerm(parts...)),
-				item("multi_line", ast.InternedBooleanTrueTerm),
+				item("multi_line", ast.InternedTerm(true)),
 			)
 		}
 

--- a/pkg/linter/linter_bench_test.go
+++ b/pkg/linter/linter_bench_test.go
@@ -20,6 +20,7 @@ func BenchmarkRegalLintingItself(b *testing.B) {
 // 656495042 ns/op	2309640068 B/op	50264746 allocs/op // OPA v1.12.2
 // 497374153 ns/op	1923188613 B/op	45981278 allocs/op // AST aggregates refactor
 // 486491514 ns/op	1906786789 B/op	45640947 allocs/op // OPA v1.13.1 + fixes
+// 420959403 ns/op	1534395760 B/op	36917131 allocs/op // Performance refactor
 func BenchmarkRegalLintingItselfPrepareOnce(b *testing.B) {
 	benchmarkLint(b, bundleLinter(b, true).MustPrepare(b.Context()))
 }


### PR DESCRIPTION
- Rewrite `walk` calls that needed the `path` from the walk so that they no longer do. This is by far the most impactful change here, accounting for 90% of the reduces allocs
- Inline and remove a few custom functions that only had a single dependent
- Avoid `count(x) == 0` and `count(x) > 0` in favor of `x == []` and `x != []` (or `""`, `set()`, etc) when the type is known
- Rewrite some `count([x | some x in y]) == z` constructs to instead use `every`
- Avoid costly path in rule-length check (counting comments) if the rule length wasn't exceeded to begin with
- Replace `some i, x in y; i > 0` with `some x in array.slice(y, 1, max)` to avoid repeated gt call
- Rewrite hot path function `ref_to_string`  to allocate much less by calling less custom functions, and replacing an `else` condition with a map lookup

Reducing almost 1/4 of all memory (B/op) previously allocated!

**BenchmarkRegalLintingItselfPrepareOnce**
```
486491514 ns/op    1906786789 B/op    45640947 allocs/op // OPA v1.13.1 + fixes
420959403 ns/op    1534395760 B/op    36917131 allocs/op // Performance refactor
```
