### PR TITLE
[feature] Create input.json Skeleton if User Would Like When One Doesn't Exist

### DIFF
--- a/internal/lsp/eval.go
+++ b/internal/lsp/eval.go
@@ -204,24 +204,6 @@ func (h PrintHook) Print(ctx print.Context, msg string) error {
 	return nil
 }
 
-func ruleHasInputRefs(rule *ast.Rule) bool {
-	if rule == nil {
-		return false
-	}
-
-	found := false
-
-	ast.WalkRefs(rule, func(ref ast.Ref) bool {
-		if len(ref) >= 2 && ref[0].Equal(ast.InputRootDocument) {
-			found = true
-		}
-
-		return found
-	})
-
-	return found
-}
-
 func inputSkeletonFromRule(rule *ast.Rule, compiler *ast.Compiler) map[string]any {
 	root := map[string]any{}
 

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -2543,6 +2543,101 @@ func (l *LanguageServer) handleExplorerCommand(ctx context.Context, params types
 	return nil
 }
 
+func (l *LanguageServer) handleInputSkeletonPrompt(
+	ctx context.Context,
+	target, ruleName string,
+	row int,
+) (bool, error) {
+	compiler := compile.NewCompilerWithRegalBuiltins()
+	compiler.Compile(l.cache.GetAllModules())
+
+	if compiler.Failed() {
+		l.log.Message("failed to compile workspace modules for input skeleton: %v", compiler.Errors)
+	}
+
+	// Using the compiled modules to parse the rules. The dependencies package used in inputSkeletonFromRule
+	// relies on compiled modules to resolve transitive dependencies.
+	var compiledRule *ast.Rule
+
+	if compiledModule, ok := compiler.Modules[target]; ok {
+		for _, rule := range compiledModule.Rules {
+			if rule.Head.Name.String() == ruleName && rule.Location.Row == row {
+				compiledRule = rule
+
+				break
+			}
+		}
+	}
+
+	if compiledRule == nil {
+		return false, nil
+	}
+
+	skeleton := inputSkeletonFromRule(compiledRule, compiler)
+	if len(skeleton) == 0 {
+		return false, nil
+	}
+
+	var action types.MessageActionItem
+
+	showMsgCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	if err := l.conn.Call(showMsgCtx, "window/showMessageRequest", types.ShowMessageRequestParams{
+		Type: 3, // info
+		Message: "No input.json/yaml file was found. " +
+			"This file is used to provide input data for rule evaluation. " +
+			"Would you like to create one?",
+		Actions: []types.MessageActionItem{
+			{Title: "Yes"},
+			{Title: "No"},
+			{Title: "Ignore"},
+		},
+	}, &action); err != nil {
+		return false, fmt.Errorf("window/showMessageRequest failed: %w", err)
+	}
+
+	switch action.Title {
+	case "Yes":
+		data, err := json.MarshalIndent(skeleton, "", "  ")
+		if err != nil {
+			return false, fmt.Errorf("failed to marshal input skeleton: %w", err)
+		}
+
+		inputFile := filepath.Join(l.workspacePath(), "input.json")
+		if err = os.WriteFile(inputFile, append(data, '\n'), 0o600); err != nil {
+			return false, fmt.Errorf("failed to create input.json: %w", err)
+		}
+
+		var openAction types.MessageActionItem
+		if err = l.conn.Call(ctx, "window/showMessageRequest", types.ShowMessageRequestParams{
+			Type:    3,
+			Message: "input.json created successfully! Running Evaluate will now pull from this file.",
+			Actions: []types.MessageActionItem{{Title: "Open"}},
+		}, &openAction); err != nil {
+			return true, fmt.Errorf("window/showMessageRequest failed: %w", err)
+		}
+
+		if openAction.Title == "Open" {
+			takeFocus := false
+
+			var showResult types.ShowDocumentResult
+			if err = l.conn.Call(ctx, "window/showDocument", types.ShowDocumentParams{
+				URI:       uri.FromPath(l.client.Identifier, inputFile),
+				TakeFocus: &takeFocus,
+			}, &showResult); err != nil {
+				l.log.Message("window/showDocument failed: %v", err)
+			}
+		}
+
+		return true, nil
+	case "Ignore":
+		l.supressInputPrompt = true
+	}
+
+	return false, nil
+}
+
 func (l *LanguageServer) handleEvalCommand(ctx context.Context, args types.CommandArgs) error {
 	if args.Target == "" || args.Query == "" {
 		l.log.Message("expected command target and query, got target %q, query %q", args.Target, args.Query)
@@ -2603,53 +2698,15 @@ func (l *LanguageServer) handleEvalCommand(ctx context.Context, args types.Comma
 
 		ruleName := strings.TrimPrefix(args.Query, module.Package.Path.String()+".")
 
-		var matchedRule *ast.Rule
-
-		for _, rule := range module.Rules {
-			if rule.Head.Name.String() == ruleName && rule.Location.Row == args.Row {
-				matchedRule = rule
-
-				break
-			}
-		}
-
-		if inputPath == "" && !l.supressInputPrompt && ruleHasInputRefs(matchedRule) {
-			var action types.MessageActionItem
-
-			reqParams := types.ShowMessageRequestParams{
-				Type: 3, // info
-				Message: "No input.json/yaml file was found. " +
-					"This file is used to provide input data for rule evaluation. " +
-					"Would you like to create one?",
-				Actions: []types.MessageActionItem{
-					{Title: "Yes"},
-					{Title: "No"},
-					{Title: "Ignore"},
-				},
+		if inputPath == "" && !l.supressInputPrompt {
+			created, err := l.handleInputSkeletonPrompt(ctx, args.Target, ruleName, args.Row)
+			// Bubbling up an error here if input.json creation fails for any reason.
+			if err != nil {
+				return err
 			}
 
-			showMsgCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-			defer cancel()
-
-			if err = l.conn.Call(showMsgCtx, "window/showMessageRequest", reqParams, &action); err != nil {
-				l.log.Message("window/showMessageRequest failed: %v", err)
-			} else if action.Title == "Yes" {
-				compiler := compile.NewCompilerWithRegalBuiltins()
-				compiler.Compile(l.cache.GetAllModules())
-
-				skeleton := inputSkeletonFromRule(matchedRule, compiler)
-
-				data, merr := json.MarshalIndent(skeleton, "", "  ")
-				if merr != nil {
-					l.log.Message("failed to marshal input skeleton: %v", merr)
-				} else {
-					inputFile := filepath.Join(l.workspacePath(), "input.json")
-					if err = os.WriteFile(inputFile, append(data, '\n'), 0o600); err != nil {
-						l.log.Message("failed to create input.json: %v", err)
-					}
-				}
-			} else if action.Title == "Ignore" {
-				l.supressInputPrompt = true
+			if created {
+				return nil
 			}
 		}
 	}

--- a/internal/lsp/server_command_test.go
+++ b/internal/lsp/server_command_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -248,12 +249,27 @@ func TestExecuteCommandEvalCreatesInputJSON(t *testing.T) {
 	defer cancel()
 
 	inputJSONCreated := make(chan struct{}, 1)
+	showDocumentReceived := make(chan struct{}, 1)
 
 	clientHandler := func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (any, error) {
-		if req.Method == "window/showMessageRequest" {
-			inputJSONCreated <- struct{}{}
+		switch req.Method {
+		case "window/showMessageRequest":
+			params := must.Return(encoding.JSONUnmarshalTo[types.ShowMessageRequestParams](*req.Params))(t)
 
-			return types.MessageActionItem{Title: "Yes"}, nil
+			if strings.Contains(params.Message, "No input.json/yaml file was found.") {
+				// The initial file creation prompt
+				inputJSONCreated <- struct{}{}
+
+				return types.MessageActionItem{Title: "Yes"}, nil
+			} else if strings.Contains(params.Message, "created successfully") {
+				// The success notification and prompt to open the file
+				return types.MessageActionItem{Title: "Open"}, nil
+			}
+
+		case "window/showDocument":
+			showDocumentReceived <- struct{}{}
+
+			return types.ShowDocumentResult{Success: true}, nil
 		}
 
 		return struct{}{}, nil
@@ -272,6 +288,7 @@ allow if {
 	input.foo.wee.age == 24
 	input.superfoo.wee == "fun"
 	input.superbar.tee == "run"
+	input.list[0].name == "test"
 }
 `
 
@@ -308,6 +325,11 @@ allow if {
       "age": "changeme"
     }
   },
+  "list": {
+    "0": {
+      "name": "changeme"
+    }
+  },
   "superbar": {
     "tee": "changeme"
   },
@@ -329,5 +351,12 @@ allow if {
 		}
 	case <-timeout.C:
 		t.Fatal("timed out waiting for window/showMessageRequest")
+	}
+
+	// Verify the success notification triggered window/showDocument.
+	select {
+	case <-showDocumentReceived:
+	case <-timeout.C:
+		t.Fatal("timed out waiting for window/showDocument")
 	}
 }


### PR DESCRIPTION
Recent PR #1929  introduced a prompt to the user that allowed them create an empty input.json file if one didn't exist. This PR creates a proper input.json file based on its references.

Also adds a fix to stop the command worker thread from being blocked if the user doesn't respond to the prompt, and testing for the creation of the input file.

Addresses the [following issue](https://github.com/open-policy-agent/vscode-opa/issues/425) that was raised in [vscode-opa](https://github.com/open-policy-agent/vscode-opa)

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->