### PR TITLE
lsp: add action and handlers for support vscode-based opa-explorer

### DIFF
--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -575,5 +575,24 @@ type (
 		Full   bool                 `json:"full,omitempty"`
 	}
 
+	ExplorerCommandArgs struct {
+		Target      string `json:"target"`
+		Strict      bool   `json:"strict,omitempty"`
+		Annotations bool   `json:"annotations,omitempty"`
+		Print       bool   `json:"print,omitempty"`
+		Format      bool   `json:"format,omitempty"`
+	}
+
+	ExplorerStageResult struct {
+		Name   string `json:"name"`
+		Output string `json:"output"`
+		Error  bool   `json:"error"`
+	}
+
+	ExplorerResult struct {
+		Stages []ExplorerStageResult `json:"stages"`
+		Plan   string                `json:"plan,omitempty"`
+	}
+
 	iuint interface{ ~int | ~uint }
 )

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -270,6 +270,20 @@ func Pointer[T any](v T) *T {
 	return &v
 }
 
+// GetMapValue extracts a typed value from a map[string]any, returning the value if the type matched,
+// or the zero values of correct type.
+func GetMapValue[T any](m map[string]any, key string) T {
+	if val, ok := m[key]; ok {
+		if typed, ok := val.(T); ok {
+			return typed
+		}
+	}
+
+	var zero T
+
+	return zero
+}
+
 // AnySliceTo converts a slice of any to a slice of T, returning an error if any element cannot be casted.
 func AnySliceTo[T any](in []any) ([]T, error) {
 	out := make([]T, 0, len(in))


### PR DESCRIPTION
This goes hand in hand with the vscode-opa change [here](https://github.com/open-policy-agent/vscode-opa/pull/403) to produce this:


https://github.com/user-attachments/assets/c76bdf46-fe1c-4e23-9086-b3d8a0a2fa9f

If we think this is the way to go, a follow-up PR could remove the old htmx-based opa-explorer code.