### PR TITLE
lsp: Gate workspace lint jobs to only run after workspace content has loaded

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -148,6 +148,9 @@ type LanguageServer struct {
 
 	// initializationGate blocks workers until the initialized notification is received
 	initializationGate chan struct{}
+	// aggregatesInitialized is closed once the initial OverwriteAggregates workspace
+	// lint has completed. Jobs that depend on the aggregate cache check this before running.
+	aggregatesInitialized chan struct{}
 
 	commandRequest       chan types.ExecuteCommandParams
 	lintWorkspaceJobs    chan lintWorkspaceJob
@@ -220,6 +223,7 @@ func NewLanguageServerMinimal(ctx context.Context, opts *LanguageServerOptions, 
 		log:                         opts.Logger,
 		featureFlags:                *featureFlags,
 		initializationGate:          make(chan struct{}),
+		aggregatesInitialized:        make(chan struct{}),
 		lintFileJobs:                make(chan lintFileJob, 10),
 		lintWorkspaceJobs:           make(chan lintWorkspaceJob, 10),
 		builtinsPositionJobs:        make(chan lintFileJob, 10),
@@ -381,7 +385,6 @@ func (l *LanguageServer) StartDiagnosticsWorker(ctx context.Context) {
 					}
 				}
 
-				// lint the file and send the diagnostics
 				if err := updateFileDiagnostics(ctx, diagnosticsRunOpts{
 					Cache:            l.cache,
 					RegalConfig:      l.getLoadedConfig(),
@@ -472,9 +475,26 @@ func (l *LanguageServer) StartDiagnosticsWorker(ctx context.Context) {
 
 				// if there are no parsed modules in the cache, then there is
 				// no need to run the aggregate report. This can happen if the
-				// server is very slow to start up.
-				if len(l.cache.GetAllModules()) == 0 {
+				// server is very slow to start up. However, we must still allow
+				// OverwriteAggregates jobs through — they are what opens the gate,
+				// and skipping them would leave aggregatesInitialized permanently false.
+				if len(l.cache.GetAllModules()) == 0 && !job.OverwriteAggregates {
 					continue
+				}
+
+				// Block all workspace lint jobs until the initial OverwriteAggregates run
+				// has completed. Jobs that arrive early (e.g. from the config watcher firing
+				// before loadWorkspaceContents finishes) would run with an incomplete module
+				// set and produce false diagnostics. The OverwriteAggregates job is exempt
+				// since it is the one that sets aggregatesInitialized.
+				if !job.OverwriteAggregates {
+					select {
+					case <-l.aggregatesInitialized:
+					default:
+						l.log.Debug("skipping workspace lint %q: aggregates not yet initialized", job.Reason)
+
+						continue
+					}
 				}
 
 				targetRules := l.getEnabledAggregateRules()
@@ -495,6 +515,10 @@ func (l *LanguageServer) StartDiagnosticsWorker(ctx context.Context) {
 				})
 				if err != nil {
 					l.log.Message("failed to update all diagnostics: %s", err)
+				}
+
+				if job.OverwriteAggregates {
+					close(l.aggregatesInitialized)
 				}
 
 				for fileURI := range l.cache.GetAllFiles() {
@@ -2181,7 +2205,8 @@ func (l *LanguageServer) handleInitialized(ctx context.Context) (any, error) {
 	// loading happens in the background
 	go func() {
 		_, failed, err := l.loadWorkspaceContents(ctx, false)
-		for _, f := range failed {
+
+for _, f := range failed {
 			l.log.Message("failed to load file %s: %s", f.URI, f.Error)
 		}
 


### PR DESCRIPTION
Addresses an error on main where workspace lint jobs are being fired before the workspace contents have a chance to finish loading. 

Changes here block workspace lint jobs until the cache has been set, which solve the issue. But need to verify if this is the right approach, and also how this approach might fit into current work that's aimed at improving lsp shutdown and testing logic.
<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->