### PR TITLE
Improved redundant-existence-check

### DIFF
--- a/bundle/regal/rules/bugs/redundant-existence-check/redundant_existence_check_test.rego
+++ b/bundle/regal/rules/bugs/redundant-existence-check/redundant_existence_check_test.rego
@@ -16,7 +16,16 @@ test_fail_redundant_existence_check if {
 		"category": "bugs",
 		"description": "Redundant existence check",
 		"level": "error",
-		"location": {"col": 3, "file": "policy.rego", "row": 7, "text": "\t\tinput.foo", "end": {"col": 12, "row": 7}},
+		"location": {
+			"col": 3,
+			"file": "policy.rego",
+			"row": 7,
+			"text": "\t\tinput.foo",
+			"end": {
+				"col": 12,
+				"row": 7,
+			},
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-existence-check", "bugs"),
@@ -36,7 +45,16 @@ test_fail_redundant_existence_check_subset if {
 		"category": "bugs",
 		"description": "Redundant existence check",
 		"level": "error",
-		"location": {"col": 3, "file": "policy.rego", "row": 7, "text": "\t\tinput.foo", "end": {"col": 12, "row": 7}},
+		"location": {
+			"col": 3,
+			"file": "policy.rego",
+			"row": 7,
+			"text": "\t\tinput.foo",
+			"end": {
+				"col": 12,
+				"row": 7,
+			},
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-existence-check", "bugs"),
@@ -75,7 +93,16 @@ test_fail_redundant_existence_check_head_assignment_of_ref if {
 		"category": "bugs",
 		"description": "Redundant existence check",
 		"level": "error",
-		"location": {"col": 3, "file": "policy.rego", "row": 7, "text": "\t\tinput.foo", "end": {"col": 12, "row": 7}},
+		"location": {
+			"col": 3,
+			"file": "policy.rego",
+			"row": 7,
+			"text": "\t\tinput.foo",
+			"end": {
+				"col": 12,
+				"row": 7,
+			},
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-existence-check", "bugs"),
@@ -94,7 +121,45 @@ test_fail_redundant_existence_check_function_arg if {
 		"category": "bugs",
 		"description": "Redundant existence check",
 		"level": "error",
-		"location": {"col": 3, "end": {"col": 6, "row": 7}, "file": "policy.rego", "row": 7, "text": "\t\tfoo"},
+		"location": {
+			"col": 3,
+			"end": {
+				"col": 6,
+				"row": 7,
+			},
+			"file": "policy.rego",
+			"row": 7,
+			"text": "\t\tfoo",
+		},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-existence-check", "bugs"),
+		}],
+		"title": "redundant-existence-check",
+	}}
+}
+
+test_fail_redundant_existence_check_function_arg_reference_after_use if {
+	r := rule.report with input as ast.with_rego_v1(`
+	fun(foo) if {
+		foo.type == "object"
+		foo.type
+	}`)
+
+	r == {{
+		"category": "bugs",
+		"description": "Redundant existence check",
+		"level": "error",
+		"location": {
+			"col": 3,
+			"end": {
+				"col": 11,
+				"row": 8,
+			},
+			"file": "policy.rego",
+			"row": 8,
+			"text": "\t\tfoo.type",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-existence-check", "bugs"),


### PR DESCRIPTION
By looking in both directions. Still not exhaustive, but that's way too expensive.. and most redundant checks are adjacent to the place of use.

Fixes #1805

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->