### PR TITLE
Include rule docs links in metadata

### DIFF
--- a/bundle/regal/ast/keywords_test.rego
+++ b/bundle/regal/ast/keywords_test.rego
@@ -121,13 +121,19 @@ test_keywords_some_no_body if {
 	_keyword_on_row(
 		kwds,
 		6,
-		{"name": "some", "location": {"row": 6, "col": 2, "end": {"col": 6, "row": 6}, "text": "some"}},
+		{
+			"name": "some",
+			"location": {"row": 6, "col": 2, "end": {"col": 6, "row": 6}, "text": "some"},
+		},
 	)
 
 	_keyword_on_row(
 		kwds,
 		6,
-		{"name": "in", "location": {"row": 6, "col": 9, "end": {"col": 11, "row": 6}, "text": "in"}},
+		{
+			"name": "in",
+			"location": {"row": 6, "col": 9, "end": {"col": 11, "row": 6}, "text": "in"},
+		},
 	)
 }
 

--- a/bundle/regal/lsp/codeaction/codeaction_test.rego
+++ b/bundle/regal/lsp/codeaction/codeaction_test.rego
@@ -225,7 +225,16 @@ test_code_actions_empty_only_means_all if {
 _diagnostics["opa-fmt"] := {
 	"code": "opa-fmt",
 	"message": "Use opa fmt to format this file",
-	"range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}},
+	"range": {
+		"start": {
+			"line": 0,
+			"character": 0,
+		},
+		"end": {
+			"line": 0,
+			"character": 1,
+		},
+	},
 }
 
 # Silly object.union only to appease the type checker, who for some reason thinks that
@@ -236,7 +245,16 @@ _diagnostics["use-assignment-operator"] := object.union(
 	{
 		"code": "use-assignment-operator",
 		"message": "Use := instead of = for assignment",
-		"range": {"start": {"line": 2, "character": 0}, "end": {"line": 2, "character": 1}},
+		"range": {
+			"start": {
+				"line": 2,
+				"character": 0,
+			},
+			"end": {
+				"line": 2,
+				"character": 1,
+			},
+		},
 		"codeDescription": {"href": "https://www.openpolicyagent.org/projects/regal/rules/style/use-assignment-operator"},
 	},
 	{},

--- a/bundle/regal/lsp/completion/providers/default/default_test.rego
+++ b/bundle/regal/lsp/completion/providers/default/default_test.rego
@@ -21,8 +21,14 @@ import rego.v1
 		"textEdit": {
 			"newText": "default ",
 			"range": {
-				"start": {"character": 0, "line": 4},
-				"end": {"character": 1, "line": 4},
+				"start": {
+					"character": 0,
+					"line": 4,
+				},
+				"end": {
+					"character": 1,
+					"line": 4,
+				},
 			},
 		},
 	}}

--- a/bundle/regal/lsp/completion/providers/packagename/packagename_test.rego
+++ b/bundle/regal/lsp/completion/providers/packagename/packagename_test.rego
@@ -29,8 +29,14 @@ test_package_name_completion_on_typing if {
 		"textEdit": {
 			"newText": "foo.bar.baz\n\n",
 			"range": {
-				"end": {"character": 9, "line": 0},
-				"start": {"character": 8, "line": 0},
+				"end": {
+					"character": 9,
+					"line": 0,
+				},
+				"start": {
+					"character": 8,
+					"line": 0,
+				},
 			},
 		},
 	}}

--- a/bundle/regal/lsp/completion/providers/ruleheadkeyword/ruleheadkeyword_test.rego
+++ b/bundle/regal/lsp/completion/providers/ruleheadkeyword/ruleheadkeyword_test.rego
@@ -17,8 +17,14 @@ test_keyword_completion_after_rule_name_no_prefix[label] if {
 	expected := object.union(completion, {"textEdit": {
 		"newText": $"{label} ",
 		"range": {
-			"start": {"line": 2, "character": 5},
-			"end": {"line": 2, "character": 5},
+			"start": {
+				"line": 2,
+				"character": 5,
+			},
+			"end": {
+				"line": 2,
+				"character": 5,
+			},
 		},
 	}})
 

--- a/bundle/regal/lsp/documenthighlight/documenthighlight.rego
+++ b/bundle/regal/lsp/documenthighlight/documenthighlight.rego
@@ -71,8 +71,14 @@ items contains item if {
 
 	item := {
 		"range": {
-			"start": {"line": input.params.position.line, "character": 2},
-			"end": {"line": input.params.position.line, "character": 10},
+			"start": {
+				"line": input.params.position.line,
+				"character": 2,
+			},
+			"end": {
+				"line": input.params.position.line,
+				"character": 10,
+			},
 		},
 		"kind": 1,
 	}
@@ -96,8 +102,14 @@ items contains item if {
 
 	item := {
 		"range": {
-			"start": {"line": i, "character": 2},
-			"end": {"line": i, "character": 2 + count(word)},
+			"start": {
+				"line": i,
+				"character": 2,
+			},
+			"end": {
+				"line": i,
+				"character": 2 + count(word),
+			},
 		},
 		"kind": 1,
 	}
@@ -110,8 +122,14 @@ items contains item if {
 	word := _attribute_from_text(input.regal.file.lines[line])
 	item := {
 		"range": {
-			"start": {"line": line, "character": 2},
-			"end": {"line": line, "character": 2 + count(word)},
+			"start": {
+				"line": line,
+				"character": 2,
+			},
+			"end": {
+				"line": line,
+				"character": 2 + count(word),
+			},
 		},
 		"kind": 1,
 	}

--- a/bundle/regal/lsp/documentlink/documentlink.rego
+++ b/bundle/regal/lsp/documentlink/documentlink.rego
@@ -27,23 +27,28 @@ items contains item if {
 	module := data.workspace.parsed[input.params.textDocument.uri]
 
 	some encoded in module.comments
-	comment := object.union(encoded, {"text": base64.decode(encoded.text)})
-	contains(comment.text, "regal ignore:")
 
-	loc := util.to_location_no_text(comment.location)
-	rules := regex.split(`,\s*`, trim_space(regex.replace(comment.text, `^.*regal ignore:\s*(\S+)`, "$1")))
+	text := base64.decode(encoded.text)
+	contains(text, "regal ignore:")
 
-	some rule in rules
-
-	pos := indexof(comment.text, rule)
+	loc := util.to_location_no_text(encoded.location)
 	row := loc.row - 1
-	col := loc.col + pos
+
+	some rule in regex.split(`,\s*`, trim_space(regex.replace(text, `^.*regal ignore:\s*(\S+)`, "$1")))
+
+	col := loc.col + indexof(text, rule)
 
 	item := {
 		"target": $"https://www.openpolicyagent.org/projects/regal/rules/{_category_for[rule]}/{rule}",
 		"range": {
-			"start": {"line": row, "character": col},
-			"end": {"line": row, "character": col + count(rule)},
+			"start": {
+				"line": row,
+				"character": col,
+			},
+			"end": {
+				"line": row,
+				"character": col + count(rule),
+			},
 		},
 		"tooltip": $"See documentation for {rule}",
 	}

--- a/bundle/regal/lsp/linkededitingrange/linkededitingrange_test.rego
+++ b/bundle/regal/lsp/linkededitingrange/linkededitingrange_test.rego
@@ -17,13 +17,25 @@ foo(bar, baz) := baz if {
 	expected_ranges := {
 		# function arg 'bar' in function head
 		{
-			"start": {"line": 2, "character": 4},
-			"end": {"line": 2, "character": 7},
+			"start": {
+				"line": 2,
+				"character": 4,
+			},
+			"end": {
+				"line": 2,
+				"character": 7,
+			},
 		},
 		# function arg 'bar' reference in function body
 		{
-			"start": {"line": 3, "character": 4},
-			"end": {"line": 3, "character": 7},
+			"start": {
+				"line": 3,
+				"character": 4,
+			},
+			"end": {
+				"line": 3,
+				"character": 7,
+			},
 		},
 	}
 
@@ -61,13 +73,25 @@ foo(bar, baz) := baz if {
 	expected_ranges := {
 		# function arg 'bar' in function head
 		{
-			"start": {"line": 2, "character": 4},
-			"end": {"line": 2, "character": 7},
+			"start": {
+				"line": 2,
+				"character": 4,
+			},
+			"end": {
+				"line": 2,
+				"character": 7,
+			},
 		},
 		# function arg 'bar' reference in function body
 		{
-			"start": {"line": 3, "character": 4},
-			"end": {"line": 3, "character": 7},
+			"start": {
+				"line": 3,
+				"character": 4,
+			},
+			"end": {
+				"line": 3,
+				"character": 7,
+			},
 		},
 	}
 

--- a/bundle/regal/lsp/testlocations/testlocations_test.rego
+++ b/bundle/regal/lsp/testlocations/testlocations_test.rego
@@ -89,7 +89,10 @@ test_foo if true
 		"location": {
 			"col": 1,
 			"row": 3,
-			"end": {"col": 9, "row": 3},
+			"end": {
+				"col": 9,
+				"row": 3,
+			},
 			"file": "file:///foo/foo.rego",
 			"text": "test_foo if true",
 		},

--- a/bundle/regal/lsp/util/range/range_test.rego
+++ b/bundle/regal/lsp/util/range/range_test.rego
@@ -37,8 +37,14 @@ test_parse if range.parse("1:5:2:10") == {
 
 test_range_contains_position_on_same_line if {
 	rng := {
-		"start": {"line": 3, "character": 6},
-		"end": {"line": 3, "character": 10},
+		"start": {
+			"line": 3,
+			"character": 6,
+		},
+		"end": {
+			"line": 3,
+			"character": 10,
+		},
 	}
 
 	range.contains_position(rng, {"line": 3, "character": 7})
@@ -46,8 +52,14 @@ test_range_contains_position_on_same_line if {
 
 test_range_contains_position_multiple_lines if {
 	rng := {
-		"start": {"line": 3, "character": 6},
-		"end": {"line": 5, "character": 20},
+		"start": {
+			"line": 3,
+			"character": 6,
+		},
+		"end": {
+			"line": 5,
+			"character": 20,
+		},
 	}
 
 	range.contains_position(rng, {"line": 4, "character": 0})
@@ -55,8 +67,14 @@ test_range_contains_position_multiple_lines if {
 
 test_range_contains_position_last_line if {
 	rng := {
-		"start": {"line": 3, "character": 6},
-		"end": {"line": 5, "character": 20},
+		"start": {
+			"line": 3,
+			"character": 6,
+		},
+		"end": {
+			"line": 5,
+			"character": 20,
+		},
 	}
 
 	range.contains_position(rng, {"line": 5, "character": 15})

--- a/bundle/regal/result/result.rego
+++ b/bundle/regal/result/result.rego
@@ -115,11 +115,11 @@ _related_resources(annotations, category, title) := arr if {
 
 	arr := [{
 		"description": "documentation",
-		"ref": $"{config.docs.base_url}/{category}/{title}",
+		"ref": $"https://www.openpolicyagent.org/projects/regal/rules/{category}/{title}",
 	}]
 }
 
-_fail_annotated(metadata, details) := violation if {
+_fail_annotated(metadata, details) := without_custom_and_scope if {
 	is_object(metadata)
 
 	with_location := object.union(metadata, details)
@@ -130,12 +130,6 @@ _fail_annotated(metadata, details) := violation if {
 	})
 
 	without_custom_and_scope := object.remove(with_category, ["custom", "scope", "schemas"])
-	related_resources := _resource_urls(without_custom_and_scope.related_resources, category)
-
-	violation := json.patch(
-		without_custom_and_scope,
-		[{"op": "replace", "path": "/related_resources", "value": related_resources}],
-	)
 }
 
 _fail_annotated_custom(metadata, details) := violation if {
@@ -150,11 +144,6 @@ _fail_annotated_custom(metadata, details) := violation if {
 
 	violation := object.remove(with_category, ["custom", "scope", "schemas"])
 }
-
-_resource_urls(related_resources, category) := [obj |
-	some item in related_resources
-	obj := object.union(item, {"ref": config.docs.resolve_url(item.ref, category)})
-]
 
 # Note that the `text` attribute always returns the entire line and *not*
 # based on the location range. This is intentional, as the context is often

--- a/bundle/regal/result/result_test.rego
+++ b/bundle/regal/result/result_test.rego
@@ -1,6 +1,5 @@
 package regal.result_test
 
-import data.regal.config
 import data.regal.result
 
 test_no_related_resources_in_result_fail_on_custom_rule_unless_provided if {
@@ -75,7 +74,7 @@ test_related_resources_generated_by_result_fail_for_builtin_rule if {
 		"level": "error",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/name", "category"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/category/name",
 		}],
 		"title": "name",
 	}

--- a/bundle/regal/rules/bugs/annotation-without-metadata/annotation_without_metadata.rego
+++ b/bundle/regal/rules/bugs/annotation-without-metadata/annotation_without_metadata.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Annotation without metadata
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/annotation-without-metadata
 package regal.rules.bugs["annotation-without-metadata"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/annotation-without-metadata/annotation_without_metadata_test.rego
+++ b/bundle/regal/rules/bugs/annotation-without-metadata/annotation_without_metadata_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.bugs["annotation-without-metadata_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.bugs["annotation-without-metadata"] as rule
 
@@ -27,7 +26,7 @@ allow := false
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/annotation-without-metadata", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/annotation-without-metadata",
 		}],
 		"title": "annotation-without-metadata",
 	}}

--- a/bundle/regal/rules/bugs/argument-always-wildcard/argument_always_wildcard.rego
+++ b/bundle/regal/rules/bugs/argument-always-wildcard/argument_always_wildcard.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Argument is always a wildcard
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/argument-always-wildcard
 package regal.rules.bugs["argument-always-wildcard"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/argument-always-wildcard/argument_always_wildcard_test.rego
+++ b/bundle/regal/rules/bugs/argument-always-wildcard/argument_always_wildcard_test.rego
@@ -17,7 +17,7 @@ test_fail[name] if {
 		"location": object.union({"file": "policy.rego"}, case.location),
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/argument-always-wildcard", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/argument-always-wildcard",
 		}],
 		"title": "argument-always-wildcard",
 	}}
@@ -25,22 +25,54 @@ test_fail[name] if {
 
 cases["single function single argument always a wildcard"] := {
 	"policy": "f(_) := 1",
-	"location": {"col": 3, "end": {"col": 4, "row": 3}, "row": 3, "text": "f(_) := 1"},
+	"location": {
+		"col": 3,
+		"end": {
+			"col": 4,
+			"row": 3,
+		},
+		"row": 3,
+		"text": "f(_) := 1",
+	},
 }
 
 cases["single argument always a wildcard"] := {
 	"policy": "f(_) := 1\nf(_) := 2",
-	"location": {"col": 3, "end": {"col": 4, "row": 3}, "row": 3, "text": "f(_) := 1"},
+	"location": {
+		"col": 3,
+		"end": {
+			"col": 4,
+			"row": 3,
+		},
+		"row": 3,
+		"text": "f(_) := 1",
+	},
 }
 
 cases["single argument always a wildcard default function"] := {
 	"policy": "default f(_) := 1\nf(_) := 2",
-	"location": {"col": 11, "end": {"col": 12, "row": 3}, "row": 3, "text": "default f(_) := 1"},
+	"location": {
+		"col": 11,
+		"end": {
+			"col": 12,
+			"row": 3,
+		},
+		"row": 3,
+		"text": "default f(_) := 1",
+	},
 }
 
 cases["multiple argument always a wildcard"] := {
 	"policy": "f(x, _) := x + 1\nf(x, _) := x + 2",
-	"location": {"col": 6, "end": {"col": 7, "row": 3}, "row": 3, "text": "f(x, _) := x + 1"},
+	"location": {
+		"col": 6,
+		"end": {
+			"col": 7,
+			"row": 3,
+		},
+		"row": 3,
+		"text": "f(x, _) := x + 1",
+	},
 }
 
 test_success_single_function_single_argument_always_a_wildcard_except_function_name if {

--- a/bundle/regal/rules/bugs/constant-condition/constant_condition.rego
+++ b/bundle/regal/rules/bugs/constant-condition/constant_condition.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Constant condition
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/constant-condition
 package regal.rules.bugs["constant-condition"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/constant-condition/constant_condition_test.rego
+++ b/bundle/regal/rules/bugs/constant-condition/constant_condition_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.bugs["constant-condition_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.bugs["constant-condition"] as rule
 
@@ -24,7 +23,7 @@ test_fail_simple_constant_condition if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/constant-condition", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/constant-condition",
 		}],
 		"title": "constant-condition",
 		"level": "error",
@@ -49,7 +48,7 @@ test_fail_if_template_string_constant_condition if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/constant-condition", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/constant-condition",
 		}],
 		"title": "constant-condition",
 		"level": "error",
@@ -84,7 +83,7 @@ test_fail_simple_constant_condition_nested if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/constant-condition", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/constant-condition",
 		}],
 		"title": "constant-condition",
 		"level": "error",
@@ -105,12 +104,15 @@ test_fail_rule_with_body_looking_generated if {
 			"file": "policy.rego",
 			"col": 12,
 			"row": 3,
-			"end": {"row": 3, "col": 16},
+			"end": {
+				"row": 3,
+				"col": 16,
+			},
 			"text": "allow if { true }",
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/constant-condition", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/constant-condition",
 		}],
 		"title": "constant-condition",
 		"level": "error",
@@ -136,7 +138,7 @@ test_fail_operator_constant_condition if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/constant-condition", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/constant-condition",
 		}],
 		"title": "constant-condition",
 		"level": "error",
@@ -165,7 +167,7 @@ test_fail_operator_constant_condition_nested if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/constant-condition", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/constant-condition",
 		}],
 		"title": "constant-condition",
 		"level": "error",

--- a/bundle/regal/rules/bugs/deprecated-builtin/deprecated_builtin.rego
+++ b/bundle/regal/rules/bugs/deprecated-builtin/deprecated_builtin.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Avoid using deprecated built-in functions
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/deprecated-builtin
 package regal.rules.bugs["deprecated-builtin"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/deprecated-builtin/deprecated_builtin_test.rego
+++ b/bundle/regal/rules/bugs/deprecated-builtin/deprecated_builtin_test.rego
@@ -22,11 +22,14 @@ test_fail_call_to_deprecated_builtin_function if {
 			"file": "policy.rego",
 			"row": 7,
 			"text": "\t\tany([true, false])",
-			"end": {"col": 6, "row": 7},
+			"end": {
+				"col": 6,
+				"row": 7,
+			},
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/deprecated-builtin", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/deprecated-builtin",
 		}],
 		"title": "deprecated-builtin",
 	}}

