### PR TITLE
docs: Show release badge when using pre-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <!-- markdownlint-disable MD041 -->
 
 [![Build Status](https://github.com/open-policy-agent/regal/workflows/Build/badge.svg)](https://github.com/open-policy-agent/regal/actions)
-![OPA v1.13.1-0.20260224105757-9b2143cdf99c](https://www.openpolicyagent.org/badge/v1.13.1-0.20260224105757-9b2143cdf99c)
+![OPA v1.13.1](https://www.openpolicyagent.org/badge/v1.13.1)
 [![codecov](https://codecov.io/github/open-policy-agent/regal/graph/badge.svg?token=EQK01YF3X3)](https://codecov.io/github/StyraInc/regal)
 [![Downloads](https://img.shields.io/github/downloads/open-policy-agent/regal/total.svg)](https://github.com/open-policy-agent/regal/releases)
 

--- a/build/update-readme.sh
+++ b/build/update-readme.sh
@@ -22,13 +22,16 @@ update_badges() {
     exit 1
   fi
 
+  # Extract base version (remove pre-release suffix for badge text)
+  BASE_VERSION=$(echo "$OPA_VERSION" | sed 's/-.*$//')
+
   # Create a temporary file for badges
   badges_tmpfile=$(mktemp)
 
   # Read the badges file and update the OPA badge line
   while IFS= read -r line; do
-    if [[ $line =~ ^\!\[OPA\ v[0-9]+\.[0-9]+\.[0-9]+\] ]]; then
-      echo "![OPA $OPA_VERSION](https://www.openpolicyagent.org/badge/$OPA_VERSION)" >> "$badges_tmpfile"
+    if [[ $line =~ ^\!\[OPA\ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+      echo "![OPA $BASE_VERSION](https://www.openpolicyagent.org/badge/$BASE_VERSION)" >> "$badges_tmpfile"
     else
       echo "$line" >> "$badges_tmpfile"
     fi

--- a/docs/readme-sections/badges.md
+++ b/docs/readme-sections/badges.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable MD041 -->
 
 [![Build Status](https://github.com/open-policy-agent/regal/workflows/Build/badge.svg)](https://github.com/open-policy-agent/regal/actions)
-![OPA v1.13.1-0.20260224105757-9b2143cdf99c](https://www.openpolicyagent.org/badge/v1.13.1-0.20260224105757-9b2143cdf99c)
+![OPA v1.13.1](https://www.openpolicyagent.org/badge/v1.13.1)
 [![codecov](https://codecov.io/github/open-policy-agent/regal/graph/badge.svg?token=EQK01YF3X3)](https://codecov.io/github/StyraInc/regal)
 [![Downloads](https://img.shields.io/github/downloads/open-policy-agent/regal/total.svg)](https://github.com/open-policy-agent/regal/releases)


### PR DESCRIPTION
If we are using a pre-release version of OPA, just show the last release prefix in the readme badge as otherwise it overflows.

<img width="1834" height="588" alt="image" src="https://github.com/user-attachments/assets/9a7abd42-28d5-48af-81ee-21a6a84b7c80" />
