### PR TITLE
feat(new): add Related Resources source link to builtin rule doc template

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -35,6 +35,7 @@ type TemplateValues struct {
 	NameOriginal string
 	Name         string
 	NameTest     string
+	FileName     string
 }
 
 var (
@@ -257,6 +258,7 @@ func createBuiltinDocs(params newRuleCommandParams) error {
 func templateValues(params newRuleCommandParams) (tvs TemplateValues) {
 	tvs.Category = params.category
 	tvs.NameOriginal = params.name
+	tvs.FileName = strings.ToLower(strings.ReplaceAll(params.name, "-", "_")) + ".rego"
 
 	if strings.Contains(params.name, "-") || strings.Contains(params.name, "_") {
 		dashedNameValue := strings.ReplaceAll(params.name, "_", "-")

--- a/internal/embeds/templates/builtin/builtin.md.tpl
+++ b/internal/embeds/templates/builtin/builtin.md.tpl
@@ -35,3 +35,7 @@ rules:
       # one of "error", "warning", "ignore"
       level: error
 ```
+
+## Related Resources
+
+- GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/{{.Category}}/{{.NameOriginal}}/{{.FileName}})


### PR DESCRIPTION
Closes #1567 (the template piece — see note on Phase 2 at the end).

## What

Builtin rule docs scaffolded by `regal new rule --type builtin` now include a `## Related Resources` section that links to the rule's `.rego` file on GitHub. This matches the pattern that already appears in hand-written rule docs such as `docs/rules/bugs/annotation-without-metadata.md`.

## How

Two small changes.

### `cmd/new.go`

`TemplateValues` gets a new field `FileName`. `templateValues()` populates it with the same normalization `templateFilename()` already uses (`strings.ToLower` + `-` → `_` + `.rego`), so the doc link resolves to the exact file `scaffoldBuiltinRule` writes:

```go
tvs.FileName = strings.ToLower(strings.ReplaceAll(params.name, "-", "_")) + ".rego"
```

### `internal/embeds/templates/builtin/builtin.md.tpl`

A new section at the end of the template:

```
## Related Resources

- GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/{{.Category}}/{{.NameOriginal}}/{{.FileName}})
```

For a rule created with `--category bugs --name my-new-rule`, this renders to `…/bundle/regal/rules/bugs/my-new-rule/my_new_rule.rego` — same path `scaffoldBuiltinRule` writes.

## Verify

```
go vet ./cmd/...    # pass
go build ./cmd/...  # pass
go test ./cmd/...   # no test files in cmd/, pass
```

I manually rendered the template against a sample `--category bugs --name my-test-rule` to confirm the resulting doc footer matches the pattern of existing rule docs.

## Scope note

The issue mentions a second item — "add a validation step to ensure this is present for any built-in rule." That's intentionally NOT in this PR: the template change here covers every new rule going forward. A retro-fit validator across the existing `docs/rules/` corpus is a separable follow-up that can cite this PR once it's merged.

This contribution was developed with AI assistance (Codex).