--- a/bundle/regal/rules/bugs/duplicate-rule/duplicate_rule.rego
+++ b/bundle/regal/rules/bugs/duplicate-rule/duplicate_rule.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Duplicate rule
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/duplicate-rule
 package regal.rules.bugs["duplicate-rule"]
 
 import data.regal.result

--- a/bundle/regal/rules/bugs/duplicate-rule/duplicate_rule_test.rego
+++ b/bundle/regal/rules/bugs/duplicate-rule/duplicate_rule_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.bugs["duplicate-rule_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.bugs["duplicate-rule"] as rule
 
@@ -26,11 +25,14 @@ test_fail_simple_duplicate_rule if {
 			"file": "policy.rego",
 			"row": 6,
 			"text": "\tallow if {",
-			"end": {"col": 3, "row": 8},
+			"end": {
+				"col": 3,
+				"row": 8,
+			},
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/duplicate-rule", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/duplicate-rule",
 		}],
 		"title": "duplicate-rule",
 	}}
@@ -82,7 +84,7 @@ test_fail_multiple_duplicate_rules if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/duplicate-rule", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/duplicate-rule",
 		}],
 		"title": "duplicate-rule",
 	}}

--- a/bundle/regal/rules/bugs/if-empty-object/if_empty_object.rego
+++ b/bundle/regal/rules/bugs/if-empty-object/if_empty_object.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Empty object following `if`
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/if-empty-object
 package regal.rules.bugs["if-empty-object"]
 
 import data.regal.capabilities

--- a/bundle/regal/rules/bugs/if-empty-object/if_empty_object_test.rego
+++ b/bundle/regal/rules/bugs/if-empty-object/if_empty_object_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.bugs["if-empty-object_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.bugs["if-empty-object"] as rule
 
@@ -24,7 +23,7 @@ test_fail_if_empty_object if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/if-empty-object", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/if-empty-object",
 		}],
 		"title": "if-empty-object",
 	}}

--- a/bundle/regal/rules/bugs/if-object-literal/if_object_literal.rego
+++ b/bundle/regal/rules/bugs/if-object-literal/if_object_literal.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Object literal following `if`
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/if-object-literal
 package regal.rules.bugs["if-object-literal"]
 
 import data.regal.capabilities

--- a/bundle/regal/rules/bugs/if-object-literal/if_object_literal_test.rego
+++ b/bundle/regal/rules/bugs/if-object-literal/if_object_literal_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.bugs["if-object-literal_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.bugs["if-object-literal"] as rule
 
@@ -41,7 +40,7 @@ test_fail[name] if {
 		"location": object.union({"file": "policy.rego"}, location),
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/if-object-literal", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/if-object-literal",
 		}],
 		"title": "if-object-literal",
 	}}

--- a/bundle/regal/rules/bugs/import-shadows-rule/import_shadows_rule.rego
+++ b/bundle/regal/rules/bugs/import-shadows-rule/import_shadows_rule.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Import shadows rule
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/import-shadows-rule
 package regal.rules.bugs["import-shadows-rule"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/import-shadows-rule/import_shadows_rule_test.rego
+++ b/bundle/regal/rules/bugs/import-shadows-rule/import_shadows_rule_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.bugs["import-shadows-rule_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.bugs["import-shadows-rule"] as rule
 
@@ -28,7 +27,7 @@ test_fail_import_shadows_rule if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/import-shadows-rule", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/import-shadows-rule",
 		}],
 		"title": "import-shadows-rule",
 	}}
@@ -57,7 +56,7 @@ test_fail_import_alias_shadows_rule if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/import-shadows-rule", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/import-shadows-rule",
 		}],
 		"title": "import-shadows-rule",
 	}}

--- a/bundle/regal/rules/bugs/impossible-not/impossible_not.rego
+++ b/bundle/regal/rules/bugs/impossible-not/impossible_not.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Impossible `not` condition
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/impossible-not
 package regal.rules.bugs["impossible-not"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/impossible-not/impossible_not_test.rego
+++ b/bundle/regal/rules/bugs/impossible-not/impossible_not_test.rego
@@ -1,6 +1,5 @@
 package regal.rules.bugs["impossible-not_test"]
 
-import data.regal.config
 import data.regal.util
 
 import data.regal.rules.bugs["impossible-not"] as rule
@@ -228,7 +227,7 @@ expected := {
 	"level": "error",
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/impossible-not", "bugs"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/impossible-not",
 	}],
 	"title": "impossible-not",
 }

--- a/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args.rego
+++ b/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Inconsistently named function arguments
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/inconsistent-args
 package regal.rules.bugs["inconsistent-args"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args_test.rego
+++ b/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.bugs["inconsistent-args_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.bugs["inconsistent-args"] as rule
 
@@ -100,7 +99,7 @@ expected := {
 	"level": "error",
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/inconsistent-args", "bugs"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/inconsistent-args",
 	}],
 	"title": "inconsistent-args",
 	"location": {"file": "policy.rego"},

--- a/bundle/regal/rules/bugs/internal-entrypoint/internal_entrypoint.rego
+++ b/bundle/regal/rules/bugs/internal-entrypoint/internal_entrypoint.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Entrypoint can't be marked internal
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/internal-entrypoint
 package regal.rules.bugs["internal-entrypoint"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/internal-entrypoint/internal_entrypoint_test.rego
+++ b/bundle/regal/rules/bugs/internal-entrypoint/internal_entrypoint_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.bugs["internal-entrypoint_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.bugs["internal-entrypoint"] as rule
 
@@ -29,7 +28,7 @@ _allow := true
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/internal-entrypoint", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/internal-entrypoint",
 		}],
 		"title": "internal-entrypoint",
 	}}
@@ -59,7 +58,7 @@ authz._allow := true
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/internal-entrypoint", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/internal-entrypoint",
 		}],
 		"title": "internal-entrypoint",
 	}}

--- a/bundle/regal/rules/bugs/invalid-metadata-attribute/invalid_metadata_attribute.rego
+++ b/bundle/regal/rules/bugs/invalid-metadata-attribute/invalid_metadata_attribute.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Invalid attribute in metadata annotation
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/invalid-metadata-attribute
 package regal.rules.bugs["invalid-metadata-attribute"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/invalid-metadata-attribute/invalid_metadata_attribute_test.rego
+++ b/bundle/regal/rules/bugs/invalid-metadata-attribute/invalid_metadata_attribute_test.rego
@@ -1,7 +1,7 @@
 package regal.rules.bugs["invalid-metadata-attribute_test"]
 
 import data.regal.ast
-import data.regal.config
+
 import data.regal.rules.bugs["invalid-metadata-attribute"] as rule
 
 test_fail_invalid_attribute if {
@@ -28,7 +28,7 @@ allow := true
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/invalid-metadata-attribute", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/invalid-metadata-attribute",
 		}],
 		"title": "invalid-metadata-attribute",
 	}}

--- a/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference.rego
+++ b/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Outside reference to internal rule or function
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/leaked-internal-reference
 package regal.rules.bugs["leaked-internal-reference"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference_test.rego
+++ b/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference_test.rego
@@ -93,7 +93,7 @@ expected := {
 	"level": "error",
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/leaked-internal-reference", "bugs"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/leaked-internal-reference",
 	}],
 	"title": "leaked-internal-reference",
 	"location": {"file": "policy.rego"},

--- a/bundle/regal/rules/bugs/not-equals-in-loop/not_equals_in_loop.rego
+++ b/bundle/regal/rules/bugs/not-equals-in-loop/not_equals_in_loop.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Use of != in loop
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/not-equals-in-loop
 package regal.rules.bugs["not-equals-in-loop"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/not-equals-in-loop/not_equals_in_loop_test.rego
+++ b/bundle/regal/rules/bugs/not-equals-in-loop/not_equals_in_loop_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.bugs["not-equals-in-loop_test"]
 
 import data.regal.ast
-import data.regal.config
 import data.regal.rules.bugs["not-equals-in-loop"] as rule
 
 test_fail_neq_in_loop if {
@@ -27,7 +26,7 @@ test_fail_neq_in_loop if {
 			},
 			"related_resources": [{
 				"description": "documentation",
-				"ref": config.docs.resolve_url("$baseUrl/$category/not-equals-in-loop", "bugs"),
+				"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/not-equals-in-loop",
 			}],
 			"title": "not-equals-in-loop",
 		},
@@ -47,7 +46,7 @@ test_fail_neq_in_loop if {
 			},
 			"related_resources": [{
 				"description": "documentation",
-				"ref": config.docs.resolve_url("$baseUrl/$category/not-equals-in-loop", "bugs"),
+				"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/not-equals-in-loop",
 			}],
 			"title": "not-equals-in-loop",
 		},
@@ -73,7 +72,7 @@ test_fail_neq_in_loop_one_liner if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/not-equals-in-loop", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/not-equals-in-loop",
 		}],
 		"title": "not-equals-in-loop",
 	}}

--- a/bundle/regal/rules/bugs/redundant-existence-check/redundant_existence_check.rego
+++ b/bundle/regal/rules/bugs/redundant-existence-check/redundant_existence_check.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Redundant existence check
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/redundant-existence-check
 package regal.rules.bugs["redundant-existence-check"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/redundant-existence-check/redundant_existence_check_test.rego
+++ b/bundle/regal/rules/bugs/redundant-existence-check/redundant_existence_check_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.bugs["redundant-existence-check_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.bugs["redundant-existence-check"] as rule
 
@@ -28,7 +27,7 @@ test_fail_redundant_existence_check if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-existence-check", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/redundant-existence-check",
 		}],
 		"title": "redundant-existence-check",
 	}}
@@ -57,7 +56,7 @@ test_fail_redundant_existence_check_subset if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-existence-check", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/redundant-existence-check",
 		}],
 		"title": "redundant-existence-check",
 	}}
@@ -105,7 +104,7 @@ test_fail_redundant_existence_check_head_assignment_of_ref if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-existence-check", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/redundant-existence-check",
 		}],
 		"title": "redundant-existence-check",
 	}}
@@ -133,7 +132,7 @@ test_fail_redundant_existence_check_function_arg if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-existence-check", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/redundant-existence-check",
 		}],
 		"title": "redundant-existence-check",
 	}}
@@ -162,7 +161,7 @@ test_fail_redundant_existence_check_function_arg_reference_after_use if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-existence-check", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/redundant-existence-check",
 		}],
 		"title": "redundant-existence-check",
 	}}

--- a/bundle/regal/rules/bugs/redundant-loop-count/redundant_loop_count.rego
+++ b/bundle/regal/rules/bugs/redundant-loop-count/redundant_loop_count.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Redundant count before loop
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/redundant-loop-count
 package regal.rules.bugs["redundant-loop-count"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/redundant-loop-count/redundant_loop_count_test.rego
+++ b/bundle/regal/rules/bugs/redundant-loop-count/redundant_loop_count_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.bugs["redundant-loop-count_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.bugs["redundant-loop-count"] as rule
 
@@ -29,7 +28,7 @@ test_fail_count_before_loop_gt_zero if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-loop-count", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/redundant-loop-count",
 		}],
 		"title": "redundant-loop-count",
 	}}
@@ -59,7 +58,7 @@ test_fail_count_before_loop_neq_zero if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-loop-count", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/redundant-loop-count",
 		}],
 		"title": "redundant-loop-count",
 	}}
@@ -89,7 +88,7 @@ test_fail_count_before_key_value_loop_gt_zero if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-loop-count", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/redundant-loop-count",
 		}],
 		"title": "redundant-loop-count",
 	}}
@@ -119,7 +118,7 @@ test_fail_count_before_key_value_loop_neq_zero if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-loop-count", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/redundant-loop-count",
 		}],
 		"title": "redundant-loop-count",
 	}}

--- a/bundle/regal/rules/bugs/rule-assigns-default/rule_assigns_default.rego
+++ b/bundle/regal/rules/bugs/rule-assigns-default/rule_assigns_default.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Rule assigned its default value
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/rule-assigns-default
 package regal.rules.bugs["rule-assigns-default"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/rule-assigns-default/rule_assigns_default_test.rego
+++ b/bundle/regal/rules/bugs/rule-assigns-default/rule_assigns_default_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.bugs["rule-assigns-default_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.bugs["rule-assigns-default"] as rule
 
@@ -31,7 +30,7 @@ test_fail_rule_assigned_default_value if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/rule-assigns-default", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/rule-assigns-default",
 		}],
 		"title": "rule-assigns-default",
 	}}

--- a/bundle/regal/rules/bugs/rule-named-if/rule_named_if.rego
+++ b/bundle/regal/rules/bugs/rule-named-if/rule_named_if.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Rule named "if"
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/rule-named-if
 package regal.rules.bugs["rule-named-if"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/rule-named-if/rule_named_if_test.rego
+++ b/bundle/regal/rules/bugs/rule-named-if/rule_named_if_test.rego
@@ -2,7 +2,7 @@ package regal.rules.bugs["rule-named-if_test"]
 
 import data.regal.ast
 import data.regal.capabilities
-import data.regal.config
+
 import data.regal.rules.bugs["rule-named-if"] as rule
 
 test_fail_rule_named_if if {
@@ -27,7 +27,7 @@ test_fail_rule_named_if if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/rule-named-if", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/rule-named-if",
 		}],
 		"title": "rule-named-if",
 	}} with input.regal.file.rego_version as "v0"

--- a/bundle/regal/rules/bugs/rule-shadows-builtin/rule_shadows_builtin.rego
+++ b/bundle/regal/rules/bugs/rule-shadows-builtin/rule_shadows_builtin.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Rule name shadows built-in
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/rule-shadows-builtin
 package regal.rules.bugs["rule-shadows-builtin"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/rule-shadows-builtin/rule_shadows_builtin_test.rego
+++ b/bundle/regal/rules/bugs/rule-shadows-builtin/rule_shadows_builtin_test.rego
@@ -13,7 +13,7 @@ test_fail_rule_name_shadows_builtin if {
 		"description": "Rule name shadows built-in",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/rule-shadows-builtin", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/rule-shadows-builtin",
 		}],
 		"title": "rule-shadows-builtin",
 		"location": {
@@ -39,7 +39,7 @@ test_fail_rule_name_shadows_builtin_namespace if {
 		"description": "Rule name shadows built-in",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/rule-shadows-builtin", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/rule-shadows-builtin",
 		}],
 		"title": "rule-shadows-builtin",
 		"location": {

--- a/bundle/regal/rules/bugs/sprintf-arguments-mismatch/sprintf_arguments_mismatch.rego
+++ b/bundle/regal/rules/bugs/sprintf-arguments-mismatch/sprintf_arguments_mismatch.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Mismatch in `sprintf` arguments count
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/sprintf-arguments-mismatch
 package regal.rules.bugs["sprintf-arguments-mismatch"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/sprintf-arguments-mismatch/sprintf_arguments_mismatch_test.rego
+++ b/bundle/regal/rules/bugs/sprintf-arguments-mismatch/sprintf_arguments_mismatch_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.bugs["sprintf-arguments-mismatch_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.bugs["sprintf-arguments-mismatch"] as rule
 
@@ -23,7 +22,7 @@ test_fail_too_many_values_in_array if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/sprintf-arguments-mismatch", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/sprintf-arguments-mismatch",
 		}],
 		"title": "sprintf-arguments-mismatch",
 	}}
