### PR TITLE
lsp/testing: Ensure test locations sent at boot

### DIFF
--- a/internal/lsp/testing.go
+++ b/internal/lsp/testing.go
@@ -78,6 +78,12 @@ func (l *LanguageServer) processTestLocationsUpdate(ctx context.Context, fileURI
 }
 
 func (l *LanguageServer) sendTestLocations(ctx context.Context, fileURI string, locations any) error {
+	if l.conn == nil {
+		l.log.Debug("sendTestLocations called with no connection: %s", fileURI)
+
+		return nil
+	}
+
 	params := map[string]any{
 		"uri":       fileURI,
 		"locations": locations,


### PR DESCRIPTION
This was missed in https://github.com/open-policy-agent/regal/pull/1888

This makes test locations more similar to diagnostics.
