### PR TITLE
lsp: Make capabilities consistent with client

### DIFF
--- a/bundle/regal/lsp/codelens/codelens.rego
+++ b/bundle/regal/lsp/codelens/codelens.rego
@@ -34,7 +34,10 @@ lenses := array.concat(
 
 # METADATA
 # description: Debug lens included in response only when client supports it
-debug_supported if input.regal.client.init_options.enableDebugCodelens == true
+debug_supported if {
+	input.regal.client.init_options.enableDebugCodelens == true
+	input.regal.server.feature_flags.debug_provider == true
+}
 
 _module := data.workspace.parsed[input.params.textDocument.uri]
 

--- a/bundle/regal/lsp/codelens/codelens_test.rego
+++ b/bundle/regal/lsp/codelens/codelens_test.rego
@@ -19,6 +19,7 @@ test_code_lenses_for_module if {
 		# Ugh, why did we make enableDebugCodelens camel case 😭
 		"regal": {
 			"client": {"init_options": {"enableDebugCodelens": true}},
+			"server": {"feature_flags": {"debug_provider": true}},
 			"file": {
 				"name": "policy.rego",
 				"lines": split(policy, "\n"),

--- a/cmd/languageserver.go
+++ b/cmd/languageserver.go
@@ -42,7 +42,10 @@ func init() {
 				verbose = true
 			}
 
-			opts := &lsp.LanguageServerOptions{Logger: log.NewLogger(log.LevelMessage, os.Stderr)}
+			opts := &lsp.LanguageServerOptions{
+				Logger:       log.NewLogger(log.LevelMessage, os.Stderr),
+				FeatureFlags: lsp.DefaultServerFeatureFlags(),
+			}
 			ls := lsp.NewLanguageServer(ctx, opts)
 
 			conf := connection.LoggingConfig{Logger: opts.Logger, LogInbound: verbose, LogOutbound: verbose}

--- a/internal/embeds/schemas/regal/lsp/common.json
+++ b/internal/embeds/schemas/regal/lsp/common.json
@@ -45,6 +45,33 @@
             }
           }
         },
+        "server": {
+          "type": "object",
+          "description": "LSP server config and state",
+          "properties": {
+            "feature_flags": {
+              "type": "object",
+              "description": "Feature flags state",
+              "properties": {
+                "debug_provider": {
+                  "type": "boolean",
+                  "description": "If the server is configured to operate as a debug provider"
+                },
+                "explorer_provider": {
+                  "type": "boolean",
+                  "description": "If the server is configured to operate as an explorer provider"
+                },
+                "inline_eval_provider": {
+                  "type": "boolean",
+                  "description": "If the server is configured to operate as an inline eval provider"
+                }
+              },
+              "required": [
+                "feature_flags"
+              ]
+            }
+          }
+        },
         "environment": {
           "type": "object",
           "description": "Environment properties for the LSP client",
@@ -62,11 +89,17 @@
               "description": "Base URI for Regal's local web server server"
             },
             "input_dot_json_path": {
-              "type": ["string", "null"],
+              "type": [
+                "string",
+                "null"
+              ],
               "description": "Path to the input.json file, if found"
             },
             "input_dot_json": {
-              "type": ["object", "null"],
+              "type": [
+                "object",
+                "null"
+              ],
               "description": "Content of the input.json file, if found"
             },
             "path_separator": {
@@ -122,6 +155,7 @@
       "type": "object",
       "required": [
         "client",
+        "server",
         "environment",
         "file"
       ]

--- a/internal/lsp/capabilities_test.go
+++ b/internal/lsp/capabilities_test.go
@@ -42,8 +42,8 @@ func TestInitializeExperimentalCapabilities(t *testing.T) {
 		t.Error("expected explorerProvider to be true")
 	}
 
-	if !response.Capabilities.Experimental.EvalProvider {
-		t.Error("expected evalProvider to be true")
+	if !response.Capabilities.Experimental.InlineEvalProvider {
+		t.Error("expected inlineEvalProvider to be true")
 	}
 
 	if !response.Capabilities.Experimental.DebugProvider {

--- a/internal/lsp/rego/rego.go
+++ b/internal/lsp/rego/rego.go
@@ -76,9 +76,10 @@ type (
 	}
 
 	RegalContext struct {
-		Client      types.Client `json:"client"`
-		File        File         `json:"file"`
-		Environment Environment  `json:"environment"`
+		Client      types.Client        `json:"client"`
+		Server      types.ServerContext `json:"server"`
+		File        File                `json:"file"`
+		Environment Environment         `json:"environment"`
 
 		Query *query.Prepared `json:"-"` // for now, might expose to Rego later
 	}

--- a/internal/lsp/rego/router_test.go
+++ b/internal/lsp/rego/router_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
 
+	"github.com/open-policy-agent/regal/internal/lsp"
 	"github.com/open-policy-agent/regal/internal/lsp/clients"
 	"github.com/open-policy-agent/regal/internal/lsp/rego"
 	"github.com/open-policy-agent/regal/internal/lsp/rego/query"
@@ -246,6 +247,9 @@ func providers(rc *rego.RegalContext, content, ignored string) rego.Providers {
 func regalContext() *rego.RegalContext {
 	return &rego.RegalContext{
 		Client: types.Client{Identifier: clients.IdentifierVSCode},
+		Server: types.ServerContext{
+			FeatureFlags: *lsp.DefaultServerFeatureFlags(),
+		},
 		Environment: rego.Environment{
 			PathSeparator:    "/",
 			WorkspaceRootURI: "file:///workspace",

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -62,7 +62,11 @@ func createAndInitServer(t *testing.T, ctx context.Context, tempDir string, clie
 	logger := log.NewLogger(log.LevelDebug, t.Output())
 
 	// set up the server and client connections
-	ls := NewLanguageServer(ctx, &LanguageServerOptions{Logger: logger, WorkspaceDiagnosticsPoll: pollingInterval})
+	ls := NewLanguageServer(ctx, &LanguageServerOptions{
+		Logger:                   logger,
+		WorkspaceDiagnosticsPoll: pollingInterval,
+		FeatureFlags:             DefaultServerFeatureFlags(),
+	})
 
 	go ls.StartDiagnosticsWorker(ctx)
 	go ls.StartConfigWorker(ctx)
@@ -87,7 +91,15 @@ func createAndInitServer(t *testing.T, ctx context.Context, tempDir string, clie
 		rootURI = uri.FromPath(clients.IdentifierGeneric, tempDir)
 	}
 
-	request := types.InitializeParams{RootURI: rootURI, ClientInfo: types.ClientInfo{Name: "go test"}}
+	request := types.InitializeParams{
+		RootURI:    rootURI,
+		ClientInfo: types.ClientInfo{Name: "go test"},
+		InitializationOptions: &types.InitializationOptions{
+			EnableDebugCodelens:       new(true),
+			EnableExplorer:            new(true),
+			EvalCodelensDisplayInline: new(true),
+		},
+	}
 
 	var response types.InitializeResult
 	testutil.NoErr(connClient.Call(ctx, "initialize", request, &response))(t)

--- a/internal/lsp/types/internal.go
+++ b/internal/lsp/types/internal.go
@@ -66,3 +66,27 @@ type Client struct {
 func NewGenericClient() Client {
 	return Client{Identifier: clients.IdentifierGeneric}
 }
+
+func (c Client) SupportsExplorer() bool {
+	return c.InitOptions != nil &&
+		c.InitOptions.EnableExplorer != nil &&
+		*c.InitOptions.EnableExplorer
+}
+
+func (c Client) SupportsDebugCodeLens() bool {
+	return c.InitOptions != nil &&
+		c.InitOptions.EnableDebugCodelens != nil &&
+		*c.InitOptions.EnableDebugCodelens
+}
+
+func (c Client) SupportsEvalCodelensDisplayInline() bool {
+	return c.InitOptions != nil &&
+		c.InitOptions.EvalCodelensDisplayInline != nil &&
+		*c.InitOptions.EvalCodelensDisplayInline
+}
+
+// ServerContext is a type which is used to contain things from the server's
+// state that is needed in RegalContext.
+type ServerContext struct {
+	FeatureFlags ServerFeatureFlags `json:"feature_flags"`
+}

--- a/internal/lsp/types/server.go
+++ b/internal/lsp/types/server.go
@@ -1,0 +1,16 @@
+package types
+
+// ServerFeatureFlags defines which custom features are enabled
+// in the language server instance. The client has its own set of matching
+// flags.
+type ServerFeatureFlags struct {
+	// ExplorerProvider indicates whether the server supports the regal.explorer
+	// command and regal/showExplorerResult notification.
+	ExplorerProvider bool `json:"explorer_provider"`
+	// InlineEvaluationProvider indicates whether the server supports the regal.eval
+	// command response being sent rather than written to file.
+	InlineEvaluationProvider bool `json:"inline_evaluation_provider"`
+	// DebugProvider indicates whether the server supports the regal.debug
+	// command and regal/startDebugging request.
+	DebugProvider bool `json:"debug_provider"`
+}

--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -31,6 +31,9 @@ type (
 		// EvalCodelensDisplayInline, if set, will show evaluation results natively
 		// in the calling editor, rather than in an output file.
 		EvalCodelensDisplayInline *bool `json:"evalCodelensDisplayInline,omitempty"`
+		// EnableExplorer, if set, will enable the regal.explorer command
+		// and related functionality.
+		EnableExplorer *bool `json:"enableExplorer,omitempty"`
 	}
 
 	InitializeParams struct {
@@ -93,15 +96,17 @@ type (
 		Experimental               *ExperimentalCapabilities `json:"experimental,omitempty"`
 	}
 
-	// ExperimentalCapabilities contains Regal-specific experimental LSP features
-	// that are not part of the standard LSP specification.
+	// ExperimentalCapabilities contains Regal-specific custom LSP features
+	// that are not part of the base LSP specification. 'Experimental' comes
+	// from the field name in the spec, rather than their status. 'Experimental'
+	// features are more just 'custom' features we have build on the LSP.
 	ExperimentalCapabilities struct {
 		// ExplorerProvider indicates whether the server supports the regal.explorer
 		// command and regal/showExplorerResult notification.
 		ExplorerProvider bool `json:"explorerProvider"`
-		// EvalProvider indicates whether the server supports the regal.eval
-		// command and regal/showEvalResult request.
-		EvalProvider bool `json:"evalProvider"`
+		// InlineEvalProvider indicates whether the server supports the regal.eval
+		// command response being sent rather than written to file.
+		InlineEvalProvider bool `json:"inlineEvalProvider"`
 		// DebugProvider indicates whether the server supports the regal.debug
 		// command and regal/startDebugging request.
 		DebugProvider bool `json:"debugProvider"`

--- a/pkg/lsp/lsp.go
+++ b/pkg/lsp/lsp.go
@@ -25,7 +25,10 @@ type Handle struct {
 // New opens a new language server session on the provided websocket connection `ws`.
 // Use the `*config.Config` argument to control the LSP session's config.
 func New(ctx context.Context, ws *websocket.Conn, c *config.Config) (*Handle, error) {
-	opts := lsp.LanguageServerOptions{Logger: log.NewLogger(log.LevelOff, os.Stderr)}
+	opts := lsp.LanguageServerOptions{
+		Logger:       log.NewLogger(log.LevelOff, os.Stderr),
+		FeatureFlags: lsp.DefaultServerFeatureFlags(),
+	}
 	if os.Getenv("REGAL_DEBUG") != "" {
 		opts.Logger.SetLevel(log.LevelDebug)
 	}


### PR DESCRIPTION
This PR follows https://github.com/open-policy-agent/regal/pull/1867, and is related to https://github.com/open-policy-agent/vscode-opa/pull/406

To make better support mismatched server and client versions.

https://github.com/user-attachments/assets/ea8ea58e-599f-4f34-ab88-4ec2843f6d82