@@ -50,7 +49,7 @@ test_fail_too_many_values_in_array_nested if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/sprintf-arguments-mismatch", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/sprintf-arguments-mismatch",
 		}],
 		"title": "sprintf-arguments-mismatch",
 	}}
@@ -74,7 +73,7 @@ test_fail_too_few_values_in_array if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/sprintf-arguments-mismatch", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/sprintf-arguments-mismatch",
 		}],
 		"title": "sprintf-arguments-mismatch",
 	}}
@@ -104,7 +103,7 @@ test_fail_different_number_of_values_with_explicit_index if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/sprintf-arguments-mismatch", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/sprintf-arguments-mismatch",
 		}],
 		"title": "sprintf-arguments-mismatch",
 	}}
@@ -131,7 +130,7 @@ test_fail_first_arg_is_variable_with_nonmatching_pattern if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/sprintf-arguments-mismatch", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/sprintf-arguments-mismatch",
 		}],
 		"title": "sprintf-arguments-mismatch",
 	}}
@@ -178,7 +177,7 @@ test_fail_padding_not_accounted_for if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/sprintf-arguments-mismatch", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/sprintf-arguments-mismatch",
 		}],
 		"title": "sprintf-arguments-mismatch",
 	}}

--- a/bundle/regal/rules/bugs/time-now-ns-twice/time_now_ns_twice.rego
+++ b/bundle/regal/rules/bugs/time-now-ns-twice/time_now_ns_twice.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Repeated calls to `time.now_ns`
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/time-now-ns-twice
 package regal.rules.bugs["time-now-ns-twice"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/time-now-ns-twice/time_now_ns_twice_test.rego
+++ b/bundle/regal/rules/bugs/time-now-ns-twice/time_now_ns_twice_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.bugs["time-now-ns-twice_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.bugs["time-now-ns-twice"] as rule
 
@@ -29,7 +28,7 @@ test_fail_time_now_ns_called_twice if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/time-now-ns-twice", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/time-now-ns-twice",
 		}],
 		"title": "time-now-ns-twice",
 	}}
@@ -58,7 +57,7 @@ test_fail_time_now_ns_called_twice_body_and_head if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/time-now-ns-twice", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/time-now-ns-twice",
 		}],
 		"title": "time-now-ns-twice",
 	}}

--- a/bundle/regal/rules/bugs/top-level-iteration/top_level_iteration.rego
+++ b/bundle/regal/rules/bugs/top-level-iteration/top_level_iteration.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Iteration in top-level assignment
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/top-level-iteration
 package regal.rules.bugs["top-level-iteration"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/top-level-iteration/top_level_iteration_test.rego
+++ b/bundle/regal/rules/bugs/top-level-iteration/top_level_iteration_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.bugs["top-level-iteration_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.bugs["top-level-iteration"] as rule
 
@@ -23,7 +22,7 @@ test_fail_top_level_iteration_wildcard if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/top-level-iteration", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/top-level-iteration",
 		}],
 		"title": "top-level-iteration",
 		"level": "error",
@@ -48,7 +47,7 @@ test_fail_top_level_iteration_named_var if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/top-level-iteration", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/top-level-iteration",
 		}],
 		"title": "top-level-iteration",
 		"level": "error",

--- a/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value.rego
+++ b/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Non-boolean return value unassigned
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/unassigned-return-value
 package regal.rules.bugs["unassigned-return-value"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value_test.rego
+++ b/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value_test.rego
@@ -27,7 +27,7 @@ test_fail_unused_return_value if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/unassigned-return-value", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/unassigned-return-value",
 		}],
 		"title": "unassigned-return-value",
 	}}
@@ -58,7 +58,7 @@ test_fail_unused_return_value_nested if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/unassigned-return-value", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/unassigned-return-value",
 		}],
 		"title": "unassigned-return-value",
 	}}

--- a/bundle/regal/rules/bugs/unused-output-variable/unused_output_variable.rego
+++ b/bundle/regal/rules/bugs/unused-output-variable/unused_output_variable.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Unused output variable
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/unused-output-variable
 package regal.rules.bugs["unused-output-variable"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/unused-output-variable/unused_output_variable_test.rego
+++ b/bundle/regal/rules/bugs/unused-output-variable/unused_output_variable_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.bugs["unused-output-variable_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.bugs["unused-output-variable"] as rule
 
@@ -16,10 +15,19 @@ test_fail_unused_output_variable if {
 		"category": "bugs",
 		"description": "Unused output variable",
 		"level": "error",
-		"location": {"col": 9, "end": {"col": 10, "row": 7}, "file": "policy.rego", "row": 7, "text": "\t\tinput[x]"},
+		"location": {
+			"col": 9,
+			"end": {
+				"col": 10,
+				"row": 7,
+			},
+			"file": "policy.rego",
+			"row": 7,
+			"text": "\t\tinput[x]",
+		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/unused-output-variable", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/unused-output-variable",
 		}],
 		"title": "unused-output-variable",
 	}}
@@ -37,10 +45,19 @@ test_fail_unused_output_variable_some if {
 		"category": "bugs",
 		"description": "Unused output variable",
 		"level": "error",
-		"location": {"col": 9, "end": {"col": 11, "row": 8}, "file": "policy.rego", "row": 8, "text": "\t\tinput[xx]"},
+		"location": {
+			"col": 9,
+			"end": {
+				"col": 11,
+				"row": 8,
+			},
+			"file": "policy.rego",
+			"row": 8,
+			"text": "\t\tinput[xx]",
+		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/unused-output-variable", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/unused-output-variable",
 		}],
 		"title": "unused-output-variable",
 	}}
@@ -62,10 +79,19 @@ _test_fail_unused_output_variable_assignment if {
 		"category": "bugs",
 		"description": "Unused output variable",
 		"level": "error",
-		"location": {"col": 14, "end": {"col": 15, "row": 6}, "file": "policy.rego", "row": 6, "text": "\t\tx := input[y]"},
+		"location": {
+			"col": 14,
+			"end": {
+				"col": 15,
+				"row": 6,
+			},
+			"file": "policy.rego",
+			"row": 6,
+			"text": "\t\tx := input[y]",
+		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/unused-output-variable", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/unused-output-variable",
 		}],
 		"title": "unused-output-variable",
 	}}

--- a/bundle/regal/rules/bugs/var-shadows-builtin/var_shadows_builtin.rego
+++ b/bundle/regal/rules/bugs/var-shadows-builtin/var_shadows_builtin.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Variable name shadows built-in
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/var-shadows-builtin
 package regal.rules.bugs["var-shadows-builtin"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/var-shadows-builtin/var_shadows_builtin_test.rego
+++ b/bundle/regal/rules/bugs/var-shadows-builtin/var_shadows_builtin_test.rego
@@ -26,7 +26,7 @@ test_fail_var_shadows_builtin if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/var-shadows-builtin", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/var-shadows-builtin",
 		}],
 		"title": "var-shadows-builtin",
 	}}

--- a/bundle/regal/rules/bugs/zero-arity-function/zero_arity_function.rego
+++ b/bundle/regal/rules/bugs/zero-arity-function/zero_arity_function.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Avoid functions without args
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/bugs/zero-arity-function
 package regal.rules.bugs["zero-arity-function"]
 
 import data.regal.ast

--- a/bundle/regal/rules/bugs/zero-arity-function/zero_arity_function_test.rego
+++ b/bundle/regal/rules/bugs/zero-arity-function/zero_arity_function_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.bugs["zero-arity-function_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.bugs["zero-arity-function"] as rule
 
@@ -24,7 +23,7 @@ test_fail_zero_arity_function if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/zero-arity-function", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/zero-arity-function",
 		}],
 		"title": "zero-arity-function",
 	}}
@@ -49,7 +48,7 @@ test_fail_zero_arity_nested_function if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/zero-arity-function", "bugs"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/zero-arity-function",
 		}],
 		"title": "zero-arity-function",
 	}}

--- a/bundle/regal/rules/custom/chained-rule-body/chained_rule_body.rego
+++ b/bundle/regal/rules/custom/chained-rule-body/chained_rule_body.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Avoid chaining rule bodies
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/custom/chained-rule-body
 package regal.rules.custom["chained-rule-body"]
 
 import data.regal.ast

--- a/bundle/regal/rules/custom/chained-rule-body/chained_rule_body_test.rego
+++ b/bundle/regal/rules/custom/chained-rule-body/chained_rule_body_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.custom["chained-rule-body_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.custom["chained-rule-body"] as rule
 
@@ -28,7 +27,7 @@ test_fail_chained_incremental_definition if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/chained-rule-body", "custom"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/custom/chained-rule-body",
 		}],
 		"title": "chained-rule-body",
 	}}

--- a/bundle/regal/rules/custom/disallow-rego-v1/disallow_rego_v1.rego
+++ b/bundle/regal/rules/custom/disallow-rego-v1/disallow_rego_v1.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Use of disallowed `import rego.v1`
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/custom/disallow-rego-v1
 package regal.rules.custom["disallow-rego-v1"]
 
 import data.regal.ast

--- a/bundle/regal/rules/custom/disallow-rego-v1/disallow_rego_v1_test.rego
+++ b/bundle/regal/rules/custom/disallow-rego-v1/disallow_rego_v1_test.rego
@@ -1,7 +1,5 @@
 package regal.rules.custom["disallow-rego-v1_test"]
 
-import data.regal.config
-
 import data.regal.rules.custom["disallow-rego-v1"] as rule
 
 test_fail_contains_rego_v1_import if {
@@ -15,7 +13,7 @@ test_fail_contains_rego_v1_import if {
 		"description": "Use of disallowed `import rego.v1`",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/disallow-rego-v1", "custom"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/custom/disallow-rego-v1",
 		}],
 		"title": "disallow-rego-v1",
 		"location": {

--- a/bundle/regal/rules/custom/forbidden-function-call/forbidden_function_call.rego
+++ b/bundle/regal/rules/custom/forbidden-function-call/forbidden_function_call.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Forbidden function call
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/custom/forbidden-function-call
 package regal.rules.custom["forbidden-function-call"]
 
 import data.regal.ast

--- a/bundle/regal/rules/custom/forbidden-function-call/forbidden_function_call_test.rego
+++ b/bundle/regal/rules/custom/forbidden-function-call/forbidden_function_call_test.rego
@@ -31,7 +31,7 @@ test_fail_forbidden_function if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/forbidden-function-call", "custom"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/custom/forbidden-function-call",
 		}],
 		"title": "forbidden-function-call",
 	}}

--- a/bundle/regal/rules/custom/missing-metadata/missing_metadata.rego
+++ b/bundle/regal/rules/custom/missing-metadata/missing_metadata.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Package or rule missing metadata
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/custom/missing-metadata
 package regal.rules.custom["missing-metadata"]
 
 import data.regal.ast

--- a/bundle/regal/rules/custom/missing-metadata/missing_metadata_test.rego
+++ b/bundle/regal/rules/custom/missing-metadata/missing_metadata_test.rego
@@ -80,7 +80,7 @@ test_fail_missing_package_metadata_report if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/missing-metadata", "custom"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/custom/missing-metadata",
 		}],
 		"title": "missing-metadata",
 	}}
@@ -150,7 +150,7 @@ baz := true
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/missing-metadata", "custom"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/custom/missing-metadata",
 		}],
 		"title": "missing-metadata",
 	}}

--- a/bundle/regal/rules/custom/naming-convention/naming_convention.rego
+++ b/bundle/regal/rules/custom/naming-convention/naming_convention.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Naming convention violation
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/custom/naming-convention
 package regal.rules.custom["naming-convention"]
 
 import data.regal.ast

--- a/bundle/regal/rules/custom/naming-convention/naming_convention_test.rego
+++ b/bundle/regal/rules/custom/naming-convention/naming_convention_test.rego
@@ -225,7 +225,7 @@ expected(description, location) := {
 	"location": location,
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/naming-convention", "custom"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/custom/naming-convention",
 	}],
 	"title": "naming-convention",
 }

--- a/bundle/regal/rules/custom/narrow-argument/narrow_argument.rego
+++ b/bundle/regal/rules/custom/narrow-argument/narrow_argument.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Function argument can be narrowed
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/custom/narrow-argument
 package regal.rules.custom["narrow-argument"]
 
 import data.regal.ast

--- a/bundle/regal/rules/custom/narrow-argument/narrow_argument_test.rego
+++ b/bundle/regal/rules/custom/narrow-argument/narrow_argument_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.custom["narrow-argument_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.custom["narrow-argument"] as rule
 
@@ -27,7 +26,7 @@ test_fail_can_be_narrowed_single_ref if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/narrow-argument", "custom"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/custom/narrow-argument",
 		}],
 		"title": "narrow-argument",
 	}}
@@ -55,7 +54,7 @@ test_fail_can_be_narrowed_prefixed_ref if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/narrow-argument", "custom"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/custom/narrow-argument",
 		}],
 		"title": "narrow-argument",
 	}}
@@ -83,7 +82,7 @@ test_fail_can_be_narrowed_prefixed_array_ref if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/narrow-argument", "custom"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/custom/narrow-argument",
 		}],
 		"title": "narrow-argument",
 	}}

--- a/bundle/regal/rules/custom/one-liner-rule/one_liner_rule.rego
+++ b/bundle/regal/rules/custom/one-liner-rule/one_liner_rule.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Rule body could be made a one-liner
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/custom/one-liner-rule
 package regal.rules.custom["one-liner-rule"]
 
 import data.regal.capabilities

--- a/bundle/regal/rules/custom/one-liner-rule/one_liner_rule_test.rego
+++ b/bundle/regal/rules/custom/one-liner-rule/one_liner_rule_test.rego
@@ -173,7 +173,7 @@ expected := {
 	"level": "error",
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/one-liner-rule", "custom"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/custom/one-liner-rule",
 	}],
 	"title": "one-liner-rule",
 	"location": {"file": "policy.rego"},

--- a/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head.rego
+++ b/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Prefer value in rule head
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/custom/prefer-value-in-head
 package regal.rules.custom["prefer-value-in-head"]
 
 import data.regal.ast

--- a/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head_test.rego
+++ b/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head_test.rego
@@ -194,7 +194,7 @@ expected := {
 	"level": "error",
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/prefer-value-in-head", "custom"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/custom/prefer-value-in-head",
 	}],
 	"title": "prefer-value-in-head",
 	"location": {"file": "policy.rego"},

--- a/bundle/regal/rules/idiomatic/ambiguous-scope/ambiguous_scope.rego
+++ b/bundle/regal/rules/idiomatic/ambiguous-scope/ambiguous_scope.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Ambiguous metadata scope
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/ambiguous-scope
 package regal.rules.idiomatic["ambiguous-scope"]
 
 import data.regal.ast

--- a/bundle/regal/rules/idiomatic/ambiguous-scope/ambiguous_scope_test.rego
+++ b/bundle/regal/rules/idiomatic/ambiguous-scope/ambiguous_scope_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.idiomatic["ambiguous-scope_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.idiomatic["ambiguous-scope"] as rule
 
@@ -31,7 +30,7 @@ allow if input.y
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/ambiguous-scope", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/ambiguous-scope",
 		}],
 		"title": "ambiguous-scope",
 	}}
@@ -63,7 +62,7 @@ func(x) if x < "10"
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/ambiguous-scope", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/ambiguous-scope",
 		}],
 		"title": "ambiguous-scope",
 	}}

--- a/bundle/regal/rules/idiomatic/boolean-assignment/boolean_assignment.rego
+++ b/bundle/regal/rules/idiomatic/boolean-assignment/boolean_assignment.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Prefer `if` over boolean assignment
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/boolean-assignment
 package regal.rules.idiomatic["boolean-assignment"]
 
 import data.regal.config

--- a/bundle/regal/rules/idiomatic/boolean-assignment/boolean_assignment_test.rego
+++ b/bundle/regal/rules/idiomatic/boolean-assignment/boolean_assignment_test.rego
@@ -26,7 +26,7 @@ test_boolean_assignment_in_rule_head if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/boolean-assignment", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/boolean-assignment",
 		}],
 		"title": "boolean-assignment",
 	}}

--- a/bundle/regal/rules/idiomatic/custom-has-key-construct/custom_has_key_construct.rego
+++ b/bundle/regal/rules/idiomatic/custom-has-key-construct/custom_has_key_construct.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Custom function may be replaced by `in` and `object.keys`
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/custom-has-key-construct
 package regal.rules.idiomatic["custom-has-key-construct"]
 
 import data.regal.ast

--- a/bundle/regal/rules/idiomatic/custom-has-key-construct/custom_has_key_construct_test.rego
+++ b/bundle/regal/rules/idiomatic/custom-has-key-construct/custom_has_key_construct_test.rego
@@ -25,7 +25,7 @@ test_fail_custom_has_key if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/custom-has-key-construct", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/custom-has-key-construct",
 		}],
 		"title": "custom-has-key-construct",
 	}}
