### PR TITLE
Cover more `non-loop-expression`s

### DIFF
--- a/bundle/regal/lsp/semantictokens/vars/comprehensions/comprehensions_test.rego
+++ b/bundle/regal/lsp/semantictokens/vars/comprehensions/comprehensions_test.rego
@@ -5,10 +5,14 @@ import data.regal.lsp.semantictokens.vars.comprehensions
 test_array_comprehension[note] if {
 	policy_one := `package regal.woo
 
-array_comprehensions := [x |  
-	some i, x in [1, 2, 3]    
-	i == 2                    
+array_comprehensions := [x |
+	some i, x in [1, 2, 3]
+	i == 2
 ]`
+
+	array_comp_tokens := comprehensions.result with input as {"params": {"textDocument": {"uri": "file://p.rego"}}}
+		with data.workspace.parsed["file://p.rego"] as regal.parse_module("p.rego", policy_one)
+
 	some note, tc in {"array comprehensions": {
 		"declarations": {
 			{"location": "4:10:4:11", "type": "var", "value": "x"},
@@ -19,8 +23,6 @@ array_comprehensions := [x |
 			{"location": "5:2:5:3", "type": "var", "value": "i"},
 		},
 	}}
-	array_comp_tokens := comprehensions.result with input as {"params": {"textDocument": {"uri": "file://p.rego"}}}
-		with data.workspace.parsed["file://p.rego"] as regal.parse_module("p.rego", policy_one)
 
 	tc.declarations == array_comp_tokens.declaration
 	tc.references == array_comp_tokens.reference
@@ -29,10 +31,14 @@ array_comprehensions := [x |
 test_set_comprehensions[note] if {
 	policy_one := `package regal.woo
 
-set_comprehensions := {x |    
-	some i, x in [1, 2, 3]    
-	i == 2                    
+set_comprehensions := {x |
+	some i, x in [1, 2, 3]
+	i == 2
 }`
+
+	set_comp_tokens := comprehensions.result with input as {"params": {"textDocument": {"uri": "file://p.rego"}}}
+		with data.workspace.parsed["file://p.rego"] as regal.parse_module("p.rego", policy_one)
+
 	some note, tc in {"set comprehensions": {
 		"declarations": {
 			{"location": "4:10:4:11", "type": "var", "value": "x"},
@@ -43,8 +49,6 @@ set_comprehensions := {x |
 			{"location": "5:2:5:3", "type": "var", "value": "i"},
 		},
 	}}
-	set_comp_tokens := comprehensions.result with input as {"params": {"textDocument": {"uri": "file://p.rego"}}}
-		with data.workspace.parsed["file://p.rego"] as regal.parse_module("p.rego", policy_one)
 
 	tc.declarations == set_comp_tokens.declaration
 	tc.references == set_comp_tokens.reference
@@ -53,10 +57,13 @@ set_comprehensions := {x |
 test_object_comprehension[note] if {
 	policy_one := `package regal.woo
 
-object_comprehensions := {k: v |  
-	some k, v in [1, 2, 3]       
-	v == 2                        
+object_comprehensions := {k: v |
+	some k, v in [1, 2, 3]
+	v == 2
 }`
+	object_comp_tokens := comprehensions.result with input as {"params": {"textDocument": {"uri": "file://p.rego"}}}
+		with data.workspace.parsed["file://p.rego"] as regal.parse_module("p.rego", policy_one)
+
 	some note, tc in {"object comprehensions": {
 		"declarations": {
 			{"location": "4:10:4:11", "type": "var", "value": "v"},
@@ -68,8 +75,6 @@ object_comprehensions := {k: v |
 			{"location": "5:2:5:3", "type": "var", "value": "v"},
 		},
 	}}
-	object_comp_tokens := comprehensions.result with input as {"params": {"textDocument": {"uri": "file://p.rego"}}}
-		with data.workspace.parsed["file://p.rego"] as regal.parse_module("p.rego", policy_one)
 
 	tc.declarations == object_comp_tokens.declaration
 	tc.references == object_comp_tokens.reference

--- a/bundle/regal/lsp/semantictokens/vars/every_expr/every_expr_test.rego
+++ b/bundle/regal/lsp/semantictokens/vars/every_expr/every_expr_test.rego
@@ -4,13 +4,16 @@ import data.regal.lsp.semantictokens.vars.every_expr
 
 test_every_vars[note] if {
 	policy := `package regal.woo
-	
+
 every_two_vars if {
-	every k, v in input.object {  
-		is_string(k)             
-		v > 0                    
+	every k, v in input.object {
+		is_string(k)
+		v > 0
 	}
 }`
+
+	tokens := every_expr.result with input as {"params": {"textDocument": {"uri": "file://p.rego"}}}
+		with data.workspace.parsed["file://p.rego"] as regal.parse_module("p.rego", policy)
 
 	some note, tc in {"every expression variables": {
 		"declarations": {
@@ -23,9 +26,6 @@ every_two_vars if {
 		},
 	}}
 
-	tokens := every_expr.result with input as {"params": {"textDocument": {"uri": "file://p.rego"}}}
-		with data.workspace.parsed["file://p.rego"] as regal.parse_module("p.rego", policy)
-
 	tc.declarations == tokens.declaration
 	tc.references == tokens.reference
 }
@@ -34,18 +34,18 @@ test_every_single_var_case if {
 	policy := `package regal.woo
 
 every_one_var if {
-	every k in input.object {  
-		is_string(k)                                
+	every k in input.object {
+		is_string(k)
 	}
 }`
+
+	tokens := every_expr.result with input as {"params": {"textDocument": {"uri": "file://p.rego"}}}
+		with data.workspace.parsed["file://p.rego"] as regal.parse_module("p.rego", policy)
 
 	some note, tc in {"every expression variables": {
 		"declarations": {{"location": "4:8:4:9", "type": "var", "value": "k"}},
 		"references": {{"location": "5:13:5:14", "type": "var", "value": "k"}},
 	}}
-
-	tokens := every_expr.result with input as {"params": {"textDocument": {"uri": "file://p.rego"}}}
-		with data.workspace.parsed["file://p.rego"] as regal.parse_module("p.rego", policy)
 
 	tc.declarations == tokens.declaration
 	tc.references == tokens.reference

--- a/bundle/regal/lsp/semantictokens/vars/some_expr/some_expr_test.rego
+++ b/bundle/regal/lsp/semantictokens/vars/some_expr/some_expr_test.rego
@@ -6,10 +6,13 @@ test_some_vars if {
 	policy := `package regal.woo
 
 some_two_vars if {
-	some i, item in input.array   
-	i < 10                        
-	item > 0                        
+	some i, item in input.array
+	i < 10
+	item > 0
 }`
+
+	tokens := some_expr.result with input as {"params": {"textDocument": {"uri": "file://p.rego"}}}
+		with data.workspace.parsed["file://p.rego"] as regal.parse_module("p.rego", policy)
 
 	some note, tc in {"some expression variables": {
 		"declarations": {
@@ -22,9 +25,6 @@ some_two_vars if {
 		},
 	}}
 
-	tokens := some_expr.result with input as {"params": {"textDocument": {"uri": "file://p.rego"}}}
-		with data.workspace.parsed["file://p.rego"] as regal.parse_module("p.rego", policy)
-
 	tc.declarations == tokens.declaration
 	tc.references == tokens.reference
 }
@@ -33,17 +33,17 @@ test_some_single_var_case if {
 	policy := `package regal.woo
 
 some_one_var if {
-	some i in input.array   
-	i < 10                                              
+	some i in input.array
+	i < 10
 }`
+
+	tokens := some_expr.result with input as {"params": {"textDocument": {"uri": "file://p.rego"}}}
+		with data.workspace.parsed["file://p.rego"] as regal.parse_module("p.rego", policy)
 
 	some note, tc in {"some expression variables": {
 		"declarations": {{"location": "4:7:4:8", "type": "var", "value": "i"}},
 		"references": {{"location": "5:2:5:3", "type": "var", "value": "i"}},
 	}}
-
-	tokens := some_expr.result with input as {"params": {"textDocument": {"uri": "file://p.rego"}}}
-		with data.workspace.parsed["file://p.rego"] as regal.parse_module("p.rego", policy)
 
 	tc.declarations == tokens.declaration
 	tc.references == tokens.reference

--- a/bundle/regal/rules/custom/naming-convention/naming_convention.rego
+++ b/bundle/regal/rules/custom/naming-convention/naming_convention.rego
@@ -11,11 +11,7 @@ import data.regal.result
 
 # target: package
 report contains violation if {
-	some convention in config.rules.custom["naming-convention"].conventions
-
-	"package" in convention.targets
-
-	not _convention_matched(ast.package_name, convention)
+	_any_package_convention_violation
 
 	violation := result.fail(
 		rego.metadata.chain(),
@@ -73,6 +69,14 @@ report contains violation if {
 		rego.metadata.chain(),
 		result.location_and_description(var, _message("variable", var.value)),
 	)
+}
+
+_any_package_convention_violation if {
+	some convention in config.rules.custom["naming-convention"].conventions
+
+	"package" in convention.targets
+
+	not _convention_matched(ast.package_name, convention)
 }
 
 _message(kind, name) := $`Naming violation: {kind} name "{name}" does not match configured convention`

--- a/bundle/regal/rules/performance/non-loop-expression/non_loop_expression.rego
+++ b/bundle/regal/rules/performance/non-loop-expression/non_loop_expression.rego
@@ -19,14 +19,14 @@ report contains violation if {
 
 	row > first_loop_row
 
-	term_vars := ast.find_term_vars(expr.terms)
-
 	# users are able to use print statements for debugging purposes
-	term_vars[0].value != "print"
+	not _is_print_call(expr.terms[0])
 
 	# if there are any term vars used in the expression, then they must have been
 	# declared after the first loop
-	every term_var in term_vars {
+	every term_var in _expr_vars(expr) {
+		not startswith(term_var.value, "$")
+
 		declared_row := min(object.get(_assignment_index, [rule_index, term_var.value], {0}))
 
 		declared_row < first_loop_row
@@ -35,16 +35,69 @@ report contains violation if {
 	violation := result.fail(rego.metadata.chain(), result.location(expr))
 }
 
-_exprs[rule_index][row] contains expr if {
-	some i
-	expr := input.rules[i].body[_]
-	rule_index := ast.rule_index_strings[i]
-	row := to_number(substring(expr.location, 0, indexof(expr.location, ":")))
+# special case for every, as variables declared don't escape its scope
+report contains violation if {
+	some rule_index
+	_every := ast.found.every[rule_index][_]
+
+	kv_vars := {_every[kind].value |
+		some kind in ["key", "value"]
+
+		_every[kind].type == "var"
+	}
+
+	some expr in _every.body
+
+	not _is_print_call(expr.terms[0])
+	not _any_var_found(expr, _every.body, kv_vars)
+
+	violation := result.fail(rego.metadata.chain(), result.location(expr))
 }
+
+_is_print_call(term) if {
+	term.type == "ref"
+	term.value[0].value == "print"
+}
+
+_any_var_found(expr, _, vars) if {
+	some term in _expr_vars(expr)
+
+	term.value in vars
+}
+
+_any_var_found(expr, body, _) if {
+	assigned := _assign_vars(body)
+
+	some term in _expr_vars(expr)
+
+	term.value in assigned
+}
+
+_assign_vars(body) := {expr.terms[1].value |
+	some expr in body
+
+	expr.terms[0].type == "ref"
+	expr.terms[0].value[0].value == "assign"
+}
+
+_expr_vars(expr) := _term_vars(expr.terms) if not expr.with
+_expr_vars(expr) := array.flatten([_term_vars(expr.terms), _vars_no_builtins(expr.with)]) if expr.with
+
+_term_vars(terms) := _vars_no_builtins(terms[2]) if {
+	terms[0].type == "ref"
+	terms[0].value[0].value == "assign"
+	terms[0].value[0].type == "var"
+} else := _vars_no_builtins(terms)
+
+_vars_no_builtins(terms) := [term |
+	some term in ast.find_term_vars(terms)
+
+	not term.value in ast.builtin_names
+]
 
 _exprs[rule_index][row] contains expr if {
 	some i
-	expr := input.rules[i].body[_].terms.body[_]
+	expr := input.rules[i].body[_]
 	rule_index := ast.rule_index_strings[i]
 	row := to_number(substring(expr.location, 0, indexof(expr.location, ":")))
 }
@@ -96,23 +149,6 @@ _loop_start_points[rule_index][loc.row] contains var if {
 	loc := util.to_location_object(var.location)
 
 	# ignore vars in comprehensions
-	_not_in_comprehension(rule_index, loc)
-}
-
-# every x, y in foo.bar
-_loop_start_points[rule_index][loc.row] contains term if {
-	some rule_index
-	terms := ast.found.every[rule_index][_]
-
-	some kind in ["key", "value"]
-	terms[kind].type == "var"
-
-	term := terms[kind]
-	loc := util.to_location_object(term.location)
-
-	# ignore vars in comprehensions... for now
-	# but we should really treat this as a special case later,
-	# as the loop vars are scoped to the every body
 	_not_in_comprehension(rule_index, loc)
 }
 

--- a/bundle/regal/rules/performance/non-loop-expression/non_loop_expression_test.rego
+++ b/bundle/regal/rules/performance/non-loop-expression/non_loop_expression_test.rego
@@ -350,6 +350,65 @@ test_non_ref_output_var if {
 	r == set()
 }
 
+test_fail_non_loop_assignment_expression if {
+	r := rule.report with input as ast.policy(`r if {
+		some a in input.b
+		c := lower("HELLO")
+		d := concat("", [a, c])
+	}`)
+		with ast.builtin_names as {"lower"}
+
+	r == with_location({
+		"col": 3,
+		"end": {
+			"col": 22,
+			"row": 5,
+		},
+		"file": "policy.rego",
+		"row": 5,
+		"text": "\t\tc := lower(\"HELLO\")",
+	})
+}
+
+test_fail_non_loop_assignment_with_expression if {
+	r := rule.report with input as ast.policy(`r if {
+		some a in input.b
+		c := lower(foo) with input as {"foo": "bar"}
+	}`)
+		with ast.builtin_names as {"lower"}
+
+	r == {{
+		"category": "performance",
+		"description": "Non-loop expression",
+		"level": "error",
+		"location": {
+			"col": 3,
+			"end": {
+				"col": 47,
+				"row": 5,
+			},
+			"file": "policy.rego",
+			"row": 5,
+			"text": "\t\tc := lower(foo) with input as {\"foo\": \"bar\"}",
+		},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/performance/non-loop-expression",
+		}],
+		"title": "non-loop-expression",
+	}}
+}
+
+test_success_non_loop_assignment_with_expression if {
+	r := rule.report with input as ast.policy(`r if {
+		some a in input.b
+		c := lower(foo) with input as {"foo": a}
+	}`)
+		with ast.builtin_names as {"lower"}
+
+	r == set()
+}
+
 with_location(location) := {{
 	"category": "performance",
 	"description": "Non-loop expression",


### PR DESCRIPTION
We now also flag assignment in iteration which could be moved out of it. Additionally fixed issues with `every` flagging vars outside of its body, so that it now only considers variables and expressions in its own scope.

Fixes #1445

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->