### PR TITLE
lsp: Fix aggregate test loop initialization 

### DIFF
--- a/internal/lsp/server_aggregates_test.go
+++ b/internal/lsp/server_aggregates_test.go
@@ -256,7 +256,7 @@ import rego.v1
 	timeout := time.NewTimer(determineTimeout())
 	defer timeout.Stop()
 
-	for success := true; !success; {
+	for success := false; !success; {
 		select {
 		case violations := <-messages["foo.rego"]:
 			if !slices.Contains(violations, "unresolved-import") {


### PR DESCRIPTION
In https://github.com/open-policy-agent/regal/commit/9900522e, workspace contents are now loaded asynchronously after the initialized notification. This exposed a bug where the test's first wait loop never executed due to `success := true` instead of `success := false`.

Without waiting, the test updates bar.rego before aggregate analysis runs. The unresolved-import violation is never computed because bar.rego is already fixed when aggregates first run.