@@ -52,7 +52,7 @@ test_fail_custom_has_key_reversed if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/custom-has-key-construct", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/custom-has-key-construct",
 		}],
 		"title": "custom-has-key-construct",
 	}}
@@ -84,7 +84,7 @@ test_fail_custom_has_key_multiple_wildcards if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/custom-has-key-construct", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/custom-has-key-construct",
 		}],
 		"title": "custom-has-key-construct",
 	}}

--- a/bundle/regal/rules/idiomatic/custom-in-construct/custom_in_construct.rego
+++ b/bundle/regal/rules/idiomatic/custom-in-construct/custom_in_construct.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Custom function may be replaced by `in` keyword
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/custom-in-construct
 package regal.rules.idiomatic["custom-in-construct"]
 
 import data.regal.ast

--- a/bundle/regal/rules/idiomatic/custom-in-construct/custom_in_construct_test.rego
+++ b/bundle/regal/rules/idiomatic/custom-in-construct/custom_in_construct_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.idiomatic["custom-in-construct_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.idiomatic["custom-in-construct"] as rule
 
@@ -26,7 +25,7 @@ test_fail_custom_in if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/custom-in-construct", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/custom-in-construct",
 		}],
 		"title": "custom-in-construct",
 	}}
@@ -51,7 +50,7 @@ test_fail_custom_in_reversed if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/custom-in-construct", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/custom-in-construct",
 		}],
 		"title": "custom-in-construct",
 	}}

--- a/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch.rego
+++ b/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Directory structure should mirror package
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/directory-package-mismatch
 package regal.rules.idiomatic["directory-package-mismatch"]
 
 import data.regal.ast

--- a/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch_test.rego
+++ b/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch_test.rego
@@ -41,7 +41,7 @@ with_location(location) := {{
 	"location": location,
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/directory-package-mismatch", "idiomatic"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/directory-package-mismatch",
 	}],
 	"title": "directory-package-mismatch",
 }}

--- a/bundle/regal/rules/idiomatic/equals-pattern-matching/equals_pattern_matching.rego
+++ b/bundle/regal/rules/idiomatic/equals-pattern-matching/equals_pattern_matching.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Prefer pattern matching in function arguments
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/equals-pattern-matching
 package regal.rules.idiomatic["equals-pattern-matching"]
 
 import data.regal.ast

--- a/bundle/regal/rules/idiomatic/equals-pattern-matching/equals_pattern_matching_test.rego
+++ b/bundle/regal/rules/idiomatic/equals-pattern-matching/equals_pattern_matching_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.idiomatic["equals-pattern-matching_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.idiomatic["equals-pattern-matching"] as rule
 
@@ -115,7 +114,7 @@ expected := {
 	"level": "error",
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/equals-pattern-matching", "idiomatic"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/equals-pattern-matching",
 	}],
 	"title": "equals-pattern-matching",
 	"location": {"file": "policy.rego"},

--- a/bundle/regal/rules/idiomatic/in-wildcard-key/in_wildcard_key.rego
+++ b/bundle/regal/rules/idiomatic/in-wildcard-key/in_wildcard_key.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Unnecessary wildcard key
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/in-wildcard-key
 package regal.rules.idiomatic["in-wildcard-key"]
 
 import data.regal.ast

--- a/bundle/regal/rules/idiomatic/in-wildcard-key/in_wildcard_key_test.rego
+++ b/bundle/regal/rules/idiomatic/in-wildcard-key/in_wildcard_key_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.idiomatic["in-wildcard-key_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.idiomatic["in-wildcard-key"] as rule
 
@@ -24,7 +23,7 @@ test_fail_wildcard_key_not_needed if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/in-wildcard-key", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/in-wildcard-key",
 		}],
 		"title": "in-wildcard-key",
 	}}

--- a/bundle/regal/rules/idiomatic/no-defined-entrypoint/no_defined_entrypoint.rego
+++ b/bundle/regal/rules/idiomatic/no-defined-entrypoint/no_defined_entrypoint.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Missing entrypoint annotation
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/no-defined-entrypoint
 package regal.rules.idiomatic["no-defined-entrypoint"]
 
 import data.regal.result

--- a/bundle/regal/rules/idiomatic/no-defined-entrypoint/no_defined_entrypoint_test.rego
+++ b/bundle/regal/rules/idiomatic/no-defined-entrypoint/no_defined_entrypoint_test.rego
@@ -1,7 +1,5 @@
 package regal.rules.idiomatic["no-defined-entrypoint_test"]
 
-import data.regal.config
-
 import data.regal.rules.idiomatic["no-defined-entrypoint"] as rule
 
 test_aggregate_entrypoints if {
@@ -45,7 +43,7 @@ test_fail_no_entrypoint_defined if {
 		"level": "error",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/no-defined-entrypoint", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/no-defined-entrypoint",
 		}],
 		"title": "no-defined-entrypoint",
 	}}

--- a/bundle/regal/rules/idiomatic/non-raw-regex-pattern/non_raw_regex_pattern.rego
+++ b/bundle/regal/rules/idiomatic/non-raw-regex-pattern/non_raw_regex_pattern.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Use raw strings for regex patterns
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/non-raw-regex-pattern
 package regal.rules.idiomatic["non-raw-regex-pattern"]
 
 import data.regal.ast

--- a/bundle/regal/rules/idiomatic/non-raw-regex-pattern/non_raw_regex_pattern_test.rego
+++ b/bundle/regal/rules/idiomatic/non-raw-regex-pattern/non_raw_regex_pattern_test.rego
@@ -18,11 +18,14 @@ test_fail_non_raw_rule_head if {
 			"file": "policy.rego",
 			"row": 3,
 			"text": "x := regex.match(\"[0-9]+\", \"1\")",
-			"end": {"col": 26, "row": 3},
+			"end": {
+				"col": 26,
+				"row": 3,
+			},
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/non-raw-regex-pattern", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/non-raw-regex-pattern",
 		}],
 		"title": "non-raw-regex-pattern",
 	}}
@@ -42,11 +45,14 @@ test_fail_non_raw_rule_body if {
 			"file": "policy.rego",
 			"row": 4,
 			"text": "\t\tregex.is_valid(\"[0-9]+\")",
-			"end": {"col": 26, "row": 4},
+			"end": {
+				"col": 26,
+				"row": 4,
+			},
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/non-raw-regex-pattern", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/non-raw-regex-pattern",
 		}],
 		"title": "non-raw-regex-pattern",
 	}}
@@ -64,11 +70,14 @@ test_fail_pattern_in_second_arg if {
 			"file": "policy.rego",
 			"row": 3,
 			"text": "r := regex.replace(\"a\", \"[a]\", \"b\")",
-			"end": {"col": 30, "row": 3},
+			"end": {
+				"col": 30,
+				"row": 3,
+			},
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/non-raw-regex-pattern", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/non-raw-regex-pattern",
 		}],
 		"title": "non-raw-regex-pattern",
 	}}

--- a/bundle/regal/rules/idiomatic/prefer-equals-comparison/prefer_equals_comparison.rego
+++ b/bundle/regal/rules/idiomatic/prefer-equals-comparison/prefer_equals_comparison.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Prefer `==` for equality comparison
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/prefer-equals-comparison
 package regal.rules.idiomatic["prefer-equals-comparison"]
 
 import data.regal.ast

--- a/bundle/regal/rules/idiomatic/prefer-equals-comparison/prefer_equals_comparison_test.rego
+++ b/bundle/regal/rules/idiomatic/prefer-equals-comparison/prefer_equals_comparison_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.idiomatic["prefer-equals-comparison_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.idiomatic["prefer-equals-comparison"] as rule
 
@@ -26,7 +25,7 @@ test_fail_impossible_assignment_2_constants if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/prefer-equals-comparison", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/prefer-equals-comparison",
 		}],
 		"title": "prefer-equals-comparison",
 	}}
@@ -51,7 +50,7 @@ test_fail_impossible_assignment_static_ref_equals_constant if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/prefer-equals-comparison", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/prefer-equals-comparison",
 		}],
 		"title": "prefer-equals-comparison",
 	}}
@@ -76,7 +75,7 @@ test_fail_impossible_assignment_constant_equals_static_ref if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/prefer-equals-comparison", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/prefer-equals-comparison",
 		}],
 		"title": "prefer-equals-comparison",
 	}}
@@ -104,7 +103,7 @@ test_fail_impossible_assignment_input_var_equals_static_ref if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/prefer-equals-comparison", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/prefer-equals-comparison",
 		}],
 		"title": "prefer-equals-comparison",
 	}}

--- a/bundle/regal/rules/idiomatic/prefer-set-or-object-rule/prefer_set_or_object_rule.rego
+++ b/bundle/regal/rules/idiomatic/prefer-set-or-object-rule/prefer_set_or_object_rule.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Prefer set or object rule over comprehension
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/prefer-set-or-object-rule
 package regal.rules.idiomatic["prefer-set-or-object-rule"]
 
 import data.regal.ast

--- a/bundle/regal/rules/idiomatic/prefer-set-or-object-rule/prefer_set_or_object_rule_test.rego
+++ b/bundle/regal/rules/idiomatic/prefer-set-or-object-rule/prefer_set_or_object_rule_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.idiomatic["prefer-set-or-object-rule_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.idiomatic["prefer-set-or-object-rule"] as rule
 
@@ -28,7 +27,7 @@ test_fail_set_comprehension_could_be_rule if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/prefer-set-or-object-rule", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/prefer-set-or-object-rule",
 		}],
 		"title": "prefer-set-or-object-rule",
 	}}
@@ -57,7 +56,7 @@ test_fail_object_comprehension_could_be_rule if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/prefer-set-or-object-rule", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/prefer-set-or-object-rule",
 		}],
 		"title": "prefer-set-or-object-rule",
 	}}

--- a/bundle/regal/rules/idiomatic/single-item-in/single_item_in.rego
+++ b/bundle/regal/rules/idiomatic/single-item-in/single_item_in.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Avoid `in` for single item collection
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/single-item-in
 package regal.rules.idiomatic["single-item-in"]
 
 import data.regal.ast

--- a/bundle/regal/rules/idiomatic/single-item-in/single_item_in_test.rego
+++ b/bundle/regal/rules/idiomatic/single-item-in/single_item_in_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.idiomatic["single-item-in_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.idiomatic["single-item-in"] as rule
 
@@ -24,7 +23,7 @@ test_fail_single_item_in_array if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/single-item-in", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/single-item-in",
 		}],
 		"title": "single-item-in",
 	}}
@@ -49,7 +48,7 @@ test_fail_single_item_in_set if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/single-item-in", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/single-item-in",
 		}],
 		"title": "single-item-in",
 	}}
@@ -74,7 +73,7 @@ test_fail_single_item_in_object if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/single-item-in", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/single-item-in",
 		}],
 		"title": "single-item-in",
 	}}

--- a/bundle/regal/rules/idiomatic/use-array-flatten/use_array_flatten.rego
+++ b/bundle/regal/rules/idiomatic/use-array-flatten/use_array_flatten.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Prefer using `array.flatten` over nested `array.concat` calls
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/use-array-flatten
 package regal.rules.idiomatic["use-array-flatten"]
 
 import data.regal.ast

--- a/bundle/regal/rules/idiomatic/use-contains/use_contains.rego
+++ b/bundle/regal/rules/idiomatic/use-contains/use_contains.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Use the `contains` keyword
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/use-contains
 package regal.rules.idiomatic["use-contains"]
 
 import data.regal.ast

--- a/bundle/regal/rules/idiomatic/use-contains/use_contains_test.rego
+++ b/bundle/regal/rules/idiomatic/use-contains/use_contains_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.idiomatic["use-contains_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.idiomatic["use-contains"] as rule
 
@@ -29,7 +28,7 @@ test_fail_should_use_contains if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-contains", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/use-contains",
 		}],
 		"title": "use-contains",
 	}}

--- a/bundle/regal/rules/idiomatic/use-if/use_if.rego
+++ b/bundle/regal/rules/idiomatic/use-if/use_if.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Use the `if` keyword
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/use-if
 package regal.rules.idiomatic["use-if"]
 
 import data.regal.ast

--- a/bundle/regal/rules/idiomatic/use-if/use_if_test.rego
+++ b/bundle/regal/rules/idiomatic/use-if/use_if_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.idiomatic["use-if_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.idiomatic["use-if"] as rule
 
@@ -29,7 +28,7 @@ test_fail_should_use_if if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-if", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/use-if",
 		}],
 		"title": "use-if",
 	}}

--- a/bundle/regal/rules/idiomatic/use-in-operator/use_in_operator.rego
+++ b/bundle/regal/rules/idiomatic/use-in-operator/use_in_operator.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Use in to check for membership
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/use-in-operator
 package regal.rules.idiomatic["use-in-operator"]
 
 import data.regal.ast

--- a/bundle/regal/rules/idiomatic/use-in-operator/use_in_operator_test.rego
+++ b/bundle/regal/rules/idiomatic/use-in-operator/use_in_operator_test.rego
@@ -1,7 +1,7 @@
 package regal.rules.idiomatic["use-in-operator_test"]
 
 import data.regal.ast
-import data.regal.config
+
 import data.regal.rules.idiomatic["use-in-operator"] as rule
 
 test_fail_use_in_operator_string_lhs if {
@@ -245,7 +245,7 @@ expected := {
 	"level": "error",
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "idiomatic"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/use-in-operator",
 	}],
 	"title": "use-in-operator",
 	"location": {"file": "policy.rego"},

--- a/bundle/regal/rules/idiomatic/use-object-keys/use_object_keys.rego
+++ b/bundle/regal/rules/idiomatic/use-object-keys/use_object_keys.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Prefer to use `object.keys`
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/use-object-keys
 package regal.rules.idiomatic["use-object-keys"]
 
 import data.regal.ast

--- a/bundle/regal/rules/idiomatic/use-object-keys/use_object_keys_test.rego
+++ b/bundle/regal/rules/idiomatic/use-object-keys/use_object_keys_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.idiomatic["use-object-keys_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.idiomatic["use-object-keys"] as rule
 
@@ -24,7 +23,7 @@ test_fail_use_object_keys_not_some_in_comprehension if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-object-keys", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/use-object-keys",
 		}],
 		"title": "use-object-keys",
 	}}
@@ -49,7 +48,7 @@ test_fail_use_object_keys_not_some_in_comprehension_single_var if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-object-keys", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/use-object-keys",
 		}],
 		"title": "use-object-keys",
 	}}
@@ -74,7 +73,7 @@ test_fail_use_object_keys_not_some_comprehension if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-object-keys", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/use-object-keys",
 		}],
 		"title": "use-object-keys",
 	}}

--- a/bundle/regal/rules/idiomatic/use-object-union-n/use_object_union_n.rego
+++ b/bundle/regal/rules/idiomatic/use-object-union-n/use_object_union_n.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Prefer using `object.union_n` over nested `object.union` calls
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/use-object-union-n
 package regal.rules.idiomatic["use-object-union-n"]
 
 import data.regal.ast

--- a/bundle/regal/rules/idiomatic/use-some-for-output-vars/use_some_for_output_vars.rego
+++ b/bundle/regal/rules/idiomatic/use-some-for-output-vars/use_some_for_output_vars.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Use `some` to declare output variables
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/use-some-for-output-vars
 package regal.rules.idiomatic["use-some-for-output-vars"]
 
 import data.regal.ast

--- a/bundle/regal/rules/idiomatic/use-some-for-output-vars/use_some_for_output_vars_test.rego
+++ b/bundle/regal/rules/idiomatic/use-some-for-output-vars/use_some_for_output_vars_test.rego
@@ -1,7 +1,7 @@
 package regal.rules.idiomatic["use-some-for-output-vars_test"]
 
 import data.regal.ast
-import data.regal.config
+
 import data.regal.rules.idiomatic["use-some-for-output-vars"] as rule
 
 test_fail_output_var_not_declared if {
@@ -24,7 +24,7 @@ test_fail_output_var_not_declared if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-some-for-output-vars", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/use-some-for-output-vars",
 		}],
 		"title": "use-some-for-output-vars",
 	}}
@@ -51,7 +51,7 @@ test_fail_multiple_output_vars_not_declared if {
 			},
 			"related_resources": [{
 				"description": "documentation",
-				"ref": config.docs.resolve_url("$baseUrl/$category/use-some-for-output-vars", "idiomatic"),
+				"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/use-some-for-output-vars",
 			}],
 			"title": "use-some-for-output-vars",
 		},
@@ -71,7 +71,7 @@ test_fail_multiple_output_vars_not_declared if {
 			},
 			"related_resources": [{
 				"description": "documentation",
-				"ref": config.docs.resolve_url("$baseUrl/$category/use-some-for-output-vars", "idiomatic"),
+				"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/use-some-for-output-vars",
 			}],
 			"title": "use-some-for-output-vars",
 		},
