### PR TITLE
[feature] Add Popup Prompt for Creating input.json If Not Present When Evaluate is Run

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -165,6 +165,9 @@ type LanguageServer struct {
 
 	workspaceRootURI         string
 	workspaceDiagnosticsPoll time.Duration
+
+	// Flag used to suppress input.json prompt if user chooses to ignore it
+	supressInputPrompt bool
 }
 
 // lintFileJob is sent to the lintFileJobs channel to trigger a
@@ -2582,6 +2585,8 @@ func (l *LanguageServer) handleEvalCommand(ctx context.Context, args types.Comma
 
 	var inputMap map[string]any
 
+	var inputPath string
+
 	// When the first comment in the file is `regal eval: use-as-input`, the AST of that module is
 	// used as the input rather than the contents of input.json/yaml. This is a development feature for
 	// working on rules (built-in or custom), allowing querying the AST of the module directly.
@@ -2597,7 +2602,33 @@ func (l *LanguageServer) handleEvalCommand(ctx context.Context, args types.Comma
 		// Normal mode — try to find the input.json/yaml file in the workspace and use as input
 		// NOTE that we don't break on missing input, as some rules don't depend on that, and should
 		// still be evaluable. We may consider returning some notice to the user though.
-		_, inputMap = rio.FindInput(uri.ToPath(args.Target), l.workspacePath())
+		inputPath, inputMap = rio.FindInput(uri.ToPath(args.Target), l.workspacePath())
+		if inputPath == "" && !l.supressInputPrompt {
+			var action types.MessageActionItem
+
+			reqParams := types.ShowMessageRequestParams{
+				Type: 3, // info
+				Message: "No input.json/yaml file was found. " +
+					"This file is used to provide input data to your rules. " +
+					"Would you like to create one?",
+				Actions: []types.MessageActionItem{
+					{Title: "Yes"},
+					{Title: "No"},
+					{Title: "Ignore"},
+				},
+			}
+
+			if err = l.conn.Call(ctx, "window/showMessageRequest", reqParams, &action); err != nil {
+				l.log.Message("window/showMessageRequest failed: %v", err)
+			} else if action.Title == "Yes" {
+				inputFile := filepath.Join(l.workspacePath(), "input.json")
+				if err = os.WriteFile(inputFile, []byte("{}\n"), 0o600); err != nil {
+					l.log.Message("failed to create input.json: %v", err)
+				}
+			} else if action.Title == "Ignore" {
+				l.supressInputPrompt = true
+			}
+		}
 	}
 
 	var result EvalResult

--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -631,5 +631,15 @@ type (
 		Success bool `json:"success"`
 	}
 
+	MessageActionItem struct {
+		Title string `json:"title"`
+	}
+
+	ShowMessageRequestParams struct {
+		Type    uint                `json:"type"`
+		Message string              `json:"message"`
+		Actions []MessageActionItem `json:"actions"`
+	}
+
 	iuint interface{ ~int | ~uint }
 )


### PR DESCRIPTION
Uses lsp capability to provide a popup prompt to the user when they run evaluate from the IDE with no input.json present. The user can close the prompt, ignore it for as long as the language server runs, or have an empty input.json file created automatically. 

<img width="1030" height="398" alt="image" src="https://github.com/user-attachments/assets/58eb8e6b-e861-4ade-a580-adaa75c3b22b" />


A follow up PR is in progress containing testing and generation of an input.json skeleton based on what fields from the input are used!

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->