### PR TITLE
Add convenience functions for working with lines and uints

### DIFF
--- a/internal/lsp/cache/cache.go
+++ b/internal/lsp/cache/cache.go
@@ -47,7 +47,7 @@ type Cache struct {
 
 	// when a file is successfully parsed, the number of lines in the file is stored
 	// here. This is used to gracefully fail when exiting unparsable files.
-	successfulParseLineCounts *concurrent.Map[string, int]
+	successfulParseLineCounts *concurrent.Map[string, uint]
 }
 
 func NewCache() *Cache {
@@ -59,7 +59,7 @@ func NewCache() *Cache {
 		diagnosticsParseErrors:    concurrent.MapOf(make(map[string][]types.Diagnostic)),
 		builtinPositionsFile:      concurrent.MapOf(make(map[string]map[uint][]types.BuiltinPosition)),
 		keywordLocationsFile:      concurrent.MapOf(make(map[string]map[uint][]types.KeywordLocation)),
-		successfulParseLineCounts: concurrent.MapOf(make(map[string]int)),
+		successfulParseLineCounts: concurrent.MapOf(make(map[string]uint)),
 		aggregateData:             concurrent.NewObject(),
 	}
 }
@@ -215,11 +215,11 @@ func (c *Cache) GetKeywordLocations(fileURI string) (map[uint][]types.KeywordLoc
 	return c.keywordLocationsFile.Get(fileURI)
 }
 