@@ -100,7 +100,7 @@ test_fail_only_one_declared if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-some-for-output-vars", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/use-some-for-output-vars",
 		}],
 		"title": "use-some-for-output-vars",
 	}}

--- a/bundle/regal/rules/idiomatic/use-strings-count/use_strings_count.rego
+++ b/bundle/regal/rules/idiomatic/use-strings-count/use_strings_count.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Use `strings.count` where possible
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/idiomatic/use-strings-count
 package regal.rules.idiomatic["use-strings-count"]
 
 import data.regal.ast

--- a/bundle/regal/rules/idiomatic/use-strings-count/use_strings_count_test.rego
+++ b/bundle/regal/rules/idiomatic/use-strings-count/use_strings_count_test.rego
@@ -18,11 +18,14 @@ test_fail_can_use_strings_count if {
 			"file": "policy.rego",
 			"row": 5,
 			"text": `x := count(indexof_n("foo", "o"))`,
-			"end": {"col": 33, "row": 5},
+			"end": {
+				"col": 33,
+				"row": 5,
+			},
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-strings-count", "idiomatic"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/idiomatic/use-strings-count",
 		}],
 		"title": "use-strings-count",
 	}}

--- a/bundle/regal/rules/imports/avoid-importing-input/avoid_importing_input.rego
+++ b/bundle/regal/rules/imports/avoid-importing-input/avoid_importing_input.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Avoid importing input
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/imports/avoid-importing-input
 package regal.rules.imports["avoid-importing-input"]
 
 import data.regal.result

--- a/bundle/regal/rules/imports/avoid-importing-input/avoid_importing_input_test.rego
+++ b/bundle/regal/rules/imports/avoid-importing-input/avoid_importing_input_test.rego
@@ -1,7 +1,7 @@
 package regal.rules.imports["avoid-importing-input_test"]
 
 import data.regal.ast
-import data.regal.config
+
 import data.regal.rules.imports["avoid-importing-input"] as rule
 
 test_fail_import_input if {
@@ -12,7 +12,7 @@ test_fail_import_input if {
 		"description": "Avoid importing input",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/avoid-importing-input", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/avoid-importing-input",
 		}],
 		"title": "avoid-importing-input",
 		"location": {
@@ -43,7 +43,7 @@ test_fail_import_input_aliased_attribute if {
 		"description": "Avoid importing input",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/avoid-importing-input", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/avoid-importing-input",
 		}],
 		"title": "avoid-importing-input",
 		"location": {

--- a/bundle/regal/rules/imports/circular-import/circular_import.rego
+++ b/bundle/regal/rules/imports/circular-import/circular_import.rego
@@ -1,10 +1,10 @@
 # METADATA
 # description: Circular import
 # related_resources:
-# - description: documentation
-#   ref: https://www.openpolicyagent.org/projects/regal/rules/imports/circular-import
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/imports/circular-import
 # schemas:
-# - input: schema.regal.ast
+#   - input: schema.regal.ast
 package regal.rules.imports["circular-import"]
 
 import data.regal.ast

--- a/bundle/regal/rules/imports/circular-import/circular_import_test.rego
+++ b/bundle/regal/rules/imports/circular-import/circular_import_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.imports["circular-import_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.imports["circular-import"] as rule
 
@@ -153,7 +152,7 @@ test_aggregate_report_fails_when_cycle_present if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/circular-import", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/circular-import",
 		}],
 		"title": "circular-import",
 	}}
@@ -179,7 +178,7 @@ test_aggregate_report_fails_when_cycle_present_in_1_package if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/circular-import", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/circular-import",
 		}],
 		"title": "circular-import",
 	}}
@@ -216,7 +215,7 @@ test_aggregate_report_fails_when_cycle_present_in_n_packages if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/circular-import", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/circular-import",
 		}],
 		"title": "circular-import",
 	}}

--- a/bundle/regal/rules/imports/confusing-alias/confusing_alias.rego
+++ b/bundle/regal/rules/imports/confusing-alias/confusing_alias.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Confusing alias of existing import
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/imports/confusing-alias
 package regal.rules.imports["confusing-alias"]
 
 import data.regal.ast

--- a/bundle/regal/rules/imports/confusing-alias/confusing_alias_test.rego
+++ b/bundle/regal/rules/imports/confusing-alias/confusing_alias_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.imports["confusing-alias_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.imports["confusing-alias"] as rule
 
@@ -72,7 +71,7 @@ violation_with_location(location) := {
 	"location": location,
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/confusing-alias", "imports"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/confusing-alias",
 	}],
 	"title": "confusing-alias",
 }

--- a/bundle/regal/rules/imports/ignored-import/ignored_import.rego
+++ b/bundle/regal/rules/imports/ignored-import/ignored_import.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Reference ignores import
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/imports/ignored-import
 package regal.rules.imports["ignored-import"]
 
 import data.regal.ast

--- a/bundle/regal/rules/imports/ignored-import/ignored_import_test.rego
+++ b/bundle/regal/rules/imports/ignored-import/ignored_import_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.imports["ignored-import_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.imports["ignored-import"] as rule
 
@@ -29,7 +28,7 @@ test_fail_ignored_import if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/ignored-import", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/ignored-import",
 		}],
 		"title": "ignored-import",
 	}}
@@ -60,7 +59,7 @@ test_fail_ignored_most_specific_import if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/ignored-import", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/ignored-import",
 		}],
 		"title": "ignored-import",
 	}}

--- a/bundle/regal/rules/imports/implicit-future-keywords/implicit_future_keywords.rego
+++ b/bundle/regal/rules/imports/implicit-future-keywords/implicit_future_keywords.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Use explicit future keyword imports
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/imports/implicit-future-keywords
 package regal.rules.imports["implicit-future-keywords"]
 
 import data.regal.config

--- a/bundle/regal/rules/imports/implicit-future-keywords/implicit_future_keywords_test.rego
+++ b/bundle/regal/rules/imports/implicit-future-keywords/implicit_future_keywords_test.rego
@@ -12,7 +12,7 @@ test_fail_future_keywords_import_wildcard if {
 		"description": "Use explicit future keyword imports",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/implicit-future-keywords", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/implicit-future-keywords",
 		}],
 		"title": "implicit-future-keywords",
 		"location": {

--- a/bundle/regal/rules/imports/import-after-rule/import_after_rule.rego
+++ b/bundle/regal/rules/imports/import-after-rule/import_after_rule.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Import declared after rule
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/imports/import-after-rule
 package regal.rules.imports["import-after-rule"]
 
 import data.regal.result

--- a/bundle/regal/rules/imports/import-after-rule/import_after_rule_test.rego
+++ b/bundle/regal/rules/imports/import-after-rule/import_after_rule_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.imports["import-after-rule_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.imports["import-after-rule"] as rule
 
@@ -29,7 +28,7 @@ test_fail_import_after_rule if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/import-after-rule", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/import-after-rule",
 		}],
 		"title": "import-after-rule",
 	}}

--- a/bundle/regal/rules/imports/import-shadows-builtin/import_shadows_builtin.rego
+++ b/bundle/regal/rules/imports/import-shadows-builtin/import_shadows_builtin.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Import shadows built-in namespace
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/imports/import-shadows-builtin
 package regal.rules.imports["import-shadows-builtin"]
 
 import data.regal.ast

--- a/bundle/regal/rules/imports/import-shadows-builtin/import_shadows_builtin_test.rego
+++ b/bundle/regal/rules/imports/import-shadows-builtin/import_shadows_builtin_test.rego
@@ -26,7 +26,7 @@ test_fail_import_shadows_builtin_name if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/import-shadows-builtin", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/import-shadows-builtin",
 		}],
 		"title": "import-shadows-builtin",
 	}}
@@ -52,7 +52,7 @@ test_fail_import_shadows_builtin_namespace if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/import-shadows-builtin", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/import-shadows-builtin",
 		}],
 		"title": "import-shadows-builtin",
 	}}

--- a/bundle/regal/rules/imports/import-shadows-import/import_shadows_import.rego
+++ b/bundle/regal/rules/imports/import-shadows-import/import_shadows_import.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Import shadows another import
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/imports/import-shadows-import
 package regal.rules.imports["import-shadows-import"]
 
 import data.regal.capabilities

--- a/bundle/regal/rules/imports/import-shadows-import/import_shadows_import_test.rego
+++ b/bundle/regal/rules/imports/import-shadows-import/import_shadows_import_test.rego
@@ -1,7 +1,7 @@
 package regal.rules.imports["import-shadows-import_test"]
 
 import data.regal.ast
-import data.regal.config
+
 import data.regal.rules.imports["import-shadows-import"] as rule
 
 test_fail_duplicate_import if {
@@ -15,7 +15,7 @@ import data.foo
 		"description": "Import shadows another import",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/import-shadows-import", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/import-shadows-import",
 		}],
 		"title": "import-shadows-import",
 		"location": {
@@ -43,7 +43,7 @@ import data.bar as foo
 		"description": "Import shadows another import",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/import-shadows-import", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/import-shadows-import",
 		}],
 		"title": "import-shadows-import",
 		"location": {

--- a/bundle/regal/rules/imports/pointless-import/pointless_import.rego
+++ b/bundle/regal/rules/imports/pointless-import/pointless_import.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Importing own package is pointless
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/imports/pointless-import
 package regal.rules.imports["pointless-import"]
 
 import data.regal.ast

--- a/bundle/regal/rules/imports/pointless-import/pointless_import_test.rego
+++ b/bundle/regal/rules/imports/pointless-import/pointless_import_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.imports["pointless-import_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.imports["pointless-import"] as rule
 
@@ -24,7 +23,7 @@ test_fail_pointless_import_of_same_package if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/pointless-import", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/pointless-import",
 		}],
 		"title": "pointless-import",
 	}}
@@ -38,7 +37,7 @@ test_success_external_ref_not_flagged if {
 
 test_success_ref_defined_in_module_flagged if {
 	r := rule.report with input as ast.policy(`import data.policy.a.b.c
-	
+
 	a.b.c := 1
 	`)
 
@@ -66,7 +65,7 @@ test_success_ref_defined_in_module_flagged if {
 
 test_success_ref_prefix_defined_in_module_flagged if {
 	r := rule.report with input as ast.policy(`import data.policy.a.b
-	
+
 	a.b.c := 1`)
 
 	r == {{

--- a/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports.rego
+++ b/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Prefer importing packages over rules
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/imports/prefer-package-imports
 package regal.rules.imports["prefer-package-imports"]
 
 import data.regal.ast

--- a/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports_test.rego
+++ b/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports_test.rego
@@ -53,7 +53,7 @@ test_fail_aggregate_report_on_imported_rule if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/prefer-package-imports", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/prefer-package-imports",
 		}],
 		"title": "prefer-package-imports",
 	}}

--- a/bundle/regal/rules/imports/redundant-alias/redundant_alias.rego
+++ b/bundle/regal/rules/imports/redundant-alias/redundant_alias.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Redundant alias
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/imports/redundant-alias
 package regal.rules.imports["redundant-alias"]
 
 import data.regal.result

--- a/bundle/regal/rules/imports/redundant-alias/redundant_alias_test.rego
+++ b/bundle/regal/rules/imports/redundant-alias/redundant_alias_test.rego
@@ -1,7 +1,7 @@
 package regal.rules.imports["redundant-alias_test"]
 
 import data.regal.ast
-import data.regal.config
+
 import data.regal.rules.imports["redundant-alias"] as rule
 
 test_fail_redundant_alias if {
@@ -12,7 +12,7 @@ test_fail_redundant_alias if {
 		"description": "Redundant alias",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-alias", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/redundant-alias",
 		}],
 		"title": "redundant-alias",
 		"location": {

--- a/bundle/regal/rules/imports/redundant-data-import/redundant_data_import.rego
+++ b/bundle/regal/rules/imports/redundant-data-import/redundant_data_import.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Redundant import of data
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/imports/redundant-data-import
 package regal.rules.imports["redundant-data-import"]
 
 import data.regal.result

--- a/bundle/regal/rules/imports/redundant-data-import/redundant_data_import_test.rego
+++ b/bundle/regal/rules/imports/redundant-data-import/redundant_data_import_test.rego
@@ -1,7 +1,7 @@
 package regal.rules.imports["redundant-data-import_test"]
 
 import data.regal.ast
-import data.regal.config
+
 import data.regal.rules.imports["redundant-data-import"] as rule
 
 test_fail_import_data if {
@@ -12,7 +12,7 @@ test_fail_import_data if {
 		"description": "Redundant import of data",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-data-import", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/redundant-data-import",
 		}],
 		"title": "redundant-data-import",
 		"location": {
@@ -37,7 +37,7 @@ test_fail_import_data_aliased if {
 		"description": "Redundant import of data",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-data-import", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/redundant-data-import",
 		}],
 		"title": "redundant-data-import",
 		"location": {

--- a/bundle/regal/rules/imports/unresolved-import/unresolved_import.rego
+++ b/bundle/regal/rules/imports/unresolved-import/unresolved_import.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Unresolved import
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/imports/unresolved-import
 package regal.rules.imports["unresolved-import"]
 
 import data.regal.ast

--- a/bundle/regal/rules/imports/unresolved-import/unresolved_import_test.rego
+++ b/bundle/regal/rules/imports/unresolved-import/unresolved_import_test.rego
@@ -178,7 +178,7 @@ with_location(location) := {
 	"location": location,
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/unresolved-import", "imports"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/unresolved-import",
 	}],
 	"title": "unresolved-import",
 }

--- a/bundle/regal/rules/imports/unresolved-reference/unresolved_reference.rego
+++ b/bundle/regal/rules/imports/unresolved-reference/unresolved_reference.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Unresolved Reference
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/imports/unresolved-reference
 package regal.rules.imports["unresolved-reference"]
 
 import data.regal.ast

--- a/bundle/regal/rules/imports/unresolved-reference/unresolved_reference_test.rego
+++ b/bundle/regal/rules/imports/unresolved-reference/unresolved_reference_test.rego
@@ -310,7 +310,7 @@ with_location(location) := {
 	# "location": location,
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/unresolved-reference", "imports"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/unresolved-reference",
 	}],
 	"title": "unresolved-reference",
 }

--- a/bundle/regal/rules/imports/use-rego-v1/use_rego_v1.rego
+++ b/bundle/regal/rules/imports/use-rego-v1/use_rego_v1.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Use `import rego.v1`
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/imports/use-rego-v1
 package regal.rules.imports["use-rego-v1"]
 
 import data.regal.ast

--- a/bundle/regal/rules/imports/use-rego-v1/use_rego_v1_test.rego
+++ b/bundle/regal/rules/imports/use-rego-v1/use_rego_v1_test.rego
@@ -17,7 +17,7 @@ test_fail_missing_rego_v1_import if {
 		"description": "Use `import rego.v1`",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-rego-v1", "imports"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/use-rego-v1",
 		}],
 		"title": "use-rego-v1",
 		"location": {

--- a/bundle/regal/rules/performance/defer-assignment/defer_assignment.rego
+++ b/bundle/regal/rules/performance/defer-assignment/defer_assignment.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Assignment can be deferred
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/performance/defer-assignment
 package regal.rules.performance["defer-assignment"]
 
 import data.regal.ast

--- a/bundle/regal/rules/performance/defer-assignment/defer_assignment_test.rego
+++ b/bundle/regal/rules/performance/defer-assignment/defer_assignment_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.performance["defer-assignment_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.performance["defer-assignment"] as rule
 
@@ -172,7 +171,7 @@ with_location(location) := {
 	"location": location,
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/defer-assignment", "performance"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/performance/defer-assignment",
 	}],
 	"title": "defer-assignment",
 }

--- a/bundle/regal/rules/performance/equals-over-count/equals_over_count.rego
+++ b/bundle/regal/rules/performance/equals-over-count/equals_over_count.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Prefer direct use of `==`/`!=` over `count` to check for empty collections
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/performance/equals-over-count
 package regal.rules.performance["equals-over-count"]
 
 import data.regal.ast

--- a/bundle/regal/rules/performance/equals-over-count/equals_over_count_test.rego
+++ b/bundle/regal/rules/performance/equals-over-count/equals_over_count_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.performance["equals-over-count_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.performance["equals-over-count"] as rule
 
@@ -30,7 +29,7 @@ test_fail_count_equals_zero[text] if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/equals-over-count", "performance"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/performance/equals-over-count",
 		}],
 		"title": "equals-over-count",
 	}}

--- a/bundle/regal/rules/performance/non-loop-expression/non_loop_expression.rego
+++ b/bundle/regal/rules/performance/non-loop-expression/non_loop_expression.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Non-loop expression
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/performance/non-loop-expression
 package regal.rules.performance["non-loop-expression"]
 
 import data.regal.ast

--- a/bundle/regal/rules/performance/non-loop-expression/non_loop_expression_test.rego
+++ b/bundle/regal/rules/performance/non-loop-expression/non_loop_expression_test.rego
@@ -1,7 +1,7 @@
 package regal.rules.performance["non-loop-expression_test"]
 
 import data.regal.ast
-import data.regal.config
+
 import data.regal.rules.performance["non-loop-expression"] as rule
 
 test_loop_start_points_walks_are_loops if {
@@ -355,7 +355,7 @@ with_location(location) := {{
 	"description": "Non-loop expression",
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/non-loop-expression", "performance"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/performance/non-loop-expression",
 	}],
 	"title": "non-loop-expression",
 	"location": location,

--- a/bundle/regal/rules/performance/walk-no-path/walk_no_path.rego
+++ b/bundle/regal/rules/performance/walk-no-path/walk_no_path.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Call to `walk` can be optimized
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/performance/walk-no-path
 package regal.rules.performance["walk-no-path"]
 
 import data.regal.ast

--- a/bundle/regal/rules/performance/walk-no-path/walk_no_path_test.rego
+++ b/bundle/regal/rules/performance/walk-no-path/walk_no_path_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.performance["walk-no-path_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.performance["walk-no-path"] as rule
 
@@ -87,7 +86,7 @@ with_location(location) := {
 	"location": location,
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/walk-no-path", "performance"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/performance/walk-no-path",
 	}],
 	"title": "walk-no-path",
 }

--- a/bundle/regal/rules/performance/with-outside-test-context/with_outside_test_context.rego
+++ b/bundle/regal/rules/performance/with-outside-test-context/with_outside_test_context.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: '`with` used outside test context'
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/performance/with-outside-test-context
 package regal.rules.performance["with-outside-test-context"]
 
 import data.regal.ast

--- a/bundle/regal/rules/performance/with-outside-test-context/with_outside_test_context_test.rego
+++ b/bundle/regal/rules/performance/with-outside-test-context/with_outside_test_context_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.performance["with-outside-test-context_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.performance["with-outside-test-context"] as rule
 
@@ -28,7 +27,7 @@ test_fail_with_used_outside_test if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/with-outside-test-context", "performance"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/performance/with-outside-test-context",
 		}],
 		"title": "with-outside-test-context",
 	}}

--- a/bundle/regal/rules/style/avoid-get-and-list-prefix/avoid_get_and_list_prefix.rego
+++ b/bundle/regal/rules/style/avoid-get-and-list-prefix/avoid_get_and_list_prefix.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Avoid `get_` and `list_` prefix for rules and functions
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/avoid-get-and-list-prefix
 package regal.rules.style["avoid-get-and-list-prefix"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/avoid-get-and-list-prefix/avoid_get_and_list_prefix_test.rego
+++ b/bundle/regal/rules/style/avoid-get-and-list-prefix/avoid_get_and_list_prefix_test.rego
@@ -1,7 +1,7 @@
 package regal.rules.style["avoid-get-and-list-prefix_test"]
 
 import data.regal.ast
-import data.regal.config
+
 import data.regal.rules.style["avoid-get-and-list-prefix"] as rule
 
 test_fail_rule_name_starts_with_get if {
@@ -12,7 +12,7 @@ test_fail_rule_name_starts_with_get if {
 		"description": "Avoid `get_` and `list_` prefix for rules and functions",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/avoid-get-and-list-prefix", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/avoid-get-and-list-prefix",
 		}],
 		"title": "avoid-get-and-list-prefix",
 		"location": {
@@ -37,7 +37,7 @@ test_fail_function_name_starts_with_list if {
 		"description": "Avoid `get_` and `list_` prefix for rules and functions",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/avoid-get-and-list-prefix", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/avoid-get-and-list-prefix",
 		}],
 		"title": "avoid-get-and-list-prefix",
 		"location": {

--- a/bundle/regal/rules/style/comprehension-term-assignment/comprehension_term_assignment.rego
+++ b/bundle/regal/rules/style/comprehension-term-assignment/comprehension_term_assignment.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Assigned value can be moved to comprehension term
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/comprehension-term-assignment
 package regal.rules.style["comprehension-term-assignment"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/comprehension-term-assignment/comprehension_term_assignment_test.rego
+++ b/bundle/regal/rules/style/comprehension-term-assignment/comprehension_term_assignment_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.style["comprehension-term-assignment_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.style["comprehension-term-assignment"] as rule
 
@@ -28,7 +27,7 @@ test_fail_comprehension_term_assignment_last_expr if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/comprehension-term-assignment", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/comprehension-term-assignment",
 		}],
 		"title": "comprehension-term-assignment",
 	}}
@@ -46,10 +45,19 @@ test_fail_comprehension_term_assignment_not_last_expr if {
 		"category": "style",
 		"description": "Assigned value can be moved to comprehension term",
 		"level": "error",
-		"location": {"col": 3, "end": {"col": 7, "row": 7}, "file": "policy.rego", "row": 7, "text": "\t\tx := y"},
+		"location": {
+			"col": 3,
+			"end": {
+				"col": 7,
+				"row": 7,
+			},
+			"file": "policy.rego",
+			"row": 7,
+			"text": "\t\tx := y",
+		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/comprehension-term-assignment", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/comprehension-term-assignment",
 		}],
 		"title": "comprehension-term-assignment",
 	}}
@@ -68,14 +76,17 @@ test_fail_comprehension_term_assignment_static_ref if {
 		"level": "error",
 		"location": {
 			"col": 3,
-			"end": {"col": 7, "row": 7},
+			"end": {
+				"col": 7,
+				"row": 7,
+			},
 			"file": "policy.rego",
 			"row": 7,
 			"text": "\t\tx := y.attribute",
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/comprehension-term-assignment", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/comprehension-term-assignment",
 		}],
 		"title": "comprehension-term-assignment",
 	}}
@@ -94,13 +105,17 @@ test_fail_object_comprehension_key_assignment_static_ref if {
 		"level": "error",
 		"location": {
 			"col": 3,
-			"end": {"col": 7, "row": 7},
+			"end": {
+				"col": 7,
+				"row": 7,
+			},
 			"file": "policy.rego",
-			"row": 7, "text": "\t\tk := y.attribute",
+			"row": 7,
+			"text": "\t\tk := y.attribute",
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/comprehension-term-assignment", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/comprehension-term-assignment",
 		}],
 		"title": "comprehension-term-assignment",
 	}}
@@ -119,13 +134,17 @@ test_fail_object_comprehension_value_assignment_static_ref if {
 		"level": "error",
 		"location": {
 			"col": 3,
-			"end": {"col": 7, "row": 7},
+			"end": {
+				"col": 7,
+				"row": 7,
+			},
 			"file": "policy.rego",
-			"row": 7, "text": "\t\tv := y.attribute",
+			"row": 7,
+			"text": "\t\tv := y.attribute",
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/comprehension-term-assignment", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/comprehension-term-assignment",
 		}],
 		"title": "comprehension-term-assignment",
 	}}

--- a/bundle/regal/rules/style/default-over-else/default_over_else.rego
+++ b/bundle/regal/rules/style/default-over-else/default_over_else.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Prefer default assignment over fallback else
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/default-over-else
 package regal.rules.style["default-over-else"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/default-over-else/default_over_else_test.rego
+++ b/bundle/regal/rules/style/default-over-else/default_over_else_test.rego
@@ -122,7 +122,7 @@ with_location(location) := {{
 	"location": location,
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/default-over-else", "style"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/default-over-else",
 	}],
 	"title": "default-over-else",
 }}

--- a/bundle/regal/rules/style/default-over-not/default_over_not.rego
+++ b/bundle/regal/rules/style/default-over-not/default_over_not.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Prefer default assignment over negated condition
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/default-over-not
 package regal.rules.style["default-over-not"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/default-over-not/default_over_not_test.rego
+++ b/bundle/regal/rules/style/default-over-not/default_over_not_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.style["default-over-not_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.style["default-over-not"] as rule
 
@@ -27,7 +26,7 @@ test_fail_default_over_not if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/default-over-not", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/default-over-not",
 		}],
 		"title": "default-over-not",
 	}}

--- a/bundle/regal/rules/style/detached-metadata/detached_metadata.rego
+++ b/bundle/regal/rules/style/detached-metadata/detached_metadata.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Detached metadata annotation
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/detached-metadata
 package regal.rules.style["detached-metadata"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/detached-metadata/detached_metadata_test.rego
+++ b/bundle/regal/rules/style/detached-metadata/detached_metadata_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.style["detached-metadata_test"]
 
 import data.regal.ast
-import data.regal.config
 import data.regal.rules.style["detached-metadata"] as rule
 
 test_fail_detached_metadata if {
@@ -30,7 +29,7 @@ allow := true
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/detached-metadata", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/detached-metadata",
 		}],
 		"title": "detached-metadata",
 	}}
@@ -63,7 +62,7 @@ allow := true
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/detached-metadata", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/detached-metadata",
 		}],
 		"title": "detached-metadata",
 	}}
@@ -132,7 +131,7 @@ package p
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/detached-metadata", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/detached-metadata",
 		}],
 		"title": "detached-metadata",
 	}}

--- a/bundle/regal/rules/style/double-negative/double_negative.rego
+++ b/bundle/regal/rules/style/double-negative/double_negative.rego
@@ -1,10 +1,10 @@
 # METADATA
 # description: Avoid double negatives
 # related_resources:
-# - description: documentation
-#   ref: https://www.openpolicyagent.org/projects/regal/rules/style/double-negative
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/double-negative
 # schemas:
-# - input: schema.regal.ast
+#   - input: schema.regal.ast
 package regal.rules.style["double-negative"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/double-negative/double_negative_test.rego
+++ b/bundle/regal/rules/style/double-negative/double_negative_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.style["double-negative_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.style["double-negative"] as rule
 
@@ -28,7 +27,7 @@ test_fail_double_negative if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/double-negative", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/double-negative",
 		}],
 		"title": "double-negative",
 		"level": "error",

--- a/bundle/regal/rules/style/external-reference/external_reference.rego
+++ b/bundle/regal/rules/style/external-reference/external_reference.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: External reference in function
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/external-reference
 package regal.rules.style["external-reference"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/external-reference/external_reference_test.rego
+++ b/bundle/regal/rules/style/external-reference/external_reference_test.rego
@@ -193,7 +193,7 @@ test_external_references_max_allowed_configuration if {
 		data.x
 		data.y
 		data.z
-		data.a 
+		data.a
 	}`)
 
 	r1 := rule.report with input as module
@@ -225,7 +225,7 @@ expected := {
 	"description": "External reference in function",
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/external-reference", "style"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/external-reference",
 	}],
 	"title": "external-reference",
 	"level": "error",

--- a/bundle/regal/rules/style/file-length/file_length.rego
+++ b/bundle/regal/rules/style/file-length/file_length.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Max file length exceeded
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/file-length
 package regal.rules.style["file-length"]
 
 import data.regal.config

--- a/bundle/regal/rules/style/file-length/file_length_test.rego
+++ b/bundle/regal/rules/style/file-length/file_length_test.rego
@@ -29,7 +29,7 @@ test_fail_configured_file_length_exceeded if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/file-length", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/file-length",
 		}],
 		"title": "file-length",
 	}}

--- a/bundle/regal/rules/style/function-arg-return/function_arg_return.rego
+++ b/bundle/regal/rules/style/function-arg-return/function_arg_return.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Function argument used for return value
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/function-arg-return
 package regal.rules.style["function-arg-return"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/function-arg-return/function_arg_return_test.rego
+++ b/bundle/regal/rules/style/function-arg-return/function_arg_return_test.rego
@@ -25,7 +25,7 @@ test_fail_function_arg_return_value if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/function-arg-return", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/function-arg-return",
 		}],
 		"title": "function-arg-return",
 	}}
@@ -51,7 +51,7 @@ test_fail_function_arg_return_value_multi_part_ref if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/function-arg-return", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/function-arg-return",
 		}],
 		"title": "function-arg-return",
 	}}

--- a/bundle/regal/rules/style/line-length/line_length.rego
+++ b/bundle/regal/rules/style/line-length/line_length.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Line too long
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/line-length
 package regal.rules.style["line-length"]
 
 import data.regal.config

--- a/bundle/regal/rules/style/line-length/line_length_test.rego
+++ b/bundle/regal/rules/style/line-length/line_length_test.rego
@@ -15,7 +15,7 @@ foo == bar; bar == baz; [a, b, c, d, e, f] := [1, 2, 3, 4, 5, 6]; qux := [q | so
 		"description": "Line too long",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/line-length", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/line-length",
 		}],
 		"title": "line-length",
 		"location": {
@@ -23,7 +23,10 @@ foo == bar; bar == baz; [a, b, c, d, e, f] := [1, 2, 3, 4, 5, 6]; qux := [q | so
 			"file": "policy.rego",
 			"row": 6,
 			"text": `foo == bar; bar == baz; [a, b, c, d, e, f] := [1, 2, 3, 4, 5, 6]; qux := [q | some q in input.nonsense]`,
-			"end": {"col": 103, "row": 6},
+			"end": {
+				"col": 103,
+				"row": 6,
+			},
 		},
 		"level": "error",
 	}}
@@ -57,11 +60,14 @@ test_fail_line_too_long_but_below_breakable_word_threshold if {
 			"file": "policy.rego",
 			"row": 7,
 			"text": "\t# Long url: https://www.example.com/this/is/a/very/long",
-			"end": {"col": 56, "row": 7},
+			"end": {
+				"col": 56,
+				"row": 7,
+			},
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/line-length", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/line-length",
 		}],
 		"title": "line-length",
 	}}
@@ -83,11 +89,14 @@ test_fail_line_exceeds_120_characters_even_if_not_in_config if {
 			"row": 5,
 			# regal ignore:line-length
 			"text": "# Long url: https://www.example.com/this/is/a/very/long/url/that/cannot/be/shortened/and/should/trigger/an/error/anyway/so/that/it/can/be/shortened",
-			"end": {"col": 147, "row": 5},
+			"end": {
+				"col": 147,
+				"row": 5,
+			},
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/line-length", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/line-length",
 		}],
 		"title": "line-length",
 	}}

--- a/bundle/regal/rules/style/messy-rule/messy_rule.rego
+++ b/bundle/regal/rules/style/messy-rule/messy_rule.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Messy incremental rule
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/messy-rule
 package regal.rules.style["messy-rule"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/messy-rule/messy_rule_test.rego
+++ b/bundle/regal/rules/style/messy-rule/messy_rule_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.style["messy-rule_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.style["messy-rule"] as rule
 
@@ -144,7 +143,7 @@ expected := {
 	"level": "error",
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/messy-rule", "style"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/messy-rule",
 	}],
 	"title": "messy-rule",
 	"location": {"file": "policy.rego"},

--- a/bundle/regal/rules/style/mixed-iteration/mixed_iteration.rego
+++ b/bundle/regal/rules/style/mixed-iteration/mixed_iteration.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Mixed iteration style
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/mixed-iteration
 package regal.rules.style["mixed-iteration"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/mixed-iteration/mixed_iteration_test.rego
+++ b/bundle/regal/rules/style/mixed-iteration/mixed_iteration_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.style["mixed-iteration_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.style["mixed-iteration"] as rule
 
@@ -24,7 +23,7 @@ test_fail_mixed_iteration if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/mixed-iteration", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/mixed-iteration",
 		}],
 		"title": "mixed-iteration",
 	}}
@@ -49,7 +48,7 @@ test_fail_mixed_iteration_nested if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/mixed-iteration", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/mixed-iteration",
 		}],
 		"title": "mixed-iteration",
 	}}

--- a/bundle/regal/rules/style/no-whitespace-comment/no_whitespace_comment.rego
+++ b/bundle/regal/rules/style/no-whitespace-comment/no_whitespace_comment.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Comment should start with whitespace
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/no-whitespace-comment
 package regal.rules.style["no-whitespace-comment"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/no-whitespace-comment/no_whitespace_comment_test.rego
+++ b/bundle/regal/rules/style/no-whitespace-comment/no_whitespace_comment_test.rego
@@ -12,7 +12,7 @@ test_fail_no_leading_whitespace if {
 		"description": "Comment should start with whitespace",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/no-whitespace-comment", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/no-whitespace-comment",
 		}],
 		"title": "no-whitespace-comment",
 		"location": {
@@ -39,7 +39,7 @@ test_fail_comments_after_shebang if {
 		"description": "Comment should start with whitespace",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/no-whitespace-comment", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/no-whitespace-comment",
 		}],
 		"title": "no-whitespace-comment",
 		"location": {
@@ -67,7 +67,7 @@ test_fail_shebang_in_body if {
 		"description": "Comment should start with whitespace",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/no-whitespace-comment", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/no-whitespace-comment",
 		}],
 		"title": "no-whitespace-comment",
 		"location": {
@@ -92,7 +92,7 @@ test_fail_no_leading_whitespace_multiple_hashes if {
 		"description": "Comment should start with whitespace",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/no-whitespace-comment", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/no-whitespace-comment",
 		}],
 		"title": "no-whitespace-comment",
 		"location": {

--- a/bundle/regal/rules/style/opa-fmt/opa_fmt.rego
+++ b/bundle/regal/rules/style/opa-fmt/opa_fmt.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: File should be formatted with `opa fmt`
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/opa-fmt
 package regal.rules.style["opa-fmt"]
 
 import data.regal.result

--- a/bundle/regal/rules/style/opa-fmt/opa_fmt_test.rego
+++ b/bundle/regal/rules/style/opa-fmt/opa_fmt_test.rego
@@ -1,6 +1,5 @@
 package regal.rules.style["opa-fmt_test"]
 
-import data.regal.config
 import data.regal.rules.style["opa-fmt"] as rule
 
 test_fail_not_formatted if {
@@ -19,7 +18,7 @@ test_fail_not_formatted if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/opa-fmt", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/opa-fmt",
 		}],
 		"title": "opa-fmt",
 	}}
@@ -48,7 +47,7 @@ test_fail_v0_required_but_v1_policy if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/opa-fmt", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/opa-fmt",
 		}],
 		"title": "opa-fmt",
 	}}

--- a/bundle/regal/rules/style/pointless-reassignment/pointless_reassignment.rego
+++ b/bundle/regal/rules/style/pointless-reassignment/pointless_reassignment.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Pointless reassignment of variable
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/pointless-reassignment
 package regal.rules.style["pointless-reassignment"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/pointless-reassignment/pointless_reassignment_test.rego
+++ b/bundle/regal/rules/style/pointless-reassignment/pointless_reassignment_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.style["pointless-reassignment_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.style["pointless-reassignment"] as rule
 
@@ -29,7 +28,7 @@ test_fail_pointless_reassignment_in_rule_head if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/pointless-reassignment", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/pointless-reassignment",
 		}],
 		"title": "pointless-reassignment",
 	}}
@@ -61,7 +60,7 @@ test_fail_pointless_reassignment_in_rule_body if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/pointless-reassignment", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/pointless-reassignment",
 		}],
 		"title": "pointless-reassignment",
 	}}
@@ -95,7 +94,7 @@ test_fail_pointless_reassignment_in_rule_body_nested if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/pointless-reassignment", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/pointless-reassignment",
 		}],
 		"title": "pointless-reassignment",
 	}}

--- a/bundle/regal/rules/style/prefer-snake-case/prefer_snake_case.rego
+++ b/bundle/regal/rules/style/prefer-snake-case/prefer_snake_case.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Prefer snake_case for names
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/prefer-snake-case
 package regal.rules.style["prefer-snake-case"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/prefer-snake-case/prefer_snake_case_test.rego
+++ b/bundle/regal/rules/style/prefer-snake-case/prefer_snake_case_test.rego
@@ -1,7 +1,7 @@
 package regal.rules.style["prefer-snake-case_test"]
 
 import data.regal.ast
-import data.regal.config
+
 import data.regal.rules.style["prefer-snake-case"] as rule
 
 test_fail_camel_cased_rule_name if {
@@ -11,7 +11,10 @@ test_fail_camel_cased_rule_name if {
 		"file": "policy.rego",
 		"row": 3,
 		"text": `camelCase := 5`,
-		"end": {"col": 10, "row": 3},
+		"end": {
+			"col": 10,
+			"row": 3,
+		},
 	}])
 }
 
@@ -46,7 +49,10 @@ test_fail_camel_cased_some_declaration if {
 		"file": "policy.rego",
 		"row": 3,
 		"text": `p if {some fooBar; input[_]}`,
-		"end": {"col": 18, "row": 3},
+		"end": {
+			"col": 18,
+			"row": 3,
+		},
 	}])
 }
 
@@ -64,7 +70,10 @@ test_fail_camel_cased_multiple_some_declaration if {
 		"file": "policy.rego",
 		"row": 6,
 		"text": "\t\tsome x, foo_bar, fooBar; x = 1; foo_bar = 2; input[_]",
-		"end": {"col": 26, "row": 6},
+		"end": {
+			"col": 26,
+			"row": 6,
+		},
 	}])
 }
 
@@ -80,7 +89,10 @@ test_fail_camel_cased_function_argument if {
 		"file": "policy.rego",
 		"row": 5,
 		"text": "f(fooBar) := fooBar",
-		"end": {"col": 9, "row": 5},
+		"end": {
+			"col": 9,
+			"row": 5,
+		},
 	}])
 }
 
@@ -97,7 +109,10 @@ test_fail_camel_cased_var_assignment if {
 		"file": "policy.rego",
 		"row": 3,
 		"text": `allow if { camelCase := 5 }`,
-		"end": {"col": 21, "row": 3},
+		"end": {
+			"col": 21,
+			"row": 3,
+		},
 	}])
 }
 
@@ -109,7 +124,10 @@ test_fail_camel_cased_multiple_var_assignment if {
 		"file": "policy.rego",
 		"row": 3,
 		"text": `allow if { snake_case := "foo"; camelCase := 5 }`,
-		"end": {"col": 42, "row": 3},
+		"end": {
+			"col": 42,
+			"row": 3,
+		},
 	}])
 }
 
@@ -125,7 +143,10 @@ test_fail_camel_cased_some_in_value if {
 		"file": "policy.rego",
 		"row": 5,
 		"text": `allow if { some cC in input }`,
-		"end": {"col": 19, "row": 5},
+		"end": {
+			"col": 19,
+			"row": 5,
+		},
 	}])
 }
 
@@ -136,7 +157,10 @@ test_fail_camel_cased_some_in_key_value if {
 		"file": "policy.rego",
 		"row": 5,
 		"text": `allow if { some cC, sc in input }`,
-		"end": {"col": 19, "row": 5},
+		"end": {
+			"col": 19,
+			"row": 5,
+		},
 	}])
 }
 
@@ -147,7 +171,10 @@ test_fail_camel_cased_some_in_key_value_2 if {
 		"file": "policy.rego",
 		"row": 5,
 		"text": `allow if { some sc, cC in input }`,
-		"end": {"col": 23, "row": 5},
+		"end": {
+			"col": 23,
+			"row": 5,
+		},
 	}])
 }
 
@@ -163,7 +190,10 @@ test_fail_camel_cased_every_value if {
 		"file": "policy.rego",
 		"row": 5,
 		"text": `allow if { every cC in input { cC == 1 } }`,
-		"end": {"col": 20, "row": 5},
+		"end": {
+			"col": 20,
+			"row": 5,
+		},
 	}])
 }
 
@@ -174,7 +204,10 @@ test_fail_camel_cased_every_key if {
 		"file": "policy.rego",
 		"row": 5,
 		"text": `allow if { every cC, sc in input { cC == 1; sc == 2 } }`,
-		"end": {"col": 20, "row": 5},
+		"end": {
+			"col": 20,
+			"row": 5,
+		},
 	}])
 }
 
@@ -190,7 +223,10 @@ test_fail_location_provided_even_when_not_in_ref if {
 		"file": "policy.rego",
 		"row": 5,
 		"text": "foo.Bar := true",
-		"end": {"col": 8, "row": 5},
+		"end": {
+			"col": 8,
+			"row": 5,
+		},
 	}])
 }
 
@@ -200,7 +236,7 @@ expected_with_locations(locations) := {with_location |
 		"description": "Prefer snake_case for names",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/prefer-snake-case", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/prefer-snake-case",
 		}],
 		"title": "prefer-snake-case",
 		"level": "error",

--- a/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration.rego
+++ b/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Prefer `some .. in` for iteration
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/prefer-some-in-iteration
 package regal.rules.style["prefer-some-in-iteration"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration_test.rego
+++ b/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration_test.rego
@@ -316,7 +316,7 @@ with_location(location) := {{
 	"location": location,
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/prefer-some-in-iteration", "style"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/prefer-some-in-iteration",
 	}],
 	"title": "prefer-some-in-iteration",
 }}

--- a/bundle/regal/rules/style/rule-length/rule_length.rego
+++ b/bundle/regal/rules/style/rule-length/rule_length.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Max rule length exceeded
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/rule-length
 package regal.rules.style["rule-length"]
 
 import data.regal.config

--- a/bundle/regal/rules/style/rule-length/rule_length_test.rego
+++ b/bundle/regal/rules/style/rule-length/rule_length_test.rego
@@ -36,7 +36,7 @@ test_fail_rule_longer_than_configured_max_length if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/rule-length", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/rule-length",
 		}],
 		"title": "rule-length",
 	}}

--- a/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package_test.rego
+++ b/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package_test.rego
@@ -57,14 +57,20 @@ test_rule_violation_if_repetition_of_more_than_one_path_component if {
 		object.union(base_result, {"location": {
 			"row": 2,
 			"col": 5,
-			"end": {"col": 16, "row": 2},
+			"end": {
+				"col": 16,
+				"row": 2,
+			},
 			"file": "example.rego",
 			"text": "    foo_bar_baz := true",
 		}}),
 		object.union(base_result, {"location": {
 			"row": 4,
 			"col": 5,
-			"end": {"col": 11, "row": 4},
+			"end": {
+				"col": 11,
+				"row": 4,
+			},
 			"file": "example.rego",
 			"text": "    barBaz := 1",
 		}}),
@@ -85,21 +91,30 @@ test_rule_violation_if_repetition_multiple if {
 			"col": 5,
 			"file": "example.rego",
 			"row": 4,
-			"end": {"col": 8, "row": 4},
+			"end": {
+				"col": 8,
+				"row": 4,
+			},
 			"text": "    bar := true",
 		}}),
 		object.union(base_result, {"location": {
 			"col": 5,
 			"file": "example.rego",
 			"row": 5,
-			"end": {"col": 14, "row": 5},
+			"end": {
+				"col": 14,
+				"row": 5,
+			},
 			"text": "    barNumber := 3",
 		}}),
 		object.union(base_result, {"location": {
 			"col": 5,
 			"file": "example.rego",
 			"row": 6,
-			"end": {"col": 14, "row": 6},
+			"end": {
+				"col": 14,
+				"row": 6,
+			},
 			"text": "    barString := \"string\"",
 		}}),
 	}
@@ -118,7 +133,10 @@ test_rule_violation_if_repetition_in_function if {
 			"col": 5,
 			"file": "example.rego",
 			"row": 4,
-			"end": {"col": 8, "row": 4},
+			"end": {
+				"col": 8,
+				"row": 4,
+			},
 			"text": "    bar(_) := true",
 		}},
 	)}
@@ -136,14 +154,20 @@ test_rule_violation_if_repetition_in_defaults if {
 			"col": 13,
 			"file": "example.rego",
 			"row": 3,
-			"end": {"col": 16, "row": 3},
+			"end": {
+				"col": 16,
+				"row": 3,
+			},
 			"text": "    default bar(_) := true",
 		}}),
 		object.union(base_result, {"location": {
 			"col": 13,
 			"file": "example.rego",
 			"row": 4,
-			"end": {"col": 22, "row": 4},
+			"end": {
+				"col": 22,
+				"row": 4,
+			},
 			"text": "    default barNumber := 3",
 		}}),
 	}
@@ -160,7 +184,10 @@ test_rule_violation_if_repetition_ref_head_rule if {
 		"col": 2,
 		"file": "example.rego",
 		"row": 4,
-		"end": {"col": 8, "row": 4},
+		"end": {
+			"col": 8,
+			"row": 4,
+		},
 		"text": "\tpolicy.decision contains \"nope\"",
 	}})}
 }

--- a/bundle/regal/rules/style/todo-comment/todo_comment.rego
+++ b/bundle/regal/rules/style/todo-comment/todo_comment.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Avoid TODO comments
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/todo-comment
 package regal.rules.style["todo-comment"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/todo-comment/todo_comment_test.rego
+++ b/bundle/regal/rules/style/todo-comment/todo_comment_test.rego
@@ -1,7 +1,7 @@
 package regal.rules.style["todo-comment_test"]
 
 import data.regal.ast
-import data.regal.config
+
 import data.regal.rules.style["todo-comment"] as rule
 
 test_fail_todo_comment if {
@@ -12,7 +12,7 @@ test_fail_todo_comment if {
 		"description": "Avoid TODO comments",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/todo-comment", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/todo-comment",
 		}],
 		"title": "todo-comment",
 		"location": {
@@ -37,7 +37,7 @@ test_fail_fixme_comment if {
 		"description": "Avoid TODO comments",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/todo-comment", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/todo-comment",
 		}],
 		"title": "todo-comment",
 		"location": {

--- a/bundle/regal/rules/style/trailing-default-rule/trailing_default_rule.rego
+++ b/bundle/regal/rules/style/trailing-default-rule/trailing_default_rule.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Default rule should be declared first
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/trailing-default-rule
 package regal.rules.style["trailing-default-rule"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/trailing-default-rule/trailing_default_rule_test.rego
+++ b/bundle/regal/rules/style/trailing-default-rule/trailing_default_rule_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.style["trailing-default-rule_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.style["trailing-default-rule"] as rule
 
@@ -40,7 +39,7 @@ test_fail_default_declared_after if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/trailing-default-rule", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/trailing-default-rule",
 		}],
 		"title": "trailing-default-rule",
 	}}

--- a/bundle/regal/rules/style/unconditional-assignment/unconditional_assignment.rego
+++ b/bundle/regal/rules/style/unconditional-assignment/unconditional_assignment.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Unconditional assignment in rule body
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/unconditional-assignment
 package regal.rules.style["unconditional-assignment"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/unconditional-assignment/unconditional_assignment_test.rego
+++ b/bundle/regal/rules/style/unconditional-assignment/unconditional_assignment_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.style["unconditional-assignment_test"]
 
 import data.regal.ast
-import data.regal.config
 import data.regal.rules.style["unconditional-assignment"] as rule
 
 test_fail_unconditional_assignment_in_body if {
@@ -14,7 +13,7 @@ test_fail_unconditional_assignment_in_body if {
 		"description": "Unconditional assignment in rule body",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/unconditional-assignment", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/unconditional-assignment",
 		}],
 		"title": "unconditional-assignment",
 		"location": {
@@ -41,7 +40,7 @@ test_fail_unconditional_eq_in_body if {
 		"description": "Unconditional assignment in rule body",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/unconditional-assignment", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/unconditional-assignment",
 		}],
 		"title": "unconditional-assignment",
 		"location": {
@@ -88,7 +87,7 @@ test_fail_unconditional_multi_value_assignment if {
 		"description": "Unconditional assignment in rule body",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/unconditional-assignment", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/unconditional-assignment",
 		}],
 		"title": "unconditional-assignment",
 		"location": {
@@ -115,7 +114,7 @@ test_fail_unconditional_map_assignment if {
 		"description": "Unconditional assignment in rule body",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/unconditional-assignment", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/unconditional-assignment",
 		}],
 		"title": "unconditional-assignment",
 		"location": {

--- a/bundle/regal/rules/style/unnecessary-some/unnecessary_some.rego
+++ b/bundle/regal/rules/style/unnecessary-some/unnecessary_some.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Unnecessary use of `some`
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/unnecessary-some
 package regal.rules.style["unnecessary-some"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/unnecessary-some/unnecessary_some_test.rego
+++ b/bundle/regal/rules/style/unnecessary-some/unnecessary_some_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.style["unnecessary-some_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.style["unnecessary-some"] as rule
 
@@ -29,7 +28,7 @@ test_fail_some_unnecessary_value if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/unnecessary-some", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/unnecessary-some",
 		}],
 		"title": "unnecessary-some",
 	}}
@@ -54,7 +53,7 @@ test_fail_some_unnecessary_key_value if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/unnecessary-some", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/unnecessary-some",
 		}],
 		"title": "unnecessary-some",
 	}}

--- a/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator.rego
+++ b/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Prefer := over = for assignment
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/use-assignment-operator
 package regal.rules.style["use-assignment-operator"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator_test.rego
+++ b/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.style["use-assignment-operator_test"]
 
 import data.regal.ast
-import data.regal.config
 import data.regal.rules.style["use-assignment-operator"] as rule
 
 test_fail_unification_in_regular_assignment if {
@@ -11,7 +10,7 @@ test_fail_unification_in_regular_assignment if {
 		"description": "Prefer := over = for assignment",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/use-assignment-operator",
 		}],
 		"title": "use-assignment-operator",
 		"location": {
@@ -36,7 +35,7 @@ test_fail_not_implicit_boolean_assignment_with_body if {
 		"description": "Prefer := over = for assignment",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/use-assignment-operator",
 		}],
 		"title": "use-assignment-operator",
 		"location": {
@@ -60,7 +59,7 @@ test_fail_not_implicit_boolean_assignment if {
 		"description": "Prefer := over = for assignment",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/use-assignment-operator",
 		}],
 		"title": "use-assignment-operator",
 		"location": {
@@ -89,7 +88,7 @@ test_fail_unification_in_default_assignment if {
 		"description": "Prefer := over = for assignment",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/use-assignment-operator",
 		}],
 		"title": "use-assignment-operator",
 		"location": {
@@ -113,7 +112,7 @@ test_fail_unification_in_default_function_assignment if {
 		"description": "Prefer := over = for assignment",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/use-assignment-operator",
 		}],
 		"title": "use-assignment-operator",
 		"location": {
@@ -147,7 +146,7 @@ test_fail_unification_in_object_rule_assignment if {
 		"description": "Prefer := over = for assignment",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/use-assignment-operator",
 		}],
 		"title": "use-assignment-operator",
 		"location": {
@@ -176,7 +175,7 @@ test_fail_unification_in_function_assignment if {
 		"description": "Prefer := over = for assignment",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/use-assignment-operator",
 		}],
 		"title": "use-assignment-operator",
 		"location": {
@@ -240,7 +239,7 @@ test_fail_unification_in_else if {
 			"description": "Prefer := over = for assignment",
 			"related_resources": [{
 				"description": "documentation",
-				"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
+				"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/use-assignment-operator",
 			}],
 			"title": "use-assignment-operator",
 			"location": {"col": 9, "file": "policy.rego", "row": 6, "text": "\t} else = true if {", "end": {
@@ -254,7 +253,7 @@ test_fail_unification_in_else if {
 			"description": "Prefer := over = for assignment",
 			"related_resources": [{
 				"description": "documentation",
-				"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
+				"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/use-assignment-operator",
 			}],
 			"title": "use-assignment-operator",
 			"location": {"col": 9, "file": "policy.rego", "row": 8, "text": "\t} else = false", "end": {

--- a/bundle/regal/rules/style/yoda-condition/yoda_condition.rego
+++ b/bundle/regal/rules/style/yoda-condition/yoda_condition.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Yoda condition
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/style/yoda-condition
 package regal.rules.style["yoda-condition"]
 
 import data.regal.ast

--- a/bundle/regal/rules/style/yoda-condition/yoda_condition_test.rego
+++ b/bundle/regal/rules/style/yoda-condition/yoda_condition_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.style["yoda-condition_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.style["yoda-condition"] as rule
 
@@ -17,8 +16,26 @@ test_fail_yoda_conditions if {
 	r := rule.report with input as module
 
 	r == expected_with_location([
-		{"col": 3, "end": {"row": 4, "col": 11}, "file": "policy.rego", "row": 4, "text": "\t\t\"foo\" == input.bar"},
-		{"col": 4, "end": {"row": 8, "col": 12}, "file": "policy.rego", "row": 8, "text": "\t\t\t\"foo\" == foo"},
+		{
+			"col": 3,
+			"end": {
+				"row": 4,
+				"col": 11,
+			},
+			"file": "policy.rego",
+			"row": 4,
+			"text": "\t\t\"foo\" == input.bar",
+		},
+		{
+			"col": 4,
+			"end": {
+				"row": 8,
+				"col": 12,
+			},
+			"file": "policy.rego",
+			"row": 8,
+			"text": "\t\t\t\"foo\" == foo",
+		},
 	])
 }
 
@@ -34,8 +51,26 @@ test_fail_yoda_conditions_not_equals if {
 	r := rule.report with input as module
 
 	r == expected_with_location([
-		{"col": 3, "end": {"col": 11, "row": 4}, "file": "policy.rego", "row": 4, "text": "\t\t\"foo\" != input.bar"},
-		{"col": 4, "end": {"col": 12, "row": 8}, "file": "policy.rego", "row": 8, "text": "\t\t\t\"foo\" != foo"},
+		{
+			"col": 3,
+			"end": {
+				"col": 11,
+				"row": 4,
+			},
+			"file": "policy.rego",
+			"row": 4,
+			"text": "\t\t\"foo\" != input.bar",
+		},
+		{
+			"col": 4,
+			"end": {
+				"col": 12,
+				"row": 8,
+			},
+			"file": "policy.rego",
+			"row": 8,
+			"text": "\t\t\t\"foo\" != foo",
+		},
 	])
 }
 
@@ -49,10 +84,46 @@ test_fail_yoda_conditions_greater_and_less_than if {
 	r := rule.report with input as module
 
 	r == expected_with_location([
-		{"col": 3, "end": {"row": 4, "col": 6}, "file": "policy.rego", "row": 4, "text": "\t\t1 < count(input.bar)"},
-		{"col": 3, "end": {"row": 5, "col": 6}, "file": "policy.rego", "row": 5, "text": "\t\t1 > count(input.bar)"},
-		{"col": 3, "end": {"row": 6, "col": 7}, "file": "policy.rego", "row": 6, "text": "\t\t1 <= count(input.bar)"},
-		{"col": 3, "end": {"row": 7, "col": 7}, "file": "policy.rego", "row": 7, "text": "\t\t1 >= count(input.bar)"},
+		{
+			"col": 3,
+			"end": {
+				"row": 4,
+				"col": 6,
+			},
+			"file": "policy.rego",
+			"row": 4,
+			"text": "\t\t1 < count(input.bar)",
+		},
+		{
+			"col": 3,
+			"end": {
+				"row": 5,
+				"col": 6,
+			},
+			"file": "policy.rego",
+			"row": 5,
+			"text": "\t\t1 > count(input.bar)",
+		},
+		{
+			"col": 3,
+			"end": {
+				"row": 6,
+				"col": 7,
+			},
+			"file": "policy.rego",
+			"row": 6,
+			"text": "\t\t1 <= count(input.bar)",
+		},
+		{
+			"col": 3,
+			"end": {
+				"row": 7,
+				"col": 7,
+			},
+			"file": "policy.rego",
+			"row": 7,
+			"text": "\t\t1 >= count(input.bar)",
+		},
 	])
 }
 
@@ -80,7 +151,7 @@ expected := {
 	"level": "error",
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/yoda-condition", "style"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/style/yoda-condition",
 	}],
 	"title": "yoda-condition",
 }

--- a/bundle/regal/rules/testing/dubious-print-sprintf/dubious_print_sprintf.rego
+++ b/bundle/regal/rules/testing/dubious-print-sprintf/dubious_print_sprintf.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Dubious use of print and sprintf
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/testing/dubious-print-sprintf
 package regal.rules.testing["dubious-print-sprintf"]
 
 import data.regal.ast

--- a/bundle/regal/rules/testing/dubious-print-sprintf/dubious_print_sprintf_test.rego
+++ b/bundle/regal/rules/testing/dubious-print-sprintf/dubious_print_sprintf_test.rego
@@ -28,7 +28,7 @@ test_fail_print_sprintf if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/dubious-print-sprintf", "testing"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/testing/dubious-print-sprintf",
 		}],
 		"title": "dubious-print-sprintf",
 	}}
@@ -59,7 +59,7 @@ test_fail_bodies_print_sprintf if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/dubious-print-sprintf", "testing"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/testing/dubious-print-sprintf",
 		}],
 		"title": "dubious-print-sprintf",
 	}}

--- a/bundle/regal/rules/testing/file-missing-test-suffix/file_missing_test_suffix.rego
+++ b/bundle/regal/rules/testing/file-missing-test-suffix/file_missing_test_suffix.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Files containing tests should have a _test.rego suffix
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/testing/file-missing-test-suffix
 package regal.rules.testing["file-missing-test-suffix"]
 
 import data.regal.ast

--- a/bundle/regal/rules/testing/file-missing-test-suffix/file_missing_test_suffix_test.rego
+++ b/bundle/regal/rules/testing/file-missing-test-suffix/file_missing_test_suffix_test.rego
@@ -1,7 +1,5 @@
 package regal.rules.testing["file-missing-test-suffix_test"]
 
-import data.regal.config
-
 import data.regal.rules.testing["file-missing-test-suffix"] as rule
 
 test_fail_test_in_file_without_test_suffix if {
@@ -16,7 +14,7 @@ test_fail_test_in_file_without_test_suffix if {
 		"description": "Files containing tests should have a _test.rego suffix",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/file-missing-test-suffix", "testing"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/testing/file-missing-test-suffix",
 		}],
 		"title": "file-missing-test-suffix",
 		"location": {"file": "policy.rego"},

--- a/bundle/regal/rules/testing/identically-named-tests/identically_named_tests.rego
+++ b/bundle/regal/rules/testing/identically-named-tests/identically_named_tests.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Multiple tests with same name
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/testing/identically-named-tests
 package regal.rules.testing["identically-named-tests"]
 
 import data.regal.ast

--- a/bundle/regal/rules/testing/identically-named-tests/identically_named_tests_test.rego
+++ b/bundle/regal/rules/testing/identically-named-tests/identically_named_tests_test.rego
@@ -1,6 +1,5 @@
 package regal.rules.testing["identically-named-tests_test"]
 
-import data.regal.config
 import data.regal.rules.testing["identically-named-tests"] as rule
 
 test_fail_identically_named_tests if {
@@ -17,7 +16,7 @@ test_fail_identically_named_tests if {
 		"description": "Multiple tests with same name",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/identically-named-tests", "testing"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/testing/identically-named-tests",
 		}],
 		"title": "identically-named-tests",
 		"location": {

--- a/bundle/regal/rules/testing/metasyntactic-variable/metasyntactic_variable.rego
+++ b/bundle/regal/rules/testing/metasyntactic-variable/metasyntactic_variable.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Metasyntactic variable name
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/testing/metasyntactic-variable
 package regal.rules.testing["metasyntactic-variable"]
 
 import data.regal.ast

--- a/bundle/regal/rules/testing/metasyntactic-variable/metasyntactic_variable_test.rego
+++ b/bundle/regal/rules/testing/metasyntactic-variable/metasyntactic_variable_test.rego
@@ -1,7 +1,6 @@
 package regal.rules.testing["metasyntactic-variable_test"]
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.testing["metasyntactic-variable"] as rule
 
@@ -59,21 +58,30 @@ test_fail_metasyntactic_vars_ref_head_strings if {
 			"file": "policy.rego",
 			"row": 3,
 			"text": "foo.a.BAR.b.C.baz := true",
-			"end": {"col": 4, "row": 3},
+			"end": {
+				"col": 4,
+				"row": 3,
+			},
 		}),
 		expected_with_location({
 			"col": 7,
 			"file": "policy.rego",
 			"row": 3,
 			"text": "foo.a.BAR.b.C.baz := true",
-			"end": {"col": 10, "row": 3},
+			"end": {
+				"col": 10,
+				"row": 3,
+			},
 		}),
 		expected_with_location({
 			"col": 15,
 			"file": "policy.rego",
 			"row": 3,
 			"text": "foo.a.BAR.b.C.baz := true",
-			"end": {"col": 18, "row": 3},
+			"end": {
+				"col": 18,
+				"row": 3,
+			},
 		}),
 	}
 }
@@ -84,7 +92,7 @@ expected := {
 	"level": "error",
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/metasyntactic-variable", "testing"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/testing/metasyntactic-variable",
 	}],
 	"title": "metasyntactic-variable",
 }

--- a/bundle/regal/rules/testing/print-or-trace-call/print_or_trace_call.rego
+++ b/bundle/regal/rules/testing/print-or-trace-call/print_or_trace_call.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Call to print or trace function
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/testing/print-or-trace-call
 package regal.rules.testing["print-or-trace-call"]
 
 import data.regal.ast

--- a/bundle/regal/rules/testing/print-or-trace-call/print_or_trace_call_test.rego
+++ b/bundle/regal/rules/testing/print-or-trace-call/print_or_trace_call_test.rego
@@ -19,14 +19,20 @@ test_fail_call_to_print_and_trace if {
 			"col": 3,
 			"file": "policy.rego",
 			"row": 4,
-			"end": {"col": 8, "row": 4},
+			"end": {
+				"col": 8,
+				"row": 4,
+			},
 			"text": "\t\tprint(\"foo\")",
 		}),
 		expected_with_location({
 			"col": 20,
 			"file": "policy.rego",
 			"row": 6,
-			"end": {"col": 25, "row": 6},
+			"end": {
+				"col": 25,
+				"row": 6,
+			},
 			"text": "\t\tx := [i | i = 0; trace(\"bar\")]",
 		}),
 	}
@@ -39,7 +45,7 @@ expected_with_location(location) := {
 	"location": location,
 	"related_resources": [{
 		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/print-or-trace-call", "testing"),
+		"ref": "https://www.openpolicyagent.org/projects/regal/rules/testing/print-or-trace-call",
 	}],
 	"title": "print-or-trace-call",
 }

--- a/bundle/regal/rules/testing/test-outside-test-package/test_outside_test_package.rego
+++ b/bundle/regal/rules/testing/test-outside-test-package/test_outside_test_package.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: Test outside of test package
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/testing/test-outside-test-package
 package regal.rules.testing["test-outside-test-package"]
 
 import data.regal.ast

--- a/bundle/regal/rules/testing/test-outside-test-package/test_outside_test_package_test.rego
+++ b/bundle/regal/rules/testing/test-outside-test-package/test_outside_test_package_test.rego
@@ -1,7 +1,7 @@
 package regal.rules.testing["test-outside-test-package_test"]
 
 import data.regal.ast
-import data.regal.config
+
 import data.regal.rules.testing["test-outside-test-package"] as rule
 
 test_fail_test_outside_test_package if {
@@ -12,14 +12,17 @@ test_fail_test_outside_test_package if {
 		"description": "Test outside of test package",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/test-outside-test-package", "testing"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/testing/test-outside-test-package",
 		}],
 		"title": "test-outside-test-package",
 		"location": {
 			"col": 1,
 			"file": "p_test.rego",
 			"row": 3,
-			"end": {"col": 9, "row": 3},
+			"end": {
+				"col": 9,
+				"row": 3,
+			},
 			"text": `test_foo if { false }`,
 		},
 		"level": "error",

--- a/bundle/regal/rules/testing/todo-test/todo_test.rego
+++ b/bundle/regal/rules/testing/todo-test/todo_test.rego
@@ -1,5 +1,8 @@
 # METADATA
 # description: TODO test encountered
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/testing/todo-test
 package regal.rules.testing["todo-test"]
 
 import data.regal.ast

--- a/bundle/regal/rules/testing/todo-test/todo_test_test.rego
+++ b/bundle/regal/rules/testing/todo-test/todo_test_test.rego
@@ -1,6 +1,5 @@
 package regal.rules.testing["todo-test_test"]
 
-import data.regal.config
 import data.regal.rules.testing["todo-test"] as rule
 
 test_fail_todo_test if {
@@ -18,7 +17,7 @@ test_fail_todo_test if {
 		"description": "TODO test encountered",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/todo-test", "testing"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/testing/todo-test",
 		}],
 		"title": "todo-test",
 		"location": {

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -327,7 +327,6 @@ func TestCreateNewBuiltinRuleFromTemplate(t *testing.T) {
 		).
 		expectFiles(
 			exists(tmpDir, "bundle/regal/rules/naming/foo-bar-baz/foo_bar_baz.rego"),
-			exists(tmpDir, "bundle/regal/rules/naming/foo-bar-baz/foo_bar_baz.rego"),
 			exists(tmpDir, "bundle/regal/rules/naming/foo-bar-baz/foo_bar_baz_test.rego"),
 			exists(tmpDir, "bundle/regal/config/provided/data.yaml"),
 			exists(tmpDir, "docs/rules/naming/foo-bar-baz.md"),

--- a/internal/embeds/templates/builtin/builtin.rego.tpl
+++ b/internal/embeds/templates/builtin/builtin.rego.tpl
@@ -1,5 +1,8 @@
 # METADATA
 # description: Add description of rule here!
+# related_resources:
+#   - description: documentation
+#     ref: https://www.openpolicyagent.org/projects/regal/rules/{{.Category}}/{{.NameOriginal}}
 package regal.rules.{{.Category}}{{.Name}}
 
 import data.regal.ast

--- a/internal/embeds/templates/builtin/builtin_test.rego.tpl
+++ b/internal/embeds/templates/builtin/builtin_test.rego.tpl
@@ -1,7 +1,6 @@
 package regal.rules.{{.Category}}{{.NameTest}}
 
 import data.regal.ast
-import data.regal.config
 
 import data.regal.rules.{{.Category}}{{.Name}} as rule
 
@@ -29,7 +28,7 @@ test_rule_named_foo_not_allowed if {
 		},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/{{.NameOriginal}}", "{{.Category}}"),
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/{{.Category}}/{{.NameOriginal}}",
 		}],
 		"title": "{{.NameOriginal}}",
 	}}


### PR DESCRIPTION
This makes rules more self-contained / declarative, and will benefit a future "regodoc" renderer. Related to that, also replace use of config.docs.resolve_url in tests in favor of static URLs. Dynamically resolving doc URLs wasn't ever needed tbh, and having tests compare against static data feels much better.

Also some style fixes to unify how location data is presented in tests.

While there are many changes here, it's mostly repeating the same changes everywhere, so don't spend much time reviewing this.

Fixes #1927

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->