### PR TITLE
Semantic package tokens in Rego

### DIFF
--- a/bundle/regal/lsp/semantictokens/semantictokens_test.rego
+++ b/bundle/regal/lsp/semantictokens/semantictokens_test.rego
@@ -10,12 +10,17 @@ import data.regal.ast
 test_function(param1, param2) := result if {
 	ast.is_constant
 }`
-	result := semantictokens.result with input as {"params": {"textDocument": {"uri": "file://p.rego"}}}
-		with data.workspace.parsed["file://p.rego"] as regal.parse_module("p.rego", policy)
+	module := regal.parse_module("p.rego", policy)
+	result := semantictokens.result with data.workspace.parsed["file:///p.rego"] as module
+		with input.regal as module.regal
+		with input.params.textDocument.uri as "file:///p.rego"
 
 	result == {"response": {
 		"imports": {{"location": "3:19:3:22", "type": "string", "value": "ast"}},
-		"packages": {{"location": "1:15:1:18", "type": "string", "value": "woo"}},
+		"packages": {
+			{"col": 0, "length": 7, "line": 0, "modifiers": 0, "type": 3},
+			{"col": 14, "length": 3, "line": 0, "modifiers": 0, "type": 0},
+		},
 		"vars": {
 			"comprehensions": {
 				"declaration": set(),

--- a/bundle/regal/lsp/semantictokens/vars/packages/packages.rego
+++ b/bundle/regal/lsp/semantictokens/vars/packages/packages.rego
@@ -6,10 +6,37 @@
 #   - input.params: schema.regal.lsp.semantictokens
 package regal.lsp.semantictokens.vars.packages
 
+import data.regal.util
+
 # METADATA
 # description: Get the module from workspace
 module := data.workspace.parsed[input.params.textDocument.uri]
 
 # METADATA
-# description: Extract package tokens - return full package path
-result contains regal.last(module.package.path)
+# description: Package keyword
+result contains token if {
+	tloc := util.to_location_object(module.package.location)
+
+	token := {
+		"line": tloc.row - 1,
+		"col": tloc.col - 1,
+		"length": tloc.end.col - tloc.col,
+		"type": 3,
+		"modifiers": 0,
+	}
+}
+
+# METADATA
+# description: Last package path term as token
+result contains token if {
+	term := regal.last(module.package.path)
+	tloc := util.to_location_object(term.location)
+
+	token := {
+		"line": tloc.row - 1,
+		"col": tloc.col - 1,
+		"length": tloc.end.col - tloc.col,
+		"type": 0,
+		"modifiers": 0,
+	}
+}

--- a/bundle/regal/lsp/semantictokens/vars/packages/packages_test.rego
+++ b/bundle/regal/lsp/semantictokens/vars/packages/packages_test.rego
@@ -3,9 +3,15 @@ package regal.lsp.semantictokens.vars.packages_test
 import data.regal.lsp.semantictokens.vars.packages
 
 test_packages if {
-	policy := `package regal.woo`
-	tokens := packages.result with input as {"params": {"textDocument": {"uri": "file://p.rego"}}}
-		with data.workspace.parsed["file://p.rego"] as regal.parse_module("p.rego", policy)
+	policy := "package regal.woo\n"
+	module := regal.parse_module("policy.rego", policy)
 
-	{"location": "1:15:1:18", "type": "string", "value": "woo"} in tokens
+	tokens := packages.result with data.workspace.parsed["file:///p.rego"] as module
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.regal.file.lines as split(policy, "\n")
+
+	tokens == {
+		{"col": 0, "length": 7, "line": 0, "modifiers": 0, "type": 3},
+		{"col": 14, "length": 3, "line": 0, "modifiers": 0, "type": 0},
+	}
 }

--- a/internal/lsp/semantictokens/semantictokens.go
+++ b/internal/lsp/semantictokens/semantictokens.go
@@ -12,16 +12,35 @@ import (
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 )
 
-const (
-	TokenTypePackage  = 0
-	TokenTypeVariable = 1
-	TokenTypeImport   = 2
+type (
+	TokenType     = uint32
+	TokenModifier = uint32
 )
 
 const (
-	ModifierDeclaration = 1 << 0
-	ModifierReference   = 1 << 1
+	Namespace TokenType = iota
+	Variable
+	Import
+	Keyword
 )
+
+const (
+	ModifierDeclaration TokenModifier = 1 << iota
+	ModifierReference
+)
+
+var Legend = types.SemanticTokensLegend{
+	TokenTypes: []string{
+		Namespace: "namespace",
+		Variable:  "variable",
+		Import:    "import",
+		Keyword:   "keyword",
+	},
+	TokenModifiers: []string{
+		ModifierDeclaration: "declaration",
+		ModifierReference:   "reference",
+	},
+}
 
 type Token struct {
 	Line      uint32
@@ -94,20 +113,15 @@ type VarsSection struct {
 
 // Represents the structured result from the Rego query
 type SemanticTokensResult struct {
-	PackageTokens []ASTLocation `json:"packages"`
+	PackageTokens []Token       `json:"packages"`
 	ImportTokens  []ASTLocation `json:"imports"`
 	Vars          VarsSection   `json:"vars"`
-	DebugInfo     interface{}   `json:"debug_info"`
+	DebugInfo     any           `json:"debug_info"`
 }
 
 func Full(ctx context.Context, result SemanticTokensResult) (*types.SemanticTokens, error) {
-	tokens := make([]Token, 0)
-
-	packageTokens, err := processPackageTokens(result.PackageTokens)
-	if err != nil {
-		return nil, err
-	}
-	tokens = append(tokens, packageTokens...)
+	tokens := make([]Token, 0, len(result.PackageTokens))
+	tokens = append(tokens, result.PackageTokens...)
 
 	varTokens, err := processVariableTokens(result.Vars)
 	if err != nil {
@@ -122,20 +136,6 @@ func Full(ctx context.Context, result SemanticTokensResult) (*types.SemanticToke
 	tokens = append(tokens, importTokens...)
 
 	return encodeTokens(tokens), nil
-}
-
-func processPackageTokens(packageTokens []ASTLocation) ([]Token, error) {
-	tokens := make([]Token, 0)
-
-	for _, pkgToken := range packageTokens {
-		token, err := extractTokens(pkgToken, TokenTypePackage, 0)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create package token: %w", err)
-		}
-		tokens = append(tokens, token)
-	}
-
-	return tokens, nil
 }
 
 func processVariableTokens(vars VarsSection) ([]Token, error) {
@@ -172,7 +172,7 @@ func processTokenCategory(category ArgTokenCategory, categoryName string) ([]Tok
 	tokens := make([]Token, 0)
 
 	for _, declToken := range category.Declaration {
-		token, err := extractTokens(declToken, TokenTypeVariable, ModifierDeclaration)
+		token, err := extractTokens(declToken, Variable, ModifierDeclaration)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create %s declaration token: %w", categoryName, err)
 		}
@@ -180,7 +180,7 @@ func processTokenCategory(category ArgTokenCategory, categoryName string) ([]Tok
 	}
 
 	for _, refToken := range category.Reference {
-		token, err := extractTokens(refToken, TokenTypeVariable, ModifierReference)
+		token, err := extractTokens(refToken, Variable, ModifierReference)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create %s reference token: %w", categoryName, err)
 		}
@@ -194,7 +194,7 @@ func processImportTokens(importTokens []ASTLocation) ([]Token, error) {
 	tokens := make([]Token, 0)
 
 	for _, importToken := range importTokens {
-		token, err := extractTokens(importToken, TokenTypeImport, 0)
+		token, err := extractTokens(importToken, Import, 0)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create import token: %w", err)
 		}

--- a/internal/lsp/semantictokens_test.go
+++ b/internal/lsp/semantictokens_test.go
@@ -26,10 +26,8 @@ func TestFull(t *testing.T) {
 		expectedTokens []semanticTokenInstance
 	}{
 		"package only": {
-			policy: `package regal.woo`,
-			expectedTokens: []semanticTokenInstance{
-				{DeltaLine: 0, DeltaCol: 14, Length: 3, Type: 0, Modifier: 0},
-			},
+			policy:         `package regal.woo`,
+			expectedTokens: []semanticTokenInstance{{Length: 7, Type: 3}, {DeltaCol: 14, Length: 3}},
 		},
 		"variable declarations": {
 			policy: `package regal.woo