-func (c *Cache) GetSuccessfulParseLineCount(fileURI string) (int, bool) {
+func (c *Cache) GetSuccessfulParseLineCount(fileURI string) (uint, bool) {
 	return c.successfulParseLineCounts.Get(fileURI)
 }
 
-func (c *Cache) SetSuccessfulParseLineCount(fileURI string, count int) {
+func (c *Cache) SetSuccessfulParseLineCount(fileURI string, count uint) {
 	c.successfulParseLineCounts.Set(fileURI, count)
 }
 

--- a/internal/lsp/documentsymbol/documentsymbol.go
+++ b/internal/lsp/documentsymbol/documentsymbol.go
@@ -1,7 +1,6 @@
 package documentsymbol
 
 import (
-	"bytes"
 	"fmt"
 	"strings"
 
@@ -20,8 +19,9 @@ func All(contents string, module *ast.Module, builtins map[string]*ast.Builtin) 
 	docSymbols := make([]types.DocumentSymbol, 0)
 	pkgSymbols := make([]types.DocumentSymbol, 0)
 
-	lines := strings.Split(contents, "\n")
-	pkgRange := types.RangeBetween(0, 0, len(lines)-1, len(lines[len(lines)-1]))
+	lines := util.NumLines(contents)
+	lastLine, _ := util.Line(contents, lines)
+	pkgRange := types.RangeBetween(0, 0, lines-1, len(lastLine))
 	pkg := documentSymbol(module.Package.Path.String(), symbols.Package, pkgRange)
 
 	// Create groups of rules and functions sharing the same name
@@ -93,11 +93,11 @@ func All(contents string, module *ast.Module, builtins map[string]*ast.Builtin) 
 
 func locationToRange(location *ast.Location) types.Range {
 	startLine := util.SafeIntToUint(location.Row - 1)
-	numLines := bytes.Count(location.Text, []byte{'\n'}) + 1
+	numLines := util.BytesNumLines(location.Text)
 
 	endLine := startLine
 	if numLines > 1 {
-		endLine += util.SafeIntToUint(numLines - 1)
+		endLine += numLines - 1
 	}
 
 	endLineContent := util.LineContents(location.Text, endLine-startLine)

--- a/internal/lsp/inlayhint/inlayhint.go
+++ b/internal/lsp/inlayhint/inlayhint.go
@@ -2,7 +2,6 @@ package inlayhint
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/types"
@@ -10,6 +9,7 @@ import (
 	"github.com/open-policy-agent/regal/internal/lsp/rego"
 	lspTypes "github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/parse"
+	"github.com/open-policy-agent/regal/internal/util"
 )
 
 var noInlayHints = make([]lspTypes.InlayHint, 0)
@@ -43,33 +43,26 @@ func FromModule(module *ast.Module, builtins builtinsMap) []lspTypes.InlayHint {
 	return inlayHints
 }
 
-func Partial(parseErrors []lspTypes.Diagnostic, contents, uri string, builtins builtinsMap) []lspTypes.InlayHint {
-	firstErrorLine := uint(0)
+func Partial(parseErrors []lspTypes.Diagnostic, policy, uri string, builtins builtinsMap) []lspTypes.InlayHint {
+	var firstErrorLine uint
 	for _, parseError := range parseErrors {
 		if parseError.Range.Start.Line > firstErrorLine {
 			firstErrorLine = parseError.Range.Start.Line
 		}
 	}
 
-	split := strings.Split(contents, "\n")
-
-	if firstErrorLine == 0 || firstErrorLine > uint(len(split)) {
-		// if there are parse errors from line 0, we skip doing anything
-		// if the last valid line is beyond the end of the file, we exit as something is up
-		return noInlayHints
+	if numLines := util.NumLines(policy); firstErrorLine > 0 && firstErrorLine < numLines {
+		// try parse the lines up to the first parse error
+		end := util.IndexByteNth(policy, '\n', firstErrorLine+2)
+		if mod, err := parse.Module(uri, policy[:end]); err == nil {
+			return FromModule(mod, builtins)
+		}
 	}
 
-	// select the lines from the contents up to the first parse error
-	lines := strings.Join(split[:firstErrorLine], "\n")
-
-	// parse the part of the module that might work
-	module, err := parse.Module(uri, lines)
-	if err != nil {
-		// if we still can't parse the bit we hoped was valid, we exit as this is 'too hard'
-		return noInlayHints
-	}
-
-	return FromModule(module, builtins)
+	// if there are parse errors from line 0, we skip doing anything
+	// if the last valid line is beyond the end of the file, we exit as something is up
+	// if we still can't parse the bit we hoped was valid, we exit as this is 'too hard'
+	return noInlayHints
 }
 
 func createInlayTooltip(named *types.NamedType) string {

--- a/internal/lsp/lint.go
+++ b/internal/lsp/lint.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	rparse "github.com/open-policy-agent/regal/internal/parse"
+	"github.com/open-policy-agent/regal/internal/util"
 	"github.com/open-policy-agent/regal/pkg/config"
 	"github.com/open-policy-agent/regal/pkg/hints"
 	"github.com/open-policy-agent/regal/pkg/linter"
@@ -75,7 +76,7 @@ func updateParse(ctx context.Context, opts updateParseOpts) (bool, error) {
 	options := rparse.ParserOptions()
 	options.RegoVersion = opts.RegoVersion
 
-	numLines := strings.Count(content, "\n") + 1
+	numLines := util.NumLines(content)
 	presentedFileName := uri.ToRelativePath(opts.FileURI, opts.WorkspaceRootURI)
 
 	module, err := rparse.ModuleWithOpts(presentedFileName, content, options)
@@ -123,17 +124,12 @@ func updateParse(ctx context.Context, opts updateParseOpts) (bool, error) {
 		}
 	}
 
-	lines := strings.Split(content, "\n")
 	diags := make([]types.Diagnostic, 0, len(astErrors))
 
 	for _, astError := range astErrors {
-		line := max(astError.Location.Row-1, 0)
-
-		lineLength := 1
-		if line < numLines {
-			lineLength = len(lines[line])
-		}
-
+		line := uint(max(astError.Location.Row-1, 0))
+		text, _ := util.Line(content, line+1)
+		lineLength := cmp.Or(uint(len(text)), 1)
 		key := "regal/parse"
 		link := "https://www.openpolicyagent.org/docs/errors/" // overview page
 

--- a/internal/lsp/rego/router.go
+++ b/internal/lsp/rego/router.go
@@ -16,7 +16,6 @@ import (
 	"github.com/open-policy-agent/regal/internal/lsp/semantictokens"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	ruri "github.com/open-policy-agent/regal/internal/lsp/uri"
-	"github.com/open-policy-agent/regal/internal/util"
 	"github.com/open-policy-agent/regal/pkg/roast/transform"
 )
 
@@ -39,7 +38,7 @@ type (
 		ContentProvider              func(uri string) (string, bool)
 		IgnoredProvider              func(uri string) bool
 		ParseErrorsProvider          func(uri string) ([]types.Diagnostic, bool)
-		SuccessfulParseCountProvider func(uri string) (int, bool)
+		SuccessfulParseCountProvider func(uri string) (uint, bool)
 	}
 
 	RegoRouter struct {
@@ -200,7 +199,7 @@ func regalContextForRequirements(prvs Providers, uri string, reqs *Requirements)
 		}
 
 		if splc, ok := prvs.SuccessfulParseCountProvider(uri); ok {
-			rctx.File.SuccessfulParseCount = util.SafeIntToUint(splc)
+			rctx.File.SuccessfulParseCount = splc
 		} else {
 			// if the file has always been unparsable, we can return early
 			return nil, nil //nolint:nilnil

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1132,15 +1132,10 @@ func (l *LanguageServer) fixEditParams(
 
 	if l.client.Identifier == clients.IdentifierIntelliJ {
 		// IntelliJ clients need a single edit that replaces the entire file
-		lines := strings.Split(oldContent, "\n")
-		endLine := len(lines) - 1
-		endChar := 0
+		numLines := util.NumLines(oldContent)
+		line, _ := util.Line(oldContent, numLines)
 
-		if endLine >= 0 {
-			endChar = len(lines[endLine])
-		}
-
-		edits = []types.TextEdit{{Range: types.RangeBetween(0, 0, endLine, endChar), NewText: res[0].Contents}}
+		edits = []types.TextEdit{{Range: types.RangeBetween(0, 0, numLines-1, len(line)), NewText: res[0].Contents}}
 	} else {
 		// Other clients use the standard diff-based edits
 		edits = ComputeEdits(oldContent, res[0].Contents)
@@ -2674,20 +2669,13 @@ func (l *LanguageServer) handleEvalCommand(ctx context.Context, args types.Comma
 }
 
 func positionToOffset(text string, p types.Position) int {
-	bytesRead := 0
-
-	for i, line := range strings.Split(text, "\n") {
-		if line == "" {
-			bytesRead++
-		} else {
-			bytesRead += len(line) + 1
-		}
-
-		//nolint:gosec
-		if i == int(p.Line)-1 {
-			return bytesRead + int(p.Character)
-		}
+	if p.Line == 0 {
+		return util.SafeUintToInt(p.Character)
 	}
 
-	return -1
+	if offset := util.IndexByteNth(text, '\n', p.Line); offset > -1 {
+		return offset + 1 + util.SafeUintToInt(p.Character)
+	}
+
+	return len(text)
 }

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -180,3 +180,21 @@ func testRequestDataCodes(t *testing.T, requestData types.FileDiagnostics, fileU
 
 	return true
 }
+
+func TestPositionToOffset(t *testing.T) {
+	t.Parallel()
+
+	text := "line1\nline2\nline3"
+
+	for line := range uint(2) {
+		for char := range uint(5) {
+			pos := types.Position{Line: line, Character: char}
+			exp := line*6 + char
+			got := util.SafeIntToUint(positionToOffset(text, pos))
+
+			if exp != got {
+				t.Fatalf("expected offset for line %d char %d to be %d, got %d", line, char, exp, got)
+			}
+		}
+	}
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -146,8 +146,7 @@ func FilepathJoiner(base string) func(string) string {
 	}
 }
 
-// SafeUintToInt will convert a uint to an int, clamping the result to
-// math.MaxInt.
+// SafeUintToInt will convert a uint to an int, clamping the result to math.MaxInt.
 func SafeUintToInt(u uint) int {
 	if u > math.MaxInt {
 		return math.MaxInt // Clamp to prevent overflow
@@ -320,7 +319,7 @@ func Reversed[T any](s []T) []T {
 }
 
 // LineContents returns the contents on line lineNum (0-indexed) from document.
-// This function assumes the lineNum is known to be contained within the document,.
+// This function assumes the lineNum is known to be contained within the document.
 func LineContents(document []byte, lineNum uint) []byte {
 	for i, line := range Lines(document) {
 		if i == lineNum {
@@ -343,4 +342,55 @@ func Lines(s []byte) iter.Seq2[uint, []byte] {
 			lineNum++
 		}
 	}
+}
+
+// NumLines returns the number of lines in s, as uint for convenience with LSP spec types and more.
+func NumLines(s string) uint {
+	return SafeIntToUint(strings.Count(s, "\n")) + 1
+}
+
+// BytesNumLines returns the number of lines in s, as uint for convenience with LSP spec types and more.
+func BytesNumLines(s []byte) uint {
+	return SafeIntToUint(bytes.Count(s, []byte{'\n'})) + 1
+}
+
+// IndexByteNth returns the index of the nth occurrence of b in s, or -1 if not found / out of range.
+func IndexByteNth(s string, b byte, n uint) (i int) {
+	for ; n > 0; n-- {
+		d := strings.IndexByte(s[i:], b)
+		if d == -1 {
+			return -1
+		}
+
+		i += d + 1
+	}
+
+	return i - 1
+}
+
+// Line returns the contents of the line at lineNum (1-indexed) in a most efficient way.
+func Line(s string, lineNum uint) (line string, ok bool) {
+	if lineNum == 0 {
+		return "", false
+	}
+
+	if lineNum == 1 {
+		if before, _, ok0 := strings.Cut(s, "\n"); ok0 {
+			return before, true
+		}
+
+		return s, true
+	}
+
+	idx := IndexByteNth(s, '\n', lineNum-1)
+	if idx == -1 {
+		return "", false
+	}
+
+	endIdx := strings.IndexByte(s[idx+1:], '\n')
+	if endIdx == -1 {
+		return s[idx+1:], true
+	}
+
+	return s[idx+1 : idx+1+endIdx], true
 }

--- a/internal/util/util_bench_test.go
+++ b/internal/util/util_bench_test.go
@@ -1,0 +1,113 @@
+package util
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Without pre-allocating, this is more than twice as slow and results in 5 allocs/op.
+// BenchmarkFilter/Filter-10    5919769    191.0 ns/op    224 B/op    1 allocs/op
+// ...
+func BenchmarkFilter(b *testing.B) {
+	strings := []string{
+		"foo", "bar", "baz", "qux", "quux", "corge", "grault", "garply", "waldo", "fred", "plugh", "xyzzy", "thud",
+		"x", "y", "z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "the", "lazy", "dog", "jumped", "over",
+		"the", "quick", "brown", "fox",
+	}
+
+	pred := func(s string) bool {
+		return len(s) > 3
+	}
+
+	b.Run("Filter", func(b *testing.B) {
+		for b.Loop() {
+			_ = Filter(strings, pred)
+		}
+	})
+}
+
+// No allocations
+func BenchmarkSorted(b *testing.B) {
+	unsorted := []string{
+		"the", "quick", "brown", "fox", "jumped", "over", "the", "lazy", "dog",
+		"foo", "bar", "baz", "qux", "quux", "corge", "grault", "garply", "waldo", "fred", "plugh", "xyzzy", "thud",
+		"x", "y", "z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j",
+	}
+	sorted := []string{
+		"a", "b", "bar", "baz", "brown", "c", "corge", "d", "dog", "e", "f", "foo", "fox", "fred", "g", "garply",
+		"grault", "h", "i", "j", "jumped", "lazy", "over", "plugh", "quick", "quux", "qux", "the", "the", "thud",
+		"waldo", "x", "xyzzy", "y", "z",
+	}
+
+	var got []string
+	for b.Loop() {
+		got = Sorted(unsorted)
+	}
+
+	if !slices.Equal(got, sorted) {
+		b.Fatalf("expected %v, got %v", sorted, got)
+	}
+}
+
+// 9090 ns/op    24576 B/op    1 allocs/op // return bytes.Split(document, []byte{'\n'})[lineNum]
+// 4726 ns/op        0 B/op    0 allocs/op // current implementation
+func BenchmarkLineContents(b *testing.B) {
+	src := []byte{}
+	for i := range uint64(1000) {
+		src = append(strconv.AppendUint(append(src, "This is line number "...), i, 10), '\n')
+	}
+
+	b.Run("LineContents", func(b *testing.B) {
+		for b.Loop() {
+			_ = LineContents(src, 500)
+		}
+	})
+}
+
+// 3.191 ns/op	       0 B/op	       0 allocs/op
+// 3912 ns/op	       0 B/op	       0 allocs/op
+// 7827 ns/op	       0 B/op	       0 allocs/op
+func BenchmarkIndexByteNth(b *testing.B) {
+	s := strings.Repeat(strings.Repeat("a", 120)+"\n", 1000)
+
+	for _, n := range []uint{1, 500, 1000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			for b.Loop() {
+				_ = IndexByteNth(s, '\n', n)
+			}
+		})
+	}
+}
+
+// 1.86 ns/op	       0 B/op	       0 allocs/op
+// 3513 ns/op	       0 B/op	       0 allocs/op
+// 7068 ns/op	       0 B/op	       0 allocs/op
+func BenchmarkLine(b *testing.B) {
+	text := strings.Repeat("this is a line\n", 1000)
+
+	for _, lineNum := range []uint{1, 500, 1000} {
+		b.Run(fmt.Sprintf("line %d", lineNum), func(b *testing.B) {
+			for b.Loop() {
+				_, _ = Line(text, lineNum)
+			}
+		})
+	}
+}
+
+// 8462 ns/op	   16384 B/op	       1 allocs/op
+// 8145 ns/op	   16384 B/op	       1 allocs/op
+// 8173 ns/op	   16384 B/op	       1 allocs/op
+func BenchmarkLineBySplit(b *testing.B) {
+	text := strings.Repeat("this is a line\n", 1000)
+
+	for _, lineNum := range []uint{1, 500, 1000} {
+		b.Run(fmt.Sprintf("line %d", lineNum), func(b *testing.B) {
+			for b.Loop() {
+				_ = strings.Split(text, "\n")[lineNum-1]
+			}
+		})
+	}
+}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,8 +1,7 @@
 package util
 
 import (
-	"slices"
-	"strconv"
+	"fmt"
 	"testing"
 
 	"github.com/open-policy-agent/regal/internal/test/must"
@@ -91,50 +90,6 @@ func TestFindClosestMatchingRoot(t *testing.T) {
 	}
 }
 
-// Without pre-allocating, this is more than twice as slow and results in 5 allocs/op.
-// BenchmarkFilter/Filter-10    5919769    191.0 ns/op    224 B/op    1 allocs/op
-// ...
-func BenchmarkFilter(b *testing.B) {
-	strings := []string{
-		"foo", "bar", "baz", "qux", "quux", "corge", "grault", "garply", "waldo", "fred", "plugh", "xyzzy", "thud",
-		"x", "y", "z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "the", "lazy", "dog", "jumped", "over",
-		"the", "quick", "brown", "fox",
-	}
-
-	pred := func(s string) bool {
-		return len(s) > 3
-	}
-
-	b.Run("Filter", func(b *testing.B) {
-		for b.Loop() {
-			_ = Filter(strings, pred)
-		}
-	})
-}
-
-// No allocations
-func BenchmarkSorted(b *testing.B) {
-	unsorted := []string{
-		"the", "quick", "brown", "fox", "jumped", "over", "the", "lazy", "dog",
-		"foo", "bar", "baz", "qux", "quux", "corge", "grault", "garply", "waldo", "fred", "plugh", "xyzzy", "thud",
-		"x", "y", "z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j",
-	}
-	sorted := []string{
-		"a", "b", "bar", "baz", "brown", "c", "corge", "d", "dog", "e", "f", "foo", "fox", "fred", "g", "garply",
-		"grault", "h", "i", "j", "jumped", "lazy", "over", "plugh", "quick", "quux", "qux", "the", "the", "thud",
-		"waldo", "x", "xyzzy", "y", "z",
-	}
-
-	var got []string
-	for b.Loop() {
-		got = Sorted(unsorted)
-	}
-
-	if !slices.Equal(got, sorted) {
-		b.Fatalf("expected %v, got %v", sorted, got)
-	}
-}
-
 func TestLineContents(t *testing.T) {
 	t.Parallel()
 
@@ -159,17 +114,42 @@ func TestLineContents(t *testing.T) {
 	}
 }
 
-// 9090 ns/op    24576 B/op    1 allocs/op // return bytes.Split(document, []byte{'\n'})[lineNum]
-// 4726 ns/op        0 B/op    0 allocs/op // current implementation
-func BenchmarkLineContents(b *testing.B) {
-	src := []byte{}
-	for i := range uint64(1000) {
-		src = append(strconv.AppendUint(append(src, "This is line number "...), i, 10), '\n')
+func TestIndexByteNth(t *testing.T) {
+	t.Parallel()
+
+	for n, exp := range []int{-1, 3, 7, 11, -1} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			t.Parallel()
+
+			must.Equal(t, exp, IndexByteNth("foo\nbar\nbaz\nqux", '\n', uint(n))) //nolint:gosec
+		})
+	}
+}
+
+func TestLine(t *testing.T) {
+	t.Parallel()
+
+	text := "line1\nline2\nline3\nline4"
+
+	for i, exp := range []string{"line1", "line2", "line3", "line4"} {
+		i++
+
+		t.Run(fmt.Sprintf("line %d", i), func(t *testing.T) {
+			t.Parallel()
+
+			line, ok := Line(text, uint(i)) //nolint:gosec
+			must.Equal(t, true, ok, "not ok at line %d", i)
+			must.Equal(t, exp, line, "content at line %d", i)
+		})
 	}
 
-	b.Run("LineContents", func(b *testing.B) {
-		for b.Loop() {
-			_ = LineContents(src, 500)
-		}
-	})
+	for _, lineNum := range []uint{0, 5} {
+		t.Run(fmt.Sprintf("line %d", lineNum), func(t *testing.T) {
+			t.Parallel()
+
+			line, ok := Line(text, lineNum)
+			must.Equal(t, false, ok)
+			must.Equal(t, "", line)
+		})
+	}
 }


### PR DESCRIPTION
I felt a need for this working on something else, but submitting this separately along with some updates for making use of the new functions.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->