### PR TITLE
Allow naming-convention rule to take list of names (not only a pattern)

### DIFF
--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -16,6 +16,101 @@ rules:
       ignore:
         files:
           - "*_test.rego"
+    naming-convention:
+      # Regal naming conventions configuration. Note that this is disabled by default, and
+      # is meant only to be run every once in a while to ensure we stick to our conventions.
+      # These conventions are not static, and the correct "fix" to a naming violation may
+      # very well be to update this configuration rather than the code.
+      #
+      # To check compliance:
+      # regal lint --enable naming-convention bundle
+      #
+      # See naming.md for rationale and examples of these conventions.
+      # NOTE: that this check is not automated, but intended to be used occasionally.
+      level: ignore
+      conventions:
+        - pattern: '\b[a-z_]{5,}\b'
+          names:
+            # indices
+            - i
+            - j
+            - k
+            # count / length
+            - n
+            # rego types
+            - arr
+            - obj
+            - set
+            - str
+            - num
+            # imaginary 'types'
+            - coll
+            - seq
+            - item
+            # ast types
+            - pkg
+            - imp
+            - ref
+            - refs
+            - var
+            - vars
+            - fun
+            - arg
+            - args
+            - term
+            - terms
+            - expr
+            - exprs
+            - rule
+            - head
+            - body
+            - call
+            - comp
+            - node
+            # ast attributes and related
+            - key
+            - keys
+            - val
+            - vals
+            - type
+            # common
+            - file
+            - text
+            - line
+            - rows
+            - cols
+            - loc
+            - end
+            - col
+            - row
+            - agg
+            - aggs
+            - cfg
+            - word
+            - start
+            - link
+            - len
+            - kind
+            - rest
+            - name
+            - pos
+            - sub
+            - sup
+            - last
+            - next
+            - lhs
+            - rhs
+            - path
+            - url
+            - uri
+            - other
+            - diff
+            - dir
+          targets:
+            - var
+      ignore:
+        files:
+          - "*_test.rego"
     narrow-argument:
       level: error
       exclude-args:

--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -102,9 +102,9 @@ rules := [rule |
 # description: all the test rules in the input AST
 tests := [rule |
 	some rule in rules
+	some term in rule.head.ref
 
-	some part in rule.head.ref
-	startswith(part.value, "test_")
+	startswith(term.value, "test_")
 ]
 
 # METADATA
@@ -212,59 +212,59 @@ function_calls[rule_index] contains call if {
 
 # METADATA
 # description: |
-#   true if both ref values (or "paths") are equal in type
+#   true if both ref values (terms) are equal in type
 #   and value for each path component, ignoring locations
-ref_value_equal(v1, v2) if {
-	count(v1) == count(v2)
+ref_value_equal(terms, other) if {
+	count(terms) == count(other)
 
-	every i, term in v1 {
-		term.type == v2[i].type
-		term.value == v2[i].value
+	every i, term in terms {
+		term.type == other[i].type
+		term.value == other[i].value
 	}
 }
 
 # METADATA
 # description: |
-#   returns a new ref value made by extending terms1 with terms2,
-#   where the first term of terms2 transformed to string
-extend_ref_terms(terms1, terms2) := array.flatten([
-	terms1,
-	object.union(terms2[0], {"type": "string"}),
-	array.slice(terms2, 1, 100),
+#   returns a new terms array made by extending terms with other,
+#   where the first term of other transformed to string
+extend_ref_terms(terms, other) := array.flatten([
+	terms,
+	object.union(other[0], {"type": "string"}),
+	array.slice(other, 1, 100),
 ])
 
 # METADATA
 # description: |
-#   true if all terms in `terms1` are also present in `terms2`
+#   true if all terms in `terms` are also present in `other`
 #   regardless of length, and ignoring locations
-is_terms_subset(terms1, terms2) if {
-	count(terms1) <= count(terms2)
+is_terms_subset(terms, other) if {
+	count(terms) <= count(other)
 
-	every i, term in terms1 {
-		term.type == terms2[i].type
-		term.value == terms2[i].value
+	every i, term in terms {
+		term.type == other[i].type
+		term.value == other[i].value
 	}
 }
 
 # METADATA
 # description: returns the "path" string of any given ref value
-ref_to_string(ref) := concat("", array.flatten([ref[0].value, [_format_part(part) |
-	some part in array.slice(ref, 1, 100)
+ref_to_string(ref) := concat("", array.flatten([ref[0].value, [_format_term(term) |
+	some term in array.slice(ref, 1, 100)
 
-	not part.type in {"call", "ref", "templatestring"}
+	not term.type in {"call", "ref", "templatestring"}
 ]]))
 
-_format_part(part) := concat("", [".", part.value]) if {
-	part.type == "string"
-	regex.match(`^[a-zA-Z_][a-zA-Z1-9_]*$`, part.value)
+_format_term(term) := concat("", [".", term.value]) if {
+	term.type == "string"
+	regex.match(`^[a-zA-Z_][a-zA-Z1-9_]*$`, term.value)
 } else := sprintf(
 	{
 		"string": `["%v"]`,
 		"var": `[%v]`,
 		"number": `[%d]`,
 		"boolean": `[%v]`,
-	}[part.type],
-	[part.value],
+	}[term.type],
+	[term.value],
 )
 
 # METADATA
@@ -275,9 +275,9 @@ _format_part(part) := concat("", [".", part.value]) if {
 #   foo.bar[baz] -> foo.bar
 ref_static_to_string(ref) := ref_to_string(array.slice(ref, 0, first_non_static)) if {
 	first_non_static := [i |
-		some i, part in ref
+		some i, term in ref
 		i > 0
-		part.type in {"call", "var", "ref", "templatestring"}
+		term.type in {"call", "var", "ref", "templatestring"}
 	][0]
 } else := ref_to_string(ref)
 
@@ -369,11 +369,11 @@ is_chained_rule_body(rule, lines) if {
 # description: answers whether variable of `name` is found anywhere in provided rule `head`
 # scope: document
 var_in_head(head, name) if {
-	some part in ["key", "value"]
-	has_named_var(head[part], name)
+	some type in ["key", "value"]
+	has_named_var(head[type], name)
 } else if {
-	some part in array.slice(head.ref, 1, 100)
-	has_named_var(part, name)
+	some term in array.slice(head.ref, 1, 100)
+	has_named_var(term, name)
 }
 
 # METADATA

--- a/bundle/regal/ast/comments.rego
+++ b/bundle/regal/ast/comments.rego
@@ -80,23 +80,23 @@ comment_blocks(comments_decoded) := blocks if {
 			some comment in row_partition
 
 			col := comment.location.col # regal ignore:comprehension-term-assignment
-			partition := [c |
-				some c in row_partition
-				c.location.col == col
+			partition := [partition_comment |
+				some partition_comment in row_partition
+				partition_comment.location.col == col
 			]
 		}
 	]
 }
 
-_splits(xs) := array.flatten([
+_splits(rows) := array.flatten([
 	# -1 ++ [ all indices where there's a step larger than one ] ++ length of xs
 	# the -1 is because we're adding +1 in array.slice
 	-1,
 	[i |
 		some i in numbers.range(0, n - 1)
-		xs[i + 1] != xs[i] + 1
+		rows[i + 1] != rows[i] + 1
 	],
 	n,
 ]) if {
-	n := count(xs)
+	n := count(rows)
 }

--- a/bundle/regal/ast/imports.rego
+++ b/bundle/regal/ast/imports.rego
@@ -46,12 +46,13 @@ resolved_imports[identifier] := paths[0] if {
 #   returns true if provided path (like ["data", "foo", "bar"]) is in the
 #   list of imports (which is commonly ast.imports)
 imports_has_path(imports, path) if {
-	pv := imports[_].path.value
+	n := count(path)
+	terms := imports[_].path.value
 
-	count(pv) == count(path)
+	count(terms) == n
 
-	every i, part in path {
-		part == pv[i].value
+	every i, term in path {
+		term == terms[i].value
 	}
 }
 
@@ -62,11 +63,7 @@ imports_has_path(imports, path) if {
 imports_keyword(imports, keyword) if {
 	capabilities.is_opa_v1
 	input.regal.file.rego_version != "v0"
-} else if {
-	pv := imports[_].path.value
-
-	_has_keyword([p.value | some p in pv], keyword)
-}
+} else if _has_keyword([term.value | term := imports[_].path.value[_]], keyword)
 
 _imported_identifier(imp) := imp.alias
 _imported_identifier(imp) := regal.last(imp.path.value).value if not imp.alias

--- a/bundle/regal/ast/keywords.rego
+++ b/bundle/regal/ast/keywords.rego
@@ -9,19 +9,19 @@ import data.regal.util
 # METADATA
 # description: collects the `if` keyword. this isn't present in the AST, so we'll simply scan the input lines
 keywords[row] contains keyword if {
-	some idx, line in input.regal.file.lines
+	some i, line in input.regal.file.lines
 
 	col := indexof(line, " if ")
 	col > 0
 
-	row := idx + 1
+	row := i + 1
 
 	not row in _comment_row_index
 
 	keyword := {
 		"name": "if",
 		"location": {
-			"row": idx + 1,
+			"row": i + 1,
 			"col": col + 2,
 		},
 	}

--- a/bundle/regal/ast/search.rego
+++ b/bundle/regal/ast/search.rego
@@ -56,8 +56,8 @@ has_term_var(terms) if {
 
 # converting to string until https://github.com/open-policy-agent/opa/issues/6736 is fixed
 _rule_index(rule) := rule_index_strings[i] if {
-	some i, r in _rules
-	r == rule
+	some i
+	rule == _rules[i]
 }
 
 # hack to work around the different input models of linting vs. the lsp package.. we
@@ -119,9 +119,9 @@ found.vars[rule_index].ref contains term if {
 	some rule_index, ref
 	found.refs[rule_index][ref]
 
-	some x, term in ref.value
+	some i, term in ref.value
 
-	x > 0
+	i > 0
 	term.type == "var"
 }
 
@@ -165,9 +165,9 @@ found.vars[rule_index].somein contains var if {
 
 	arr := value[0].value
 
-	some var in array.flatten([_find_nested_vars(arr[1]), [v |
+	some var in array.flatten([_find_nested_vars(arr[1]), [var |
 		count(arr) == 4
-		some v in _find_nested_vars(arr[2])
+		some var in _find_nested_vars(arr[2])
 	]])
 }
 

--- a/bundle/regal/config/exclusion.rego
+++ b/bundle/regal/config/exclusion.rego
@@ -16,10 +16,10 @@ excluded_file(category, title, file) if {
 # description: |
 #   pattern_compiler transforms a glob pattern into a set of glob
 #   patterns to make the combined set behave as .gitignore
-patterns_compiler(patterns) := {pat |
+patterns_compiler(patterns) := {compiled |
 	some pattern in patterns
-	some p in _leading_doublestar_pattern(_internal_slashes(pattern))
-	some pat in _trailing_slash(p)
+	some processed in _leading_doublestar_pattern(_internal_slashes(pattern))
+	some compiled in _trailing_slash(processed)
 } if {
 	patterns != []
 }

--- a/bundle/regal/lsp/codeaction/codeaction.rego
+++ b/bundle/regal/lsp/codeaction/codeaction.rego
@@ -23,22 +23,22 @@ result["response"] := actions
 actions contains action if {
 	"quickfix" in only
 
-	some diag in input.params.context.diagnostics
+	some diagnostic in input.params.context.diagnostics
 
-	[title, args] := rules[diag.code]
+	[title, args] := rules[diagnostic.code]
 	action := {
 		"title": title,
 		"kind": "quickfix",
-		"diagnostics": [diag],
+		"diagnostics": [diagnostic],
 		"isPreferred": true,
 		"command": {
 			"title": title,
-			"command": $"regal.fix.{diag.code}",
+			"command": $"regal.fix.{diagnostic.code}",
 			"tooltip": title,
 			"arguments": [json.marshal(object.filter(
 				{
 					"target": input.params.textDocument.uri,
-					"diagnostic": diag,
+					"diagnostic": diagnostic,
 				},
 				args,
 			))],
@@ -47,22 +47,22 @@ actions contains action if {
 }
 
 # METADATA
-# description: Generic code action to ignore any rule in config from diag
+# description: Generic code action to ignore any rule in config from diagnostics
 actions contains action if {
 	"quickfix" in only
 
-	some diag in input.params.context.diagnostics
+	some diagnostic in input.params.context.diagnostics
 
 	action := {
 		"title": "Ignore this rule in config",
 		"kind": "quickfix",
-		"diagnostics": [diag],
+		"diagnostics": [diagnostic],
 		"isPreferred": false,
 		"command": {
 			"title": "Ignore this rule in config",
 			"command": "regal.config.disable-rule",
 			"tooltip": "Ignore this rule in config",
-			"arguments": [json.marshal({"diagnostic": diag})],
+			"arguments": [json.marshal({"diagnostic": diagnostic})],
 		},
 	}
 }
@@ -76,19 +76,19 @@ actions contains action if {
 	input.regal.client.identifier == clients.vscode
 	"quickfix" in only
 
-	some diag in input.params.context.diagnostics
+	some diagnostic in input.params.context.diagnostics
 
 	# always show the docs link
-	title := $"Show documentation for {diag.code}"
+	title := $"Show documentation for {diagnostic.code}"
 	action := {
 		"title": title,
 		"kind": "quickfix",
-		"diagnostics": [diag],
+		"diagnostics": [diagnostic],
 		"command": {
 			"title": title,
 			"command": "vscode.open",
 			"tooltip": title,
-			"arguments": [diag.codeDescription.href],
+			"arguments": [diagnostic.codeDescription.href],
 		},
 	}
 }

--- a/bundle/regal/lsp/codelens/codelens.rego
+++ b/bundle/regal/lsp/codelens/codelens.rego
@@ -28,8 +28,8 @@ result["response"] := lenses if {
 # METADATA
 # description: contains code lenses determined for module
 lenses := array.concat(
-	[l | some l in _eval_lenses],
-	[l | some l in _debug_lenses],
+	util.to_array(_eval_lenses),
+	util.to_array(_debug_lenses),
 )
 
 # METADATA
@@ -61,10 +61,10 @@ _eval_lenses contains _rule_lens(input.params.textDocument.uri, rule, "regal.eva
 	not rule.head.args
 }
 
-_debug_lenses contains lens if {
+_debug_lenses contains obj if {
 	debug_supported
 
-	lens := {
+	obj := {
 		"range": range.from_location(result.location(_module.package).location),
 		"command": {
 			"title": "Debug",
@@ -78,7 +78,7 @@ _debug_lenses contains lens if {
 	}
 }
 
-_debug_lenses contains lens if {
+_debug_lenses contains obj if {
 	debug_supported
 
 	some rule in _module.rules
@@ -89,7 +89,7 @@ _debug_lenses contains lens if {
 	# no need to add a debug lens for a rule like `pi := 3.14`
 	not _unconditional_constant(rule)
 
-	lens := _rule_lens(input.params.textDocument.uri, rule, "regal.debug", "Debug")
+	obj := _rule_lens(input.params.textDocument.uri, rule, "regal.debug", "Debug")
 }
 
 _rule_lens(file_uri, rule, command, title) := {

--- a/bundle/regal/lsp/completion/providers/booleans/booleans.rego
+++ b/bundle/regal/lsp/completion/providers/booleans/booleans.rego
@@ -20,17 +20,17 @@ items contains item if {
 
 	word := location.word_at(line, input.params.position.character + 1)
 
-	some b in ["true", "false"]
+	some str in ["true", "false"]
 
-	startswith(b, word.text)
+	startswith(str, word.text)
 
 	item := {
-		"label": b,
+		"label": str,
 		"kind": kind.constant,
 		"detail": "boolean value",
 		"textEdit": {
 			"range": location.word_range(word, input.params.position),
-			"newText": b,
+			"newText": str,
 		},
 	}
 }

--- a/bundle/regal/lsp/completion/providers/packagename/packagename.rego
+++ b/bundle/regal/lsp/completion/providers/packagename/packagename.rego
@@ -15,11 +15,11 @@ items contains item if {
 	startswith(line, "package ")
 	input.params.position.character > 7
 
-	ps := input.regal.environment.path_separator
+	path_sep := input.regal.environment.path_separator
 
 	abs_dir := _base(input.params.textDocument.uri)
 	rel_dir := trim_prefix(abs_dir, input.regal.environment.workspace_root_path)
-	fix_dir := replace(replace(trim_prefix(rel_dir, ps), ".", "_"), ps, ".")
+	fix_dir := replace(replace(trim_prefix(rel_dir, path_sep), ".", "_"), path_sep, ".")
 
 	word := location.ref_at(line, input.params.position.character + 1)
 
@@ -36,50 +36,50 @@ items contains item if {
 	}
 }
 
-_base(uri) := base if {
-	path := trim_prefix(uri, "file://")
-	base := substring(path, 0, regal.last(indexof_n(path, input.regal.environment.path_separator)))
+_base(uri) := str if {
+	end := trim_prefix(uri, "file://")
+	str := substring(end, 0, regal.last(indexof_n(end, input.regal.environment.path_separator)))
 }
 
-_suggestions(dir, text) := [path |
+_suggestions(dir, text) := [str |
 	parts := split(dir, ".")
 	len_p := count(parts)
 
 	some n in numbers.range(0, len_p)
 
-	formatted_parts := [p |
-		some index, part in array.slice(parts, n, len_p)
-		p := _format_part(part, _needs_quoting(part))
+	formatted_parts := [formatted |
+		some index, str in array.slice(parts, n, len_p)
+		formatted := _format_part(str, _needs_quoting(str))
 	]
 
-	path := concat("", [p |
-		some index, part in formatted_parts
-		p := _delimit_part(part, array.slice(formatted_parts, index + 1, index + 2))
+	str := concat("", [delimited |
+		some index, str in formatted_parts
+		delimited := _delimit_part(str, array.slice(formatted_parts, index + 1, index + 2))
 	])
 
-	path != ""
+	str != ""
 
 	# it's not valid Rego to have a hypenated first part
-	not startswith(path, `["`)
+	not startswith(str, `["`)
 
-	startswith(path, text)
+	startswith(str, text)
 ]
 
 # matches anything with a non alphanumeric character or underscore anywhere in
 # the part. E.g. "foo@bar", "@foo-bar" etc.
-_needs_quoting(part) := regex.match(`[^a-zA-Z0-9_]`, part)
+_needs_quoting(str) := regex.match(`[^a-zA-Z0-9_]`, str)
 
-_format_part(part, false) := part
-_format_part(part, true) := $`["{part}"]`
+_format_part(str, false) := str
+_format_part(str, true) := $`["{str}"]`
 
-_delimit_part(part, next_part) := $"{part}." if {
-	next_part != []
-	not startswith(next_part[0], "[")
+_delimit_part(str, next) := $"{str}." if {
+	next != []
+	not startswith(next[0], "[")
 }
 
-_delimit_part(part, next_part) := part if {
-	next_part != []
-	startswith(next_part[0], "[")
+_delimit_part(str, next) := str if {
+	next != []
+	startswith(next[0], "[")
 }
 
-_delimit_part(part, []) := part
+_delimit_part(str, []) := str

--- a/bundle/regal/lsp/documenthighlight/documenthighlight.rego
+++ b/bundle/regal/lsp/documenthighlight/documenthighlight.rego
@@ -142,9 +142,9 @@ _attribute_from_text(line) := word if {
 		"# custom:",
 	})
 
-	idx := indexof(line, ":")
-	idx != -1
+	i := indexof(line, ":")
+	i != -1
 
 	# Trim the leading '# ' and anything following (and including) ':'
-	word := substring(line, 2, idx - 2)
+	word := substring(line, 2, i - 2)
 }

--- a/bundle/regal/lsp/selectionrange/selectionrange.rego
+++ b/bundle/regal/lsp/selectionrange/selectionrange.rego
@@ -109,9 +109,9 @@ _find_ranges(node, position) := array.reverse([{"range": value_range} |
 
 # the SelectionRange object is recursive, so we need to reach for tricks here!
 _to_selection_range(ranges) := json.patch(ranges[0], [patch |
-	some i, r in array.slice(ranges, 1, count(ranges))
+	some i, arr in array.slice(ranges, 1, count(ranges))
 
-	patch := {"op": "add", "path": util.repeat("/parent", i + 1), "value": r}
+	patch := {"op": "add", "path": util.repeat("/parent", i + 1), "value": arr}
 ])
 
 _estimated_import_range(imp) := import_range if {

--- a/bundle/regal/lsp/semantictokens/semantictokens.rego
+++ b/bundle/regal/lsp/semantictokens/semantictokens.rego
@@ -47,7 +47,7 @@ arg_tokens.reference contains arg if {
 
 	rule.head.args
 
-	arg_names := {v.value | some v in rule.head.args}
+	arg_names := {term.value | some term in rule.head.args}
 
 	walk(rule.body, [_, expr])
 
@@ -63,7 +63,7 @@ arg_tokens.reference contains arg if {
 # description: Extract variable references in call expressions
 arg_tokens.reference contains arg if {
 	some rule in module.rules
-	arg_names := {v.value | some v in rule.head.args}
+	arg_names := {term.value | some term in rule.head.args}
 	walk(rule.body, [_, expr])
 
 	some term in expr.terms

--- a/bundle/regal/lsp/signaturehelp/signaturehelp.rego
+++ b/bundle/regal/lsp/signaturehelp/signaturehelp.rego
@@ -14,11 +14,11 @@ result["response"] := signature
 # scope: document
 default signature := null
 
-signature := s if {
+signature := obj if {
 	func_info := _function_at_position(input.regal.file.lines, input.params.position)
 	builtin_info := data.workspace.builtins[func_info.name]
 
-	s := {
+	obj := {
 		"signatures": [{
 			"label": _build_function_label(builtin_info.decl, func_info.name),
 			# some builtins had a space at the start
@@ -33,7 +33,7 @@ signature := s if {
 
 default _function_at_position(_, _) := {}
 
-_function_at_position(lines, position) := func if {
+_function_at_position(lines, position) := function if {
 	content := concat("\n", lines)
 	text := _text_up_to_position(lines, content, position)
 
@@ -41,7 +41,7 @@ _function_at_position(lines, position) := func if {
 	result := regex.find_all_string_submatch_n(`([a-zA-Z_][a-zA-Z0-9_.]*)\(([^)]*)$`, text, -1)
 	last_match := regal.last(result)
 
-	func := {"name": last_match[1], "active_param": strings.count(last_match[2], ",") + 1}
+	function := {"name": last_match[1], "active_param": strings.count(last_match[2], ",") + 1}
 }
 
 # when position is after the last line
@@ -66,9 +66,9 @@ _text_up_to_position(lines, _, position) := concat("\n", all_lines) if {
 	])
 }
 
-_build_function_label(decl, func_name) := label if {
-	param_labels := concat(", ", [_param_label(arg) | some arg in decl.args])
-	label := sprintf("%s(%s) -> %s", [func_name, param_labels, decl.result.type])
+_build_function_label(declaration, func_name) := label if {
+	param_labels := concat(", ", [_param_label(arg) | some arg in declaration.args])
+	label := sprintf("%s(%s) -> %s", [func_name, param_labels, declaration.result.type])
 }
 
 _build_parameters(args) := [param |

--- a/bundle/regal/lsp/template/template.rego
+++ b/bundle/regal/lsp/template/template.rego
@@ -23,9 +23,9 @@ render_for_builtin(builtin) := content if {
 _docs_link(builtin, category) := link if {
 	builtin.categories != []
 
-	link := [trim_prefix(bc, "url=") |
-		some bc in builtin.categories
-		startswith(bc, "url=")
+	link := [trim_prefix(_category, "url=") |
+		some _category in builtin.categories
+		startswith(_category, "url=")
 	][0]
 } else := sprintf("https://www.openpolicyagent.org/docs/policy-reference/#builtin-%s-%s", [
 	category,
@@ -60,7 +60,7 @@ _category(builtin) := builtin.categories[0] if {
 # here to work around the **extremely** annoying behavior of strings.render_template
 # where missing keys are treated as fatal errors instead of giving template authors a
 # chance to handle this: https://github.com/open-policy-agent/opa/issues/7931
-_to_safe_builtin(builtin) := safe if {
+_to_safe_builtin(builtin) := obj if {
 	safe_attributes := {
 		"description": "(no description)",
 		"categories": [],
@@ -75,7 +75,7 @@ _to_safe_builtin(builtin) := safe if {
 	}
 
 	merged := object.union(safe_attributes, builtin)
-	safe := object.union(merged, {"decl": {"args": [_to_safe_arg(i, arg) | some i, arg in merged.decl.args]}})
+	obj := object.union(merged, {"decl": {"args": [_to_safe_arg(i, arg) | some i, arg in merged.decl.args]}})
 }
 
 _to_safe_arg(i, arg) := arg if {

--- a/bundle/regal/lsp/testlocations/testlocations.rego
+++ b/bundle/regal/lsp/testlocations/testlocations.rego
@@ -14,11 +14,11 @@ import data.regal.result as rs
 #   the location (which has start and end char range too).
 result contains object.union(loc, {
 	"package": _package_ref_string,
-	"name": ast.ref_static_to_string(test.head.ref),
+	"name": ast.ref_static_to_string(rule.head.ref),
 }) if {
-	some test in ast.tests
+	some rule in ast.tests
 
-	loc := rs.location(test.head)
+	loc := rs.location(rule.head)
 }
 
 _package_ref_string := ast.ref_to_string(input.package.path)

--- a/bundle/regal/lsp/util/range/range.rego
+++ b/bundle/regal/lsp/util/range/range.rego
@@ -33,34 +33,34 @@ from_location(location) := {
 #     ref: https://www.openpolicyagent.org/projects/regal/custom-rules/roast#compact-location-format
 parse(location_string) := {
 	"start": {
-		"line": to_number(r) - 1,
-		"character": to_number(c) - 1,
+		"line": to_number(parts[0]) - 1,
+		"character": to_number(parts[1]) - 1,
 	},
 	"end": {
-		"line": to_number(er) - 1,
-		"character": to_number(ec) - 1,
+		"line": to_number(parts[2]) - 1,
+		"character": to_number(parts[3]) - 1,
 	},
 } if {
-	[r, c, er, ec] := split(location_string, ":")
+	parts := split(location_string, ":")
 }
 
 # METADATA
-# description: checks if a given position 'pos' is found within range 'rng'
+# description: checks if a given position 'pos' is found within 'range'
 # scope: document
-contains_position(rng, pos) if {
-	pos.line > rng.start.line
-	pos.line < rng.end.line
+contains_position(range, pos) if {
+	pos.line > range.start.line
+	pos.line < range.end.line
 } else if {
-	pos.line == rng.start.line
-	pos.line < rng.end.line
-	pos.character >= rng.start.character
+	pos.line == range.start.line
+	pos.line < range.end.line
+	pos.character >= range.start.character
 } else if {
-	pos.line > rng.start.line
-	pos.line == rng.end.line
-	pos.character <= rng.end.character
+	pos.line > range.start.line
+	pos.line == range.end.line
+	pos.character <= range.end.character
 } else if {
-	pos.line == rng.start.line
-	pos.line == rng.end.line
-	pos.character >= rng.start.character
-	pos.character <= rng.end.character
+	pos.line == range.start.line
+	pos.line == range.end.line
+	pos.character >= range.start.character
+	pos.character <= range.end.character
 }

--- a/bundle/regal/result/result.rego
+++ b/bundle/regal/result/result.rego
@@ -30,8 +30,8 @@ import data.regal.util
 #  no longer used, but kept for compatibility reasons.
 ## regal ignore:argument-always-wildcard
 aggregate(_, aggregate_data) := {
-	"aggregate_source": {"package_path": [part.value |
-		some i, part in input.package.path
+	"aggregate_source": {"package_path": [term.value |
+		some i, term in input.package.path
 		i > 0
 	]},
 	"aggregate_data": aggregate_data,
@@ -110,10 +110,10 @@ notice(metadata) := result if {
 # regal ignore:narrow-argument
 _related_resources(annotations, _, _) := annotations.related_resources
 
-_related_resources(annotations, category, title) := rr if {
+_related_resources(annotations, category, title) := arr if {
 	not annotations.related_resources
 
-	rr := [{
+	arr := [{
 		"description": "documentation",
 		"ref": $"{config.docs.base_url}/{category}/{title}",
 	}]
@@ -151,9 +151,9 @@ _fail_annotated_custom(metadata, details) := violation if {
 	violation := object.remove(with_category, ["custom", "scope", "schemas"])
 }
 
-_resource_urls(related_resources, category) := [r |
+_resource_urls(related_resources, category) := [obj |
 	some item in related_resources
-	r := object.union(item, {"ref": config.docs.resolve_url(item.ref, category)})
+	obj := object.union(item, {"ref": config.docs.resolve_url(item.ref, category)})
 ]
 
 # Note that the `text` attribute always returns the entire line and *not*
@@ -173,30 +173,30 @@ _with_text(loc_obj) := loc if {
 #   new code should most often use one of the ranged_ location functions instead, as
 #   that will also include an `"end"` location attribute
 # scope: document
-location(x) := _with_text(util.to_location_object(x.location))
-location(x) := _with_text(util.to_location_object(x[0].location)) if is_array(x)
-location(x) := _with_text(util.to_location_object(x)) if is_string(x)
+location(node) := _with_text(util.to_location_object(node.location))
+location(node) := _with_text(util.to_location_object(node[0].location)) if is_array(node)
+location(node) := _with_text(util.to_location_object(node)) if is_string(node)
 
 # METADATA
 # description: |
 #   returns a "normalized" location object from the location value found in the AST, along
 #   with an overridden description field. This is useful for rules that want to provide a custom message,
 #   perhaps depending on the context of the violation.
-location_and_description(x, description) := object.union(
-	location(x),
+location_and_description(node, description) := object.union(
+	location(node),
 	{"description": description},
 )
 
 # METADATA
-# description: creates a location where x is the start, and y is the end (calculated from `text`)
-ranged_location_between(x, y) := object.union(
-	location(x),
-	{"location": {"end": location(y).location.end}},
+# description: creates a location combining the start and end locations (calculated from `text`)
+ranged_location_between(start, end) := object.union(
+	location(start),
+	{"location": {"end": location(end).location.end}},
 )
 
 # METADATA
 # description: creates a location where the first term location is the start, and the last term location is the end
-ranged_from_ref(ref) := ranged_location_between(ref[0], regal.last(ref))
+ranged_from_ref(terms) := ranged_location_between(terms[0], regal.last(terms))
 
 # METADATA
 # description: |

--- a/bundle/regal/rules/bugs/argument-always-wildcard/argument_always_wildcard.rego
+++ b/bundle/regal/rules/bugs/argument-always-wildcard/argument_always_wildcard.rego
@@ -10,9 +10,9 @@ import data.regal.util
 report contains violation if {
 	some name, functions in _function_groups
 
-	fn := util.any_set_item(functions)
+	fun := util.any_set_item(functions)
 
-	some pos, _ in fn.head.args
+	some pos, _ in fun.head.args
 
 	every function in functions {
 		function.head.args[pos].type == "var"
@@ -21,13 +21,13 @@ report contains violation if {
 
 	not _function_name_excepted(name)
 
-	violation := result.fail(rego.metadata.chain(), result.location(fn.head.args[pos]))
+	violation := result.fail(rego.metadata.chain(), result.location(fun.head.args[pos]))
 }
 
-_function_groups[name] contains fn if {
-	some fn in ast.functions
+_function_groups[name] contains fun if {
+	some fun in ast.functions
 
-	name := ast.ref_to_string(fn.head.ref)
+	name := ast.ref_to_string(fun.head.ref)
 }
 
 _function_name_excepted(name) if {

--- a/bundle/regal/rules/bugs/duplicate-rule/duplicate_rule.rego
+++ b/bundle/regal/rules/bugs/duplicate-rule/duplicate_rule.rego
@@ -33,32 +33,32 @@ _message(locations) := sprintf(
 	count(locations) > 1
 }
 
-_rules_as_text := [util.to_location_object(rule.location).text | some rule in input.rules]
-
 _duplicates contains indices if {
+	rules_as_text := [util.to_location_object(rule.location).text | some rule in input.rules]
+
 	# Remove whitespace from textual representation of rule and create a hash from the result.
 	# This provides a decent, and importantly *cheap*, approximation of duplicates. We can then
 	# parse the text of these suspected duplicate rules to get a more exact result.
-	rules_hashed := [crypto.md5(regex.replace(text, `\s+`, "")) | some text in _rules_as_text]
+	rules_hashed := [crypto.md5(regex.replace(text, `\s+`, "")) | some text in rules_as_text]
 
 	some possible_duplicates in util.find_duplicates(rules_hashed)
 
 	# need to include the original index here to be able to backtrack that to the rule
-	asts := {index: ast |
+	parsed_by_index := {index: parsed |
 		some index in possible_duplicates
 
-		module := sprintf("package p\n\nimport rego.v1\n\n%s", [_rules_as_text[index]])
+		module := sprintf("package p\n\nimport rego.v1\n\n%s", [rules_as_text[index]])
 
 		# note that we _don't_ use regal.parse_module here, as we do not want location
 		# information — only the structure of the AST must match
-		ast := rego.parse_module("", module)
+		parsed := rego.parse_module("", module)
 	}
 
-	keys := [key | some key, _ in asts]
+	keys := [key | some key, _ in parsed_by_index]
 
 	indices := [keys[index] |
-		some dups in util.find_duplicates([val | some val in asts])
-		some index in dups
+		some duplicate in util.find_duplicates([val | some val in parsed_by_index])
+		some index in duplicate
 	]
 
 	indices != []

--- a/bundle/regal/rules/bugs/impossible-not/impossible_not.rego
+++ b/bundle/regal/rules/bugs/impossible-not/impossible_not.rego
@@ -112,7 +112,7 @@ aggregate_report contains violation if {
 _var_to_ref(terms) := [terms] if terms.type == "var"
 _var_to_ref(terms) := terms.value if terms.type == "ref"
 
-_to_string(ref) := concat(".", [part.value | some part in ref])
+_to_string(ref) := concat(".", [term.value | some term in ref])
 
 _resolve(ref, _, _) := _to_string(ref) if ref[0].value == "data"
 
@@ -122,7 +122,7 @@ _resolve(ref, _, imported_symbols) := concat(".", resolved) if {
 
 	resolved := array.concat(
 		imported_symbols[ref[0].value],
-		[part.value | some part in array.slice(ref, 1, 100)],
+		[term.value | some term in array.slice(ref, 1, 100)],
 	)
 }
 
@@ -132,10 +132,7 @@ _resolve(ref, pkg_path, imported_symbols) := concat(".", resolved) if {
 
 	not imported_symbols[ref[0].value]
 
-	resolved := array.concat(
-		pkg_path,
-		[part.value | some part in ref],
-	)
+	resolved := array.concat(pkg_path, [term.value | some term in ref])
 }
 
 # METADATA

--- a/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args.rego
+++ b/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args.rego
@@ -23,9 +23,9 @@ report contains violation if {
 	some name, args_list in function_args_by_name
 	not _arity_mismatch(args_list) # leave that to the compiler
 
-	by_position := [s | # "partition" the args by their position
+	by_position := [partitioned | # "partition" the args by their position
 		some i, _ in args_list[0]
-		s := [item[i] | some item in args_list]
+		partitioned := [item[i] | some item in args_list]
 	]
 
 	some position in by_position
@@ -54,7 +54,7 @@ _inconsistent_args(position) if {
 
 # Return the _second_ function found by name, as that
 # is reasonably the location the inconsistency is found
-_find_function_by_name(name) := [fn |
-	some fn in ast.functions
-	ast.ref_to_string(fn.head.ref) == name
+_find_function_by_name(name) := [fun |
+	some fun in ast.functions
+	ast.ref_to_string(fun.head.ref) == name
 ][1]

--- a/bundle/regal/rules/bugs/redundant-existence-check/redundant_existence_check.rego
+++ b/bundle/regal/rules/bugs/redundant-existence-check/redundant_existence_check.rego
@@ -28,14 +28,14 @@ report contains violation if {
 #  would certainly be possible, the cost does not justify the benefit, as it's
 #  quite unlikely that existence checks are found there
 report contains violation if {
-	some func in ast.functions
+	some rule in ast.functions
 
 	arg_vars := {term.value |
-		some term in func.head.args
+		some term in rule.head.args
 		term.type == "var"
 	}
 
-	some expr in func.body
+	some expr in rule.body
 
 	not expr.negated
 	expr.terms.type == "var"

--- a/bundle/regal/rules/bugs/redundant-loop-count/redundant_loop_count.rego
+++ b/bundle/regal/rules/bugs/redundant-loop-count/redundant_loop_count.rego
@@ -26,14 +26,14 @@ report contains violation if {
 	next.terms.symbols[0].value[0].value[1].value in {"member_2", "member_3"}
 
 	# Last, ensure that the same ref that was counted is the one iterated over
-	a := expr.terms[1].value[1]
-	a.type == "ref"
+	term := expr.terms[1].value[1]
+	term.type == "ref"
 
-	b := regal.last(next.terms.symbols[0].value)
-	b.type == "ref"
+	other := regal.last(next.terms.symbols[0].value)
+	other.type == "ref"
 
-	count(a.value) == count(b.value)
-	ast.is_terms_subset(a.value, b.value)
+	count(term.value) == count(other.value)
+	ast.is_terms_subset(term.value, other.value)
 
 	violation := result.fail(rego.metadata.chain(), result.location(expr.terms[1]))
 }

--- a/bundle/regal/rules/bugs/sprintf-arguments-mismatch/sprintf_arguments_mismatch.rego
+++ b/bundle/regal/rules/bugs/sprintf-arguments-mismatch/sprintf_arguments_mismatch.rego
@@ -19,10 +19,10 @@ notices contains result.notice(rego.metadata.chain()) if not "sprintf" in object
 #   compare it to the number of items in the array (if known), and flag when the numbers
 #   don't match
 report contains violation if {
-	some rule_index, fn
-	ast.function_calls[rule_index][fn].name == "sprintf"
+	some rule_index, fun
+	ast.function_calls[rule_index][fun].name == "sprintf"
 
-	fn.args[1].type == "array" # can only check static arrays, not vars
+	fun.args[1].type == "array" # can only check static arrays, not vars
 
 	# this could come either from a term directly (the common case):
 	#     sprintf("%d", [1])
@@ -33,9 +33,9 @@ report contains violation if {
 	# this rule can definitely miss more advanced things, like re-assignemt from
 	# another variable. tbh, that's a waste of time. what we should make sure is
 	# to not report anything erroneously.
-	format_term := _first_arg_value(rule_index, fn.args[0])
+	format_term := _first_arg_value(rule_index, fun.args[0])
 
-	values_in_arr := count(fn.args[1].value)
+	values_in_arr := count(fun.args[1].value)
 	str_no_escape := replace(format_term.value, "%%", "") # don't include '%%' as it's used to "escape" %
 	num_patterns := strings.count(str_no_escape, "%")
 	num_paddings := strings.count(str_no_escape, "%-*s") # these require 2 arguments to be provided
@@ -43,7 +43,7 @@ report contains violation if {
 
 	values_in_str != values_in_arr
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_between(fn.args[0], regal.last(fn.args)))
+	violation := result.fail(rego.metadata.chain(), result.ranged_location_between(fun.args[0], regal.last(fun.args)))
 }
 
 # see: https://pkg.go.dev/fmt#hdr-Explicit_argument_indexes
@@ -51,8 +51,8 @@ report contains violation if {
 # values array. this calculates the number to subtract from the total expected
 # number of values based on the number of eai's occurring more than once
 _repeated_explicit_argument_indexes(str) := sum([n |
-	some eai in {eai | some eai in regex.find_n(`%\[\d\]`, str, -1)}
-	n := strings.count(str, eai) - 1
+	some exp_arg_idx in {exp_arg_idx | some exp_arg_idx in regex.find_n(`%\[\d\]`, str, -1)}
+	n := strings.count(str, exp_arg_idx) - 1
 ])
 
 _first_arg_value(_, term) := term if term.type == "string"
@@ -60,12 +60,12 @@ _first_arg_value(_, term) := term if term.type == "string"
 _first_arg_value(rule_index, term) := found if {
 	term.type == "var"
 
-	trow := to_number(util.substring_to(term.location, 0, ":"))
+	row := to_number(util.substring_to(term.location, 0, ":"))
 
 	found := [rhs |
 		some expr in ast.found.expressions[rule_index]
 
-		to_number(util.substring_to(expr.location, 0, ":")) < trow
+		to_number(util.substring_to(expr.location, 0, ":")) < row
 
 		[lhs, rhs] := ast.assignment_terms(expr.terms)
 		lhs.type == "var"

--- a/bundle/regal/rules/custom/naming-convention/naming_convention.rego
+++ b/bundle/regal/rules/custom/naming-convention/naming_convention.rego
@@ -9,13 +9,14 @@ import data.regal.result
 # target: package
 report contains violation if {
 	some convention in config.rules.custom["naming-convention"].conventions
+
 	"package" in convention.targets
 
-	not regex.match(convention.pattern, ast.package_name)
+	not _convention_matched(ast.package_name, convention)
 
 	violation := result.fail(
 		rego.metadata.chain(),
-		result.location_and_description(input.package, _message("package", ast.package_name, convention.pattern)),
+		result.location_and_description(input.package, _message("package", ast.package_name)),
 	)
 }
 
@@ -28,11 +29,11 @@ report contains violation if {
 
 	name := ast.ref_to_string(rule.head.ref)
 
-	not regex.match(convention.pattern, name)
+	not _convention_matched(name, convention)
 
 	violation := result.fail(
 		rego.metadata.chain(),
-		result.location_and_description(rule.head, _message("rule", name, convention.pattern)),
+		result.location_and_description(rule.head, _message("rule", name)),
 	)
 }
 
@@ -45,11 +46,11 @@ report contains violation if {
 
 	name := ast.ref_to_string(rule.head.ref)
 
-	not regex.match(convention.pattern, name)
+	not _convention_matched(name, convention)
 
 	violation := result.fail(
 		rego.metadata.chain(),
-		result.location_and_description(rule.head, _message("function", name, convention.pattern)),
+		result.location_and_description(rule.head, _message("function", name)),
 	)
 }
 
@@ -62,12 +63,19 @@ report contains violation if {
 
 	var := ast.found.vars[_][_][_]
 
-	not regex.match(convention.pattern, var.value)
+	not startswith(var.value, "$")
+	not _convention_matched(var.value, convention)
 
 	violation := result.fail(
 		rego.metadata.chain(),
-		result.location_and_description(var, _message("variable", var.value, convention.pattern)),
+		result.location_and_description(var, _message("variable", var.value)),
 	)
 }
 
-_message(kind, name, pattern) := $`Naming convention violation: {kind} name "{name}" does not match pattern '{pattern}'`
+_message(kind, name) := $`Naming violation: {kind} name "{name}" does not match configured convention`
+
+_convention_matched(name, convention) if {
+	name in convention.names
+} else if {
+	regex.match(convention.pattern, name)
+}

--- a/bundle/regal/rules/custom/naming-convention/naming_convention_test.rego
+++ b/bundle/regal/rules/custom/naming-convention/naming_convention_test.rego
@@ -9,7 +9,7 @@ test_fail_package_name_does_not_match_pattern if {
 		with config.rules as conventions([{"targets": ["package"], "pattern": `^foo\.bar\..+$`}])
 
 	r == {expected(
-		`Naming convention violation: package name "foo.bar" does not match pattern '^foo\.bar\..+$'`,
+		`Naming violation: package name "foo.bar" does not match configured convention`,
 		{
 			"col": 1,
 			"file": "policy.rego",
@@ -35,7 +35,7 @@ test_fail_rule_name_does_not_match_pattern if {
 		with config.rules as conventions([{"targets": ["rule"], "pattern": "^[a-z]+$"}])
 
 	r == {expected(
-		`Naming convention violation: rule name "FOO" does not match pattern '^[a-z]+$'`,
+		`Naming violation: rule name "FOO" does not match configured convention`,
 		{
 			"col": 1,
 			"file": "policy.rego",
@@ -61,7 +61,7 @@ test_fail_function_name_does_not_match_pattern if {
 		with config.rules as conventions([{"targets": ["function"], "pattern": "^[a-z]+$"}])
 
 	r == {expected(
-		`Naming convention violation: function name "fooBar" does not match pattern '^[a-z]+$'`,
+		`Naming violation: function name "fooBar" does not match configured convention`,
 		{
 			"col": 1,
 			"file": "policy.rego",
@@ -93,7 +93,7 @@ test_fail_var_name_does_not_match_pattern if {
 		with config.rules as conventions([{"targets": ["variable"], "pattern": "^[a-z_]+$"}])
 
 	r == {expected(
-		`Naming convention violation: variable name "fooBar" does not match pattern '^[a-z_]+$'`,
+		`Naming violation: variable name "fooBar" does not match configured convention`,
 		{
 			"col": 3,
 			"file": "policy.rego",
@@ -139,7 +139,7 @@ test_fail_multiple_conventions if {
 
 	r == {
 		expected(
-			`Naming convention violation: package name "foo.bar" does not match pattern '^acmecorp\.[a-z_\.]+$'`,
+			`Naming violation: package name "foo.bar" does not match configured convention`,
 			{
 				"col": 1,
 				"file": "policy.rego",
@@ -152,7 +152,7 @@ test_fail_multiple_conventions if {
 			},
 		),
 		expected(
-			`Naming convention violation: rule name "foo" does not match pattern '^bar$|^foo_bar$'`,
+			`Naming violation: rule name "foo" does not match configured convention`,
 			{
 				"col": 2,
 				"file": "policy.rego",
@@ -165,7 +165,7 @@ test_fail_multiple_conventions if {
 			},
 		),
 		expected(
-			`Naming convention violation: variable name "fooBar" does not match pattern '^bar$|^foo_bar$'`,
+			`Naming violation: variable name "fooBar" does not match configured convention`,
 			{
 				"col": 3,
 				"file": "policy.rego",
@@ -178,6 +178,44 @@ test_fail_multiple_conventions if {
 			},
 		),
 	}
+}
+
+test_fail_variable_name_does_not_match_name_in_list if {
+	policy := ast.policy(`
+	allow if {
+		fooBar := true
+		fooBar == true
+	}
+	`)
+	r := rule.report with input as policy
+		with config.rules as conventions([{"targets": ["var"], "names": ["foo_bar"]}])
+
+	r == {expected(
+		`Naming violation: variable name "fooBar" does not match configured convention`,
+		{
+			"col": 3,
+			"file": "policy.rego",
+			"row": 5,
+			"end": {
+				"col": 9,
+				"row": 5,
+			},
+			"text": "\t\tfooBar := true",
+		},
+	)}
+}
+
+test_success_variable_name_matches_name_in_list if {
+	policy := ast.policy(`
+	allow if {
+		foo_bar := true
+		foo_bar == true
+	}
+	`)
+	r := rule.report with input as policy
+		with config.rules as conventions([{"targets": ["variable"], "names": ["foo_bar"]}])
+
+	r == set()
 }
 
 expected(description, location) := {

--- a/bundle/regal/rules/custom/narrow-argument/narrow_argument.rego
+++ b/bundle/regal/rules/custom/narrow-argument/narrow_argument.rego
@@ -96,13 +96,11 @@ _functions[name] contains {"rule_index": i, "args_refs": args_refs} if {
 		arg := ast.found.refs[ast.rule_index_strings[i]][_].value[0].value
 		arg in variable_args
 		ref_vals := {vals |
-			some g
-			ast.found.refs[ast.rule_index_strings[i]][g].value[0].value == arg
+			some j
+			ast.found.refs[ast.rule_index_strings[i]][j].value[0].value == arg
 
-			ref := ast.found.refs[ast.rule_index_strings[i]][g].value
-			vals := [part.value |
-				some part in array.slice(ref, 0, _first_var_pos(ref))
-			]
+			ref := ast.found.refs[ast.rule_index_strings[i]][j].value
+			vals := [term.value | some term in array.slice(ref, 0, _first_var_pos(ref))]
 		}
 	}
 
@@ -111,8 +109,8 @@ _functions[name] contains {"rule_index": i, "args_refs": args_refs} if {
 
 _first_var_pos(ref) := pos if {
 	pos := [i |
-		some i, part in ref
-		part.type == "var"
+		some i, term in ref
+		term.type == "var"
 		i > 0
 	][0]
 } else := count(ref) + 1

--- a/bundle/regal/rules/custom/one-liner-rule/one_liner_rule.rego
+++ b/bundle/regal/rules/custom/one-liner-rule/one_liner_rule.rego
@@ -28,10 +28,7 @@ report contains violation if {
 	# Note that this will give us the text representation of the whole rule,
 	# which we'll need as the "if" is only visible here ¯\_(ツ)_/¯
 	rule_location := util.to_location_object(rule.location)
-	lines := [line |
-		some s in split(rule_location.text, "\n")
-		line := trim_space(s)
-	]
+	lines := [trim_space(line) | some line in split(rule_location.text, "\n")]
 
 	regex.match(`\s+if`, lines[0])
 	_rule_body_brackets(lines)

--- a/bundle/regal/rules/idiomatic/boolean-assignment/boolean_assignment.rego
+++ b/bundle/regal/rules/idiomatic/boolean-assignment/boolean_assignment.rego
@@ -7,12 +7,12 @@ import data.regal.result
 
 report contains violation if {
 	head := input.rules[_].head
-	rhv := head.value
+	term := head.value
 
-	rhv.type == "call"
-	rhv.value[0].type == "ref"
+	term.type == "call"
+	term.value[0].type == "ref"
 
-	ref_name := rhv.value[0].value[0].value
+	ref_name := term.value[0].value[0].value
 
 	config.capabilities.builtins[ref_name].decl.result == "boolean"
 

--- a/bundle/regal/rules/idiomatic/equals-pattern-matching/equals_pattern_matching.rego
+++ b/bundle/regal/rules/idiomatic/equals-pattern-matching/equals_pattern_matching.rego
@@ -12,43 +12,43 @@ import data.regal.result
 # ->
 # f(1)
 report contains violation if {
-	some fn in ast.functions
+	some fun in ast.functions
 
-	not fn.body
-	not fn.else
+	not fun.body
+	not fun.else
 
-	val := fn.head.value
+	val := fun.head.value
 	val.type == "call"
 	val.value[0].type == "ref"
 	val.value[0].value[0].value == "equal"
 
 	term := _normalize_eq_terms(val.value, ast.scalar_types)
 
-	some arg in fn.head.args
+	some arg in fun.head.args
 
 	arg.type == "var"
 	term.value == arg.value
 
-	violation := result.fail(rego.metadata.chain(), result.location(fn))
+	violation := result.fail(rego.metadata.chain(), result.location(fun))
 }
 
 # f(x) if x == 1
 # ->
 # f(1)
 report contains violation if {
-	some fn in ast.functions
+	some fun in ast.functions
 
-	fn.body
-	not fn.else
+	fun.body
+	not fun.else
 
 	# FOR NOW: Limit to a lone comparison
 	# More elaborate cases are certainly doable,
 	# but we'd need to keep track of whatever else
 	# each var is up to in the body, and that's..
 	# well, elaborate.
-	count(fn.body) == 1
+	count(fun.body) == 1
 
-	expr := fn.body[0]
+	expr := fun.body[0]
 
 	expr.terms[0].type == "ref"
 	expr.terms[0].value[0].type == "var"
@@ -56,12 +56,12 @@ report contains violation if {
 
 	term := _normalize_eq_terms(expr.terms, ast.scalar_types)
 
-	some arg in fn.head.args
+	some arg in fun.head.args
 
 	arg.type == "var"
 	term.value == arg.value
 
-	violation := result.fail(rego.metadata.chain(), result.location(fn))
+	violation := result.fail(rego.metadata.chain(), result.location(fun))
 }
 
 # normalize var to always always be on the left hand side

--- a/bundle/regal/rules/idiomatic/non-raw-regex-pattern/non_raw_regex_pattern.rego
+++ b/bundle/regal/rules/idiomatic/non-raw-regex-pattern/non_raw_regex_pattern.rego
@@ -23,9 +23,8 @@ report contains violation if {
 
 	loc := util.to_location_object(value[pos].location)
 	row := input.regal.file.lines[loc.row - 1]
-	chr := substring(row, loc.col - 1, 1)
 
-	chr == `"`
+	substring(row, loc.col - 1, 1) == `"`
 
 	violation := result.fail(rego.metadata.chain(), result.location(value[pos]))
 }

--- a/bundle/regal/rules/idiomatic/prefer-equals-comparison/prefer_equals_comparison.rego
+++ b/bundle/regal/rules/idiomatic/prefer-equals-comparison/prefer_equals_comparison.rego
@@ -27,8 +27,8 @@ _unassignable(term, _) if {
 
 _unassignable(term, rule_index) if {
 	term.type == "var"
-	ri := to_number(rule_index)
-	not ast.is_output_var(input.rules[ri], term)
+	i := to_number(rule_index)
+	not ast.is_output_var(input.rules[i], term)
 	not _is_declared_comp_term(term, rule_index)
 }
 

--- a/bundle/regal/rules/idiomatic/use-in-operator/use_in_operator.rego
+++ b/bundle/regal/rules/idiomatic/use-in-operator/use_in_operator.rego
@@ -11,15 +11,15 @@ report contains violation if {
 	terms[0].type == "ref"
 	terms[0].value[0].value in {"eq", "equal"}
 
-	nl_terms := _non_loop_term(terms)
-	count(nl_terms) == 1
+	non_loop_terms := _non_loop_term(terms)
+	count(non_loop_terms) == 1
 
-	nlt := nl_terms[0]
-	_static_term(nlt.term)
+	head := non_loop_terms[0]
+	_static_term(head.term)
 
 	# Use the non-loop term position to determine the
 	# location of the loop term (3 is the count of terms)
-	violation := result.fail(rego.metadata.chain(), result.location(terms[3 - nlt.pos]))
+	violation := result.fail(rego.metadata.chain(), result.location(terms[3 - head.pos]))
 }
 
 _non_loop_term(terms) := [{"pos": i + 1, "term": term} |

--- a/bundle/regal/rules/idiomatic/use-object-keys/use_object_keys.rego
+++ b/bundle/regal/rules/idiomatic/use-object-keys/use_object_keys.rego
@@ -45,9 +45,9 @@ report contains violation if {
 
 	ref := _ref(comprehension.value.body)
 
-	vars := [part |
-		some part in array.slice(ref, 1, 100)
-		part.type == "var"
+	vars := [term |
+		some term in array.slice(ref, 1, 100)
+		term.type == "var"
 	]
 
 	count(vars) == 1

--- a/bundle/regal/rules/idiomatic/use-some-for-output-vars/use_some_for_output_vars.rego
+++ b/bundle/regal/rules/idiomatic/use-some-for-output-vars/use_some_for_output_vars.rego
@@ -13,7 +13,10 @@ report contains violation if {
 	not startswith(term.value, "$")
 	not term.value in ast.imported_identifiers
 	not term.value in ast.rule_names
-	not true in {true | some v in ast.found.vars[rule_index].some; v.value == term.value}
+	not true in {true |
+		some var in ast.found.vars[rule_index].some
+		var.value == term.value
+	}
 
 	rule := input.rules[to_number(rule_index)]
 

--- a/bundle/regal/rules/idiomatic/use-strings-count/use_strings_count.rego
+++ b/bundle/regal/rules/idiomatic/use-strings-count/use_strings_count.rego
@@ -26,8 +26,11 @@ report contains violation if {
 	ref[1].value[0].value[0].type == "var"
 	ref[1].value[0].value[0].value == "indexof_n"
 
-	loc1 := result.location(ref[0])
-	loc2 := result.location(ref[1])
-
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_between(loc1, loc2))
+	violation := result.fail(
+		rego.metadata.chain(),
+		result.ranged_location_between(
+			result.location(ref[0]),
+			result.location(ref[1]),
+		),
+	)
 }

--- a/bundle/regal/rules/imports/circular-import/circular_import.rego
+++ b/bundle/regal/rules/imports/circular-import/circular_import.rego
@@ -11,12 +11,12 @@ import data.regal.ast
 import data.regal.result
 import data.regal.util
 
-_refs[ref] contains r.location if {
-	some r
-	ast.found.refs[_][r].value[0].value == "data"
-	ast.static_ref(r)
+_refs[str] contains ref.location if {
+	some ref
+	ast.found.refs[_][ref].value[0].value == "data"
+	ast.static_ref(ref)
 
-	ref := concat(".", [e.value | some e in r.value])
+	str := concat(".", [term.value | some term in ref.value])
 }
 
 _refs[ref] contains imported.path.location if {
@@ -24,7 +24,7 @@ _refs[ref] contains imported.path.location if {
 
 	imported.path.value[0].value == "data"
 
-	ref := concat(".", [e.value | some e in imported.path.value])
+	ref := concat(".", [term.value | some term in imported.path.value])
 }
 
 # METADATA
@@ -38,16 +38,16 @@ aggregate_report contains violation if {
 	# 2+ files required in the aggregated set for a circular import to be possible
 	count(_aggregated) > 1
 
-	some g in _groups
+	some group in _groups
 
-	count(g) > 1
+	count(group) > 1
 
-	sorted_group := sort(g)
+	sorted_group := sort(group)
 
 	[file, referenced_location] := [file_loc |
-		some m1 in sorted_group
-		some m2 in sorted_group
-		file_loc := _package_locations[m1][m2]
+		some vertices_one in sorted_group
+		some vertices_two in sorted_group
+		file_loc := _package_locations[vertices_one][vertices_two]
 	][0]
 
 	violation := result.fail(rego.metadata.chain(), {
@@ -61,11 +61,11 @@ aggregate_report contains violation if {
 #   - input: schema.regal.aggregate
 aggregate_report contains violation if {
 	# this rule tests for self dependencies
-	some g in _groups
+	some group in _groups
 
-	count(g) == 1
+	count(group) == 1
 
-	some pkg in g # this will be the only package
+	some pkg in group # this will be the only package
 
 	pkg in _import_graph[pkg] # without this, check below is extremely expensive!
 
@@ -88,9 +88,9 @@ _package_locations[referenced_pkg][pkg.package_name] := [file, util.any_set_item
 # METADATA
 # schemas:
 #   - input: schema.regal.aggregate
-_import_graph[pkg.package_name] contains edge if {
+_import_graph[pkg.package_name] contains str if {
 	some pkg in _aggregated
-	some edge, _ in pkg.refs
+	some str, _ in pkg.refs
 }
 
 _reachable_index[pkg] := graph.reachable(_import_graph, {pkg}) if some pkg, _ in _import_graph
@@ -104,9 +104,9 @@ _groups contains group if {
 	# even if only to themselves
 	_import_graph[pkg] != {}
 
-	group := {m |
-		some m in graph.reachable(_import_graph, {pkg})
-		pkg in _reachable_index[m]
+	group := {vertices |
+		some vertices in graph.reachable(_import_graph, {pkg})
+		pkg in _reachable_index[vertices]
 	}
 }
 

--- a/bundle/regal/rules/imports/confusing-alias/confusing_alias.rego
+++ b/bundle/regal/rules/imports/confusing-alias/confusing_alias.rego
@@ -2,6 +2,7 @@
 # description: Confusing alias of existing import
 package regal.rules.imports["confusing-alias"]
 
+import data.regal.ast
 import data.regal.result
 
 report contains violation if {
@@ -9,7 +10,8 @@ report contains violation if {
 	some imp in input.imports
 
 	imp != aliased
-	_paths_equal(aliased.path.value, imp.path.value)
+	count(aliased.path.value) == count(imp.path.value)
+	ast.is_terms_subset(aliased.path.value, imp.path.value)
 
 	violation := result.fail(rego.metadata.chain(), result.location(aliased))
 }
@@ -18,13 +20,4 @@ _aliased_imports contains imp if {
 	some imp in input.imports
 
 	imp.alias
-}
-
-_paths_equal(p1, p2) if {
-	count(p1) == count(p2)
-
-	every i, part in p1 {
-		part.type == p2[i].type
-		part.value == p2[i].value
-	}
 }

--- a/bundle/regal/rules/imports/ignored-import/ignored_import.rego
+++ b/bundle/regal/rules/imports/ignored-import/ignored_import.rego
@@ -5,7 +5,7 @@ package regal.rules.imports["ignored-import"]
 import data.regal.ast
 import data.regal.result
 
-_import_paths contains [p.value | some p in imp.path.value] if {
+_import_paths contains [term.value | some term in imp.path.value] if {
 	some imp in input.imports
 
 	imp.path.value[0].value in {"data", "input"}
@@ -18,11 +18,11 @@ report contains violation if {
 	ref.value[0].type == "var"
 	ref.value[0].value in {"data", "input"}
 
-	most_specific_match := regal.last(sort([ip |
-		ref_path := [p.value | some p in ref.value]
+	most_specific_match := regal.last(sort([import_path |
+		ref_path := [term.value | some term in ref.value]
 
-		some ip in _import_paths
-		array.slice(ref_path, 0, count(ip)) == ip
+		some import_path in _import_paths
+		array.slice(ref_path, 0, count(import_path)) == import_path
 	]))
 
 	violation := result.fail(rego.metadata.chain(), object.union(

--- a/bundle/regal/rules/imports/pointless-import/pointless_import.rego
+++ b/bundle/regal/rules/imports/pointless-import/pointless_import.rego
@@ -23,8 +23,8 @@ report contains violation if {
 # description: report pointless imports of rule paths defined in the same module
 report contains violation if {
 	rule_paths := {path |
-		rref := input.rules[_].head.ref
-		path := ast.extend_ref_terms(input.package.path, rref)
+		ref := input.rules[_].head.ref
+		path := ast.extend_ref_terms(input.package.path, ref)
 	}
 	imp_path := input.imports[_].path
 

--- a/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports.rego
+++ b/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports.rego
@@ -16,7 +16,7 @@ aggregate contains entry if {
 		_import.path.value[0].value == "data"
 		len := count(_import.path.value)
 		len > 1
-		path := [part.value | some part in array.slice(_import.path.value, 1, len)]
+		path := [term.value | some term in array.slice(_import.path.value, 1, len)]
 
 		# Special case for custom rules, where we don't want to flag e.g. `import data.regal.ast`
 		# as unknown, even though it's not a package included in evaluation.

--- a/bundle/regal/rules/imports/unresolved-import/unresolved_import.rego
+++ b/bundle/regal/rules/imports/unresolved-import/unresolved_import.rego
@@ -16,7 +16,7 @@ aggregate contains entry if {
 		_import.path.value[0].value == "data"
 		len := count(_import.path.value)
 		len > 1
-		path := [part.value | some part in array.slice(_import.path.value, 1, len)]
+		path := [term.value | some term in array.slice(_import.path.value, 1, len)]
 
 		# Special case for custom rules, where we don't want to flag e.g. `import data.regal.ast`
 		# as unknown, even though it's not a package included in evaluation.
@@ -71,14 +71,14 @@ _custom_regal_package_and_import(pkg_path, "regal") if {
 # but if we have a rule like foo.bar.baz
 # we'll want to include both foo.bar and foo.bar.baz
 _to_paths(pkg_path, ref) := util.all_paths(_to_path(pkg_path, ref)) if count(ref) < 3
-_to_paths(pkg_path, ref) := [_to_path(pkg_path, p) | some p in util.all_paths(ref)] if count(ref) > 2
+_to_paths(pkg_path, ref) := [_to_path(pkg_path, terms) | some terms in util.all_paths(ref)] if count(ref) > 2
 
-_to_path(pkg_path, ref) := array.flatten([pkg_path, ref[0].value, [_to_string(part) |
-	some part in array.slice(ref, 1, 100)
+_to_path(pkg_path, terms) := array.flatten([pkg_path, terms[0].value, [_to_string(term) |
+	some term in array.slice(terms, 1, 100)
 ]])
 
-_to_string(part) := part.value if part.type == "string"
-_to_string(part) := "**" if part.type == "var"
+_to_string(term) := term.value if term.type == "string"
+_to_string(term) := "**" if term.type == "var"
 
 _except_imports contains split(trim_prefix(str, "data."), ".") if {
 	some str in config.rules.imports["unresolved-import"]["except-imports"]

--- a/bundle/regal/rules/performance/defer-assignment/defer_assignment.rego
+++ b/bundle/regal/rules/performance/defer-assignment/defer_assignment.rego
@@ -51,9 +51,7 @@ _var_value_used_in_expression(value, expr) if {
 }
 
 _var_value_used_in_expression(value, expr) if {
-	some w in expr.with
-
-	walk(w, [_, node])
+	walk(expr.with, [_, node])
 
 	node.type == "var"
 	node.value == value

--- a/bundle/regal/rules/performance/non-loop-expression/non_loop_expression.rego
+++ b/bundle/regal/rules/performance/non-loop-expression/non_loop_expression.rego
@@ -7,8 +7,8 @@ import data.regal.result
 import data.regal.util
 
 report contains violation if {
-	some rule_index, sps in _loop_start_points
-	first_loop_row := min(object.keys(sps))
+	some rule_index, start_points in _loop_start_points
+	first_loop_row := min(object.keys(start_points))
 
 	some row, expr
 	_exprs[rule_index][row][expr]

--- a/bundle/regal/rules/style/external-reference/external_reference.rego
+++ b/bundle/regal/rules/style/external-reference/external_reference.rego
@@ -49,8 +49,8 @@ _named_vars(arg) := {var.value | some var in ast.find_term_vars(arg)} if arg.typ
 #   note: this doesn't check for built-in calls or calls to function
 #   defined in the same package, as those are already covered by
 #   "fn_namespaces" in the report rule
-_function_call_ctx(fn, path) if {
-	object.get(fn, array.slice(path, 0, count(path) - 4), false).type == "call"
+_function_call_ctx(fun, path) if {
+	object.get(fun, array.slice(path, 0, count(path) - 4), false).type == "call"
 } else if {
 	terms_path := array.slice(path, 0, util.last_indexof(path, "terms") + 2)
 	next_term_path := array.flatten([
@@ -60,5 +60,5 @@ _function_call_ctx(fn, path) if {
 
 	# ["body", 0, "terms", 1]
 
-	object.get(fn, next_term_path, null) != null
+	object.get(fun, next_term_path, null) != null
 }

--- a/bundle/regal/rules/style/function-arg-return/function_arg_return.rego
+++ b/bundle/regal/rules/style/function-arg-return/function_arg_return.rego
@@ -9,12 +9,12 @@ import data.regal.result
 report contains violation if {
 	included_functions := ast.all_function_names - _excluded_functions
 
-	some fn
-	ast.function_calls[_][fn].name in included_functions
+	some fun
+	ast.function_calls[_][fun].name in included_functions
 
-	count(fn.args) > count(ast.all_functions[fn.name].decl.args)
+	count(fun.args) > count(ast.all_functions[fun.name].decl.args)
 
-	violation := result.fail(rego.metadata.chain(), result.location(regal.last(fn.args)))
+	violation := result.fail(rego.metadata.chain(), result.location(regal.last(fun.args)))
 }
 
 _excluded_functions contains "print"

--- a/bundle/regal/rules/style/messy-rule/messy_rule.rego
+++ b/bundle/regal/rules/style/messy-rule/messy_rule.rego
@@ -6,15 +6,15 @@ import data.regal.ast
 import data.regal.result
 
 report contains violation if {
-	some i, rule1 in input.rules
+	some i, rule in input.rules
 
 	# tests aren't really incremental rules, and other rules
 	# will flag multiple rules with the same name
-	not startswith(trim_prefix(rule1.head.ref[0].value, "todo_"), "test_")
+	not startswith(trim_prefix(rule.head.ref[0].value, "todo_"), "test_")
 
 	cur_name := ast.rule_names_ordered[i]
 
-	some j, rule2 in input.rules
+	some j, other in input.rules
 
 	j > i
 
@@ -24,5 +24,5 @@ report contains violation if {
 	previous_name := ast.rule_names_ordered[j - 1]
 	previous_name != nxt_name
 
-	violation := result.fail(rego.metadata.chain(), result.location(rule2))
+	violation := result.fail(rego.metadata.chain(), result.location(other))
 }

--- a/bundle/regal/rules/style/prefer-snake-case/prefer_snake_case.rego
+++ b/bundle/regal/rules/style/prefer-snake-case/prefer_snake_case.rego
@@ -8,19 +8,19 @@ import data.regal.result
 report contains violation if {
 	ast.package_name != lower(ast.package_name)
 
-	some part in input.package.path
+	some term in input.package.path
 
-	part.value != lower(part.value)
+	term.value != lower(term.value)
 
-	violation := result.fail(rego.metadata.chain(), result.location(part))
+	violation := result.fail(rego.metadata.chain(), result.location(term))
 }
 
 report contains violation if {
-	part := input.rules[_].head.ref[_]
+	term := input.rules[_].head.ref[_]
 
-	part.value != lower(part.value)
+	term.value != lower(term.value)
 
-	violation := result.fail(rego.metadata.chain(), result.location(part))
+	violation := result.fail(rego.metadata.chain(), result.location(term))
 }
 
 report contains violation if {

--- a/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration.rego
+++ b/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration.rego
@@ -67,9 +67,9 @@ _invalid_some_location(rule, location) if {
 
 # don't recommend `some .. in` if iteration occurs inside of arrays, objects, or sets
 _invalid_some_context(rule, path) if {
-	some p in util.all_paths(path)
+	some arr in util.all_paths(path)
 
-	node := object.get(rule, p, false)
+	node := object.get(rule, arr, false)
 
 	_impossible_some(node)
 }
@@ -80,9 +80,9 @@ _invalid_some_context(rule, path) if {
 # not _directly_ replaceable by `some .. in`, so we'll leave it
 # be here
 _invalid_some_context(rule, path) if {
-	some p in util.all_paths(path)
+	some arr in util.all_paths(path)
 
-	node := object.get(rule, p, [])
+	node := object.get(rule, arr, [])
 
 	node.terms[0].type == "ref"
 	node.terms[0].value[0].type == "var"

--- a/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package.rego
+++ b/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package.rego
@@ -36,9 +36,9 @@ _possible_offending_prefixes contains concat("", formatted_combination) if {
 
 	count(combination) > 1
 
-	formatted_combination := array.flatten([combination[0], [w |
+	formatted_combination := array.flatten([combination[0], [formatted |
 		some word in util.rest(combination)
 
-		w := regex.replace(word, `^[a-z]`, upper(substring(word, 0, 1)))
+		formatted := regex.replace(word, `^[a-z]`, upper(substring(word, 0, 1)))
 	]])
 }

--- a/bundle/regal/rules/style/yoda-condition/yoda_condition.rego
+++ b/bundle/regal/rules/style/yoda-condition/yoda_condition.rego
@@ -20,7 +20,7 @@ report contains violation if {
 
 _ref_with_vars(ref) if {
 	count(ref) > 2
-	some i, part in ref
+	some i, term in ref
 	i > 0
-	part.type == "var"
+	term.type == "var"
 }

--- a/bundle/regal/rules/testing/metasyntactic-variable/metasyntactic_variable.rego
+++ b/bundle/regal/rules/testing/metasyntactic-variable/metasyntactic_variable.rego
@@ -24,9 +24,9 @@ _metasyntactic := {
 
 report contains violation if {
 	some rule in input.rules
-	some part in ast.named_refs(rule.head.ref)
+	some term in ast.named_refs(rule.head.ref)
 
-	lower(part.value) in _metasyntactic
+	lower(term.value) in _metasyntactic
 
 	# In case we have chained rule bodies — only flag the location where we have an actual name:
 	# foo {
@@ -36,7 +36,7 @@ report contains violation if {
 	# }
 	not ast.is_chained_rule_body(rule, input.regal.file.lines)
 
-	violation := result.fail(rego.metadata.chain(), result.location(part))
+	violation := result.fail(rego.metadata.chain(), result.location(term))
 }
 
 report contains violation if {

--- a/bundle/regal/util/util.rego
+++ b/bundle/regal/util/util.rego
@@ -7,11 +7,11 @@ package regal.util
 #   returns a set of sets containing all indices of duplicates in the array,
 #   so e.g. [1, 1, 2, 3, 3, 3] would return {{0, 1}, {3, 4, 5}} and so on
 find_duplicates(arr) := {indices |
-	some i, x in arr
+	some i, item in arr
 
 	indices := {j |
-		some j, y in arr
-		x == y
+		some j, other in arr
+		item == other
 	}
 
 	count(indices) > 1
@@ -19,23 +19,20 @@ find_duplicates(arr) := {indices |
 
 # METADATA
 # description: returns true if array has duplicates of item
-has_duplicates(arr, item) if count([x |
-	some x in arr
-	x == item
+has_duplicates(arr, item) if count([1 |
+	some other in arr
+	other == item
 ]) > 1
 
 # METADATA
 # description: |
 #   returns an array of arrays built from all parts of the provided path array,
 #   so e.g. [1, 2, 3] would return [[1], [1, 2], [1, 2, 3]]
-all_paths(path) := [array.slice(path, 0, len) | some len in numbers.range(1, count(path))]
+all_paths(arr) := [array.slice(arr, 0, n) | some n in numbers.range(1, count(arr))]
 
 # METADATA
 # description: attempts to turn any key in provided object into numeric form
-keys_to_numbers(obj) := {num: v |
-	some k, v in obj
-	num := to_number(k)
-}
+keys_to_numbers(obj) := {to_number(key): val | some key, val in obj}
 
 # METADATA
 # description: returns a substring cut off at stop_str, or the whole string if not found
@@ -53,12 +50,12 @@ to_location_object(loc) := {
 		"col": end_col,
 	},
 } if {
-	[r, c, er, ec] := split(loc, ":")
+	[row_str, col_str, end_row_str, end_col_str] := split(loc, ":")
 
-	row := to_number(r)
-	col := to_number(c)
-	end_row := to_number(er)
-	end_col := to_number(ec)
+	row := to_number(row_str)
+	col := to_number(col_str)
+	end_row := to_number(end_row_str)
+	end_col := to_number(end_col_str)
 
 	text := _location_to_text(row, col, end_row, end_col)
 } else := loc
@@ -67,16 +64,16 @@ to_location_object(loc) := {
 # description: convert location string to location object, without the 'text' attribute
 # scope: document
 to_location_no_text(loc) := {
-	"row": to_number(r),
-	"col": to_number(c),
+	"row": to_number(row_str),
+	"col": to_number(col_str),
 	"end": {
-		"row": to_number(er),
-		"col": to_number(ec),
+		"row": to_number(end_row_str),
+		"col": to_number(end_col_str),
 	},
 } if {
 	is_string(loc)
 
-	[r, c, er, ec] := split(loc, ":")
+	[row_str, col_str, end_row_str, end_col_str] := split(loc, ":")
 }
 
 # METADATA
@@ -95,12 +92,12 @@ _location_to_text(row, col, end_row, end_col) := text if {
 	row != end_row
 
 	lines := array.slice(input.regal.file.lines, row - 1, end_row)
-	text := concat("\n", [new |
+	text := concat("\n", [line_cut |
 		len := count(lines) - 1
 
 		some i, line in lines
 
-		new := _cut_col(i, len, line, col, end_col)
+		line_cut := _cut_col(i, len, line, col, end_col)
 	])
 }
 
@@ -125,21 +122,21 @@ _cut_col(i, len, line, _, end_col) := substring(line, 0, end_col) if {
 # scope: document
 default point_in_range(_, _) := false
 
-point_in_range(p, range) if {
-	p[0] >= range[0][0]
-	p[0] <= range[1][0]
-	p[1] >= range[0][1]
-	p[1] <= range[1][1]
+point_in_range(point, range) if {
+	point[0] >= range[0][0]
+	point[0] <= range[1][0]
+	point[1] >= range[0][1]
+	point[1] <= range[1][1]
 }
 
-point_in_range(p, range) if {
-	p[0] > range[0][0]
-	p[0] < range[1][0]
+point_in_range(point, range) if {
+	point[0] > range[0][0]
+	point[0] < range[1][0]
 }
 
 # METADATA
 # description: short-hand helper to prepare values for pretty-printing
-json_pretty(value) := json.marshal_with_options(value, {
+json_pretty(val) := json.marshal_with_options(val, {
 	"indent": "  ",
 	"pretty": true,
 })
@@ -149,27 +146,27 @@ json_pretty(value) := json.marshal_with_options(value, {
 rest(arr) := array.slice(arr, 1, count(arr))
 
 # METADATA
-# description: converts x to set if array, returns x if set
+# description: converts coll to set if array, returns coll if set
 # scope: document
-to_set(x) := x if is_set(x)
-to_set(x) := {y | some y in x} if not is_set(x)
+to_set(coll) := coll if is_set(coll)
+to_set(coll) := {item | some item in coll} if not is_set(coll)
 
 # METADATA
-# description: converts x to array if set, returns x if array
+# description: converts coll to array if set, returns coll if array
 # scope: document
-to_array(x) := x if is_array(x)
-to_array(x) := [y | some y in x] if not is_array(x)
+to_array(coll) := coll if is_array(coll)
+to_array(coll) := [item | some item in coll] if not is_array(coll)
 
 # METADATA
-# description: true if s1 and s2 has any intersecting items
-intersects(s1, s2) if intersection({s1, s2}) != set()
+# description: true if set and other has any intersecting items
+intersects(set, other) if intersection({set, other}) != set()
 
 # METADATA
 # description: returns the item contained in a single-item set
-single_set_item(s) := item if {
-	count(s) == 1
+single_set_item(set) := item if {
+	count(set) == 1
 
-	some item in s
+	some item in set
 }
 
 # @anderseknert looked into the different implementations and sort was still the fastest
@@ -179,11 +176,14 @@ single_set_item(s) := item if {
 # | sort(s)[0]            | 9,184  | 7,816 | 133       |
 # METADATA
 # description: returns any item of a set
-any_set_item(s) := sort(s)[0]
+any_set_item(set) := sort(set)[0]
 
 # METADATA
 # description: returns last index of item, or undefined (*not* -1) if missing
-last_indexof(arr, item) := regal.last([i | some i, x in arr; x == item])
+last_indexof(arr, item) := regal.last([i |
+	some i, other in arr
+	other == item
+])
 
 # METADATA
 # description: |
@@ -195,12 +195,11 @@ longest_prefix(coll) := [] if {
 } else := prefix if {
 	arr := to_array(coll)
 	end := min([count(seq) | some seq in arr]) - 1
-	rng := numbers.range(0, end)
 
 	# collect indices where items differ
 	# we only care about the first diff, but no way to exit early with that value
-	dif := [n |
-		some n in rng
+	diff := [n |
+		some n in numbers.range(0, end)
 
 		first := arr[0][n]
 
@@ -208,11 +207,11 @@ longest_prefix(coll) := [] if {
 		sub[n] != first
 	]
 
-	prefix := array.slice(arr[0], 0, _longest_dif(dif, end))
+	prefix := array.slice(arr[0], 0, _longest_diff(diff, end))
 }
 
-_longest_dif(diff, len) := len + 1 if diff == []
-_longest_dif(diff, _) := diff[0] if diff != []
+_longest_diff(diff, len) := len + 1 if diff == []
+_longest_diff(diff, _) := diff[0] if diff != []
 
 # METADATA
 # description: |
@@ -229,8 +228,8 @@ parse_bool("False") := false
 parse_bool("FALSE") := false
 
 # METADATA
-# description: creates a string where s is repeated n times
-repeat(s, n) := replace(sprintf("%-*s", [n, " "]), " ", s)
+# description: creates a string where str is repeated n times
+repeat(str, n) := replace(sprintf("%-*s", [n, " "]), " ", str)
 
 # METADATA
 # description: |

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -1,0 +1,140 @@
+# Naming Convention
+
+This document outlines the recommended naming conventions when writing Rego for Regal, custom linter rules, or really
+any Rego targeting OPA's AST or Regal's RoAST format (which is derived from the former). The purpose of these
+conventions is reducing ambiguity by sticking to a consistent set of names, which _always refer to the same thing_.
+
+Regal contributors are encouraged to follow these conventions, but **not** required to. The conventions are here to
+support us in writing more consistent Rego for the context of Regal, not act as an obstacle for contributing.
+
+## Compliance Check
+
+You can run `regal lint --enable naming-convention bundle` to check the Regal bundle for compliance against
+these naming conventions. This check is not automated, but can be run occasionally to catch and correct inconsistencies
+in naming. The list of "allowed" words can and will of course also change over time.
+
+An alternative that we **may** consider for the future is to run this check in CI configured at `warn` level. But while
+this could be a friendly nudge, it also risks to clutter our build logs with messages that are mostly of the "notice"
+kind.
+
+## Rules and Functions
+
+- Use an underscore prefix for any rule that is internal to a package (e.g., `_count_vars`).
+
+## Variables
+
+- We commonly use three letter abbreviations for variable names related to Rego and AST types, such as `val`, `num`,
+  or `ref`. The plural form of such identifiers is naturally the name + `s`, e.g. `vals`, `nums`, `refs`.
+- Four letter words, like `rule`, `body`, `term`, `...`, are never abbreviated.
+  Consistently sticking to this convention makes for concise but easily readable code, that aligns nicely.
+- Use `<name>` + `other` for comparisons and equality checks.
+- Use `i`, `j`, `k`, `...` for indices.
+- Use `n` for counts, or lengths.
+- `_` may be used as a prefix for local variables when (and only when) a name shadows or otherwise conflicts with
+  another identifier in the same scope, and there's no better name to use.
+- Three or four letter variable names should not be used for anything but known names and types.
+- Longer variable names are allowed to describe shapes and state outside of the Rego / AST domai.
+
+### Longer Variable Names
+
+- Use longer and more descriptive names (with words separated by underscores) whenever the "default" names are
+  insufficient. All names of length 5 and above are excepted from our naming convention policy, but should still be
+  carefully chosen.
+- When using longer variable names, it is often preferable to use full words instead of abbreviations, e.g.
+  `empty_arrays` over `empty_arrs`.
+- When using longer variable names, try to see if any existing name describes the same thing, and if so, use that.
+
+Future versions of this document may include commonly used longer variable names.
+
+### AST Nodes
+
+The following names should be used consistently across Regal for variables representing AST nodes of the given type.
+
+- `node` - The "any" type for AST elements whose type is not specified or known at the place of use.
+- `pkg` - An argument or variable representing a package node.
+- `imp` - An argument or variable representing an import node.
+- `rule` - An argument or variable representing a rule node.
+- `ref` - An argument or variable representing a ref node.
+- `fun` - An argument or variable representing a function node.
+- `head` - An argument or variable representing a rule head node, or occasionally the head of a ref.
+- `body` - An argument or variable representing a body node.
+- `expr` - An argument or variable representing an expression.
+- `args` - The array of terms representing the arguments of a function.
+- `arg` - A function argument term. May also be referenced as `term` when that is more appropriate to the context.
+- `term` - An argument or variable representing a term node.
+- `terms` - An array of terms, as found in for example the `value` of a `ref`.
+
+### JSON Types
+
+- `str` - String
+- `num` - Number
+- `arr` - Array
+- `obj` - Object (where `key`/ `val` are used for object keys and values).
+- `set` - Set
+
+(Boolean values and null are almost never stored in variables.)
+
+### AST Types
+
+- `term` - Term
+- `rule` - Rule
+- `body` - Body
+- `call` - Call
+- `comp` - Comprehension
+- `ref` - Ref
+- `set` - Set
+
+### Collections
+
+- `coll` - A variable representing any collection type. Prefer `arr`, `obj`, or `set` when the type is known.
+- `seq` - Use to represent values that either arrays or sets.
+
+### Location and Position
+
+- `rows` - An array of rows (line numbers).
+- `cols` - An array of columns.
+- `text` - The source code text corresponding to a location.
+- `line` - The text of a single line of source code.
+- `loc` - A location string or object.
+- `row` - The row number of a location.
+- `col` - The column number of a location.
+- `end` - The end position of a location.
+
+### Regal-specific
+
+- `cfg` - A variable representing a Regal configuration object.
+- `aggs` - A collection of aggregates
+- `agg` - An aggregated item
+
+### Language Server
+
+- `file` - A variable representing a file path.
+- `word` - A variable representing a word, such as a variable name, function name, etc.
+- `url` - A variable representing a URL.
+- `uri` - A variable representing a URI.
+- `dir` - A variable representing a directory path.
+
+### Various
+
+- `other` - A variable representing the other item in a comparison or equality check.
+- `start` - The start of something.
+- `name` - The name of something, such as a rule or variable.
+- `link` - A variable representing a link, such as a URL or URI.
+- `path` - A variable representing a file or URI path.
+- `kind` - The kind of something, such as a rule vs. a type.
+- `rest` - The rest of something, such as the remaining terms in a ref after the head.
+- `last` - The last item in a collection.
+- `next` - The next item in a collection.
+- `diff` - A variable representing the difference between two items.
+- `len` - The length of something.
+- `pos` - A position, such as a cursor position.
+- `sub` - A subset.
+- `sup` - A superset.
+- `lhs` - The left-hand side of a rule or expression.
+- `rhs` - The right-hand side of a rule or expression.
+
+## Avoid
+
+- `parts`/`part` — When referring to terms in types like `ref`s or `array`s. Should most often be replaced by
+  `terms`, `args`, or whatever is more specific.
+- `item` — For anything but array or set items of unspecified type.

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -200,8 +200,8 @@ func TestLintRuleNamingConventionFromCustomCategory(t *testing.T) {
 	testutil.AssertNumViolations(t, 2, rep)
 
 	expectedViolations := []string{
-		`Naming convention violation: package name "custom_naming_convention" does not match pattern '^acmecorp\.[a-z_\.]+$'`,
-		`Naming convention violation: rule name "naming_convention_fail" does not match pattern '^_[a-z_]+$|^allow$'`,
+		`Naming violation: package name "custom_naming_convention" does not match configured convention`,
+		`Naming violation: rule name "naming_convention_fail" does not match configured convention`,
 	}
 
 	for _, violation := range rep.Violations {


### PR DESCRIPTION
While the title of this PR is what we'll want in the release notes, this is 95% an internal change meant to improve Regal for ourselves. That a custom rule got better is mostly a happy coincidence :)

Since we started working on Regal, we have learnt a lot about both OPA, the AST and of course our own domains — static analysis, linting and language servers. The terminology used in the project has grown organically along with that, and with time we've found a shared vocabulary for the project. There's however been no lack of code written before we knew better, and as this PR highlights, there have been many places where names have been picked rather arbitrarily.

Additionally, the lack of a documented vocabulary meant it wasn't accessible outside of our own internal know-how. This change aims to fix that by:

1. Documenting the terminlogy and vocabulary of Regal and our domain
2. Provide the means to help check how well we follow our stated naming conventions
3. Update our Rego code to comply with these naming conventions

While having this goes a long way to unify our terminology, there are things that won't be caught by a simple "allow list" like this. As an example, our use of the name `ref` sometimes mean the "outer" type (the ref term), and sometimes it refers to only the the term slice of the ref (which should rather be called `terms`). That's out of scope for this PR, but could be something to look into later.

As noted in the change, we will not enforce anything related to naming conventions, but occasionally check this and make fixes accordingly (and without ever getting in the way of anyone contributing to the project).

Fixes #1493