@@ -39,21 +37,23 @@ test_function(param1, param2) := result if {
 }
 `,
 			expectedTokens: []semanticTokenInstance{
-				{DeltaLine: 0, DeltaCol: 14, Length: 3, Type: 0, Modifier: 0},
+				{Length: 7, Type: 3},
+				{DeltaLine: 0, DeltaCol: 14, Length: 3},
 				{DeltaLine: 2, DeltaCol: 14, Length: 6, Type: 1, Modifier: 1},
 				{DeltaLine: 0, DeltaCol: 8, Length: 6, Type: 1, Modifier: 1},
 			},
 		},
 		"variable references": {
 			policy: `package regal.woo
-			
+
 test_function(param1) := result if {
       calc3 := 1
       calc3 == param1
 }
 `,
 			expectedTokens: []semanticTokenInstance{
-				{DeltaLine: 0, DeltaCol: 14, Length: 3, Type: 0, Modifier: 0},
+				{Length: 7, Type: 3},
+				{DeltaLine: 0, DeltaCol: 14, Length: 3},
 				{DeltaLine: 2, DeltaCol: 14, Length: 6, Type: 1, Modifier: 1},
 				{DeltaLine: 2, DeltaCol: 15, Length: 6, Type: 1, Modifier: 2},
 			},
@@ -62,7 +62,7 @@ test_function(param1) := result if {
 			policy: `package regal.woo
 
 import data.regal.ast
-			
+
 test_function(param1) := result if {
       calc3 := 1
       calc3 == param1
@@ -70,26 +70,28 @@ test_function(param1) := result if {
 }
 `,
 			expectedTokens: []semanticTokenInstance{
-				{DeltaLine: 0, DeltaCol: 14, Length: 3, Type: 0, Modifier: 0},
-				{DeltaLine: 2, DeltaCol: 18, Length: 3, Type: 2, Modifier: 0},
+				{Length: 7, Type: 3},
+				{DeltaLine: 0, DeltaCol: 14, Length: 3},
+				{DeltaLine: 2, DeltaCol: 18, Length: 3, Type: 2},
 				{DeltaLine: 2, DeltaCol: 14, Length: 6, Type: 1, Modifier: 1},
 				{DeltaLine: 2, DeltaCol: 15, Length: 6, Type: 1, Modifier: 2},
 			},
 		},
 		"full policy with package, declarations and references": {
 			policy: `package regal.woo
-			
+
 test_function(param1) := result if {
 	  calc1 := param1 * 2
       calc2 := param2 + 10
       result := calc1 + calc2
-	  
+
       calc3 := 1
       calc3 == param1
 }
 `,
 			expectedTokens: []semanticTokenInstance{
-				{DeltaLine: 0, DeltaCol: 14, Length: 3, Type: 0, Modifier: 0},
+				{Length: 7, Type: 3},
+				{DeltaLine: 0, DeltaCol: 14, Length: 3},
 				{DeltaLine: 2, DeltaCol: 14, Length: 6, Type: 1, Modifier: 1},
 				{DeltaLine: 1, DeltaCol: 12, Length: 6, Type: 1, Modifier: 2},
 				{DeltaLine: 5, DeltaCol: 15, Length: 6, Type: 1, Modifier: 2},
@@ -98,22 +100,23 @@ test_function(param1) := result if {
 		"comprehensions": {
 			policy: `package regal.woo
 
-array_comprehensions := [x |  
-    some i, x in [1, 2, 3]    
-    i == 2                    
+array_comprehensions := [x |
+    some i, x in [1, 2, 3]
+    i == 2
 ]
 
-set_comprehensions := {x |    
-    some i, x in [1, 2, 3]    
-    i == 2                    
+set_comprehensions := {x |
+    some i, x in [1, 2, 3]
+    i == 2
 }
 
-object_comprehensions := {k: v |  
-    some k, v in [1, 2, 3]       
-    v == 2                        
+object_comprehensions := {k: v |
+    some k, v in [1, 2, 3]
+    v == 2
 }`,
 			expectedTokens: []semanticTokenInstance{
-				{DeltaLine: 0, DeltaCol: 14, Length: 3, Type: 0, Modifier: 0},
+				{Length: 7, Type: 3},
+				{DeltaLine: 0, DeltaCol: 14, Length: 3},
 				{DeltaLine: 2, DeltaCol: 25, Length: 1, Type: 1, Modifier: 2},
 				{DeltaLine: 1, DeltaCol: 9, Length: 1, Type: 1, Modifier: 1},
 				{DeltaLine: 0, DeltaCol: 0, Length: 1, Type: 1, Modifier: 1},
@@ -139,19 +142,20 @@ object_comprehensions := {k: v |
 			policy: `package regal.woo
 
 every_two_vars_construct if {
-    every k, v in input.object {  
-        is_string(k)             
-        v > 0                    
+    every k, v in input.object {
+        is_string(k)
+        v > 0
     }
 }
 
 every_one_var_construct if {
-    every k in input.object {  
-        is_string(k)                                
+    every k in input.object {
+        is_string(k)
     }
 }`,
 			expectedTokens: []semanticTokenInstance{
-				{DeltaLine: 0, DeltaCol: 14, Length: 3, Type: 0, Modifier: 0},
+				{Length: 7, Type: 3},
+				{DeltaLine: 0, DeltaCol: 14, Length: 3},
 				{DeltaLine: 3, DeltaCol: 10, Length: 1, Type: 1, Modifier: 1},
 				{DeltaLine: 0, DeltaCol: 3, Length: 1, Type: 1, Modifier: 1},
 				{DeltaLine: 1, DeltaCol: 18, Length: 1, Type: 1, Modifier: 2},
@@ -164,17 +168,18 @@ every_one_var_construct if {
 			policy: `package regal.woo
 
 some_two_vars_construct if {
-    some i, item in input.array   
-    i < 10                        
-    item > 0                        
+    some i, item in input.array
+    i < 10
+    item > 0
 }
 
 some_one_var_construct if {
-    some i in input.array   
-    i < 10                                              
+    some i in input.array
+    i < 10
 }`,
 			expectedTokens: []semanticTokenInstance{
-				{DeltaLine: 0, DeltaCol: 14, Length: 3, Type: 0, Modifier: 0},
+				{Length: 7, Type: 3},
+				{DeltaLine: 0, DeltaCol: 14, Length: 3},
 				{DeltaLine: 3, DeltaCol: 9, Length: 1, Type: 1, Modifier: 1},
 				{DeltaLine: 0, DeltaCol: 3, Length: 4, Type: 1, Modifier: 1},
 				{DeltaLine: 1, DeltaCol: 4, Length: 1, Type: 1, Modifier: 2},

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -40,6 +40,7 @@ import (
 	"github.com/open-policy-agent/regal/internal/lsp/log"
 	"github.com/open-policy-agent/regal/internal/lsp/rego"
 	"github.com/open-policy-agent/regal/internal/lsp/rego/query"
+	"github.com/open-policy-agent/regal/internal/lsp/semantictokens"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	rparse "github.com/open-policy-agent/regal/internal/parse"
@@ -1811,18 +1812,8 @@ func (l *LanguageServer) handleInitialize(ctx context.Context, params types.Init
 			SelectionRangeProvider:     true,
 			LinkedEditingRangeProvider: true,
 			SemanticTokensProvider: types.SemanticTokensOptions{
-				Legend: types.SemanticTokensLegend{
-					TokenTypes: []string{
-						"namespace",
-						"variable",
-						"namespace",
-					},
-					TokenModifiers: []string{
-						"declaration",
-						"reference",
-					},
-				},
-				Full: true,
+				Legend: semantictokens.Legend,
+				Full:   true,
 			},
 			// 'Experimental' is LSP terminology, we are using these to be
 			// 'custom' additions that are ready for use, but not in the base


### PR DESCRIPTION
Finally had a moment to play some with @SeanLedford's great work on semantic tokens, and I could not resist seeing what moving a first part of the token creation over to Rego. Feels pretty straightforward, although a bit of a pain updating the token tests. But that's a good problem to have!