### PR TITLE
Semantic import tokens Rego rewrite

### DIFF
--- a/bundle/regal/lsp/semantictokens/semantictokens_test.rego
+++ b/bundle/regal/lsp/semantictokens/semantictokens_test.rego
@@ -16,7 +16,10 @@ test_function(param1, param2) := result if {
 		with input.params.textDocument.uri as "file:///p.rego"
 
 	result == {"response": {
-		"imports": {{"location": "3:19:3:22", "type": "string", "value": "ast"}},
+		"imports": {
+			{"col": 0, "length": 6, "line": 2, "type": 3},
+			{"col": 18, "length": 3, "line": 2, "type": 2},
+		},
 		"packages": {
 			{"col": 0, "length": 7, "line": 0, "modifiers": 0, "type": 3},
 			{"col": 14, "length": 3, "line": 0, "modifiers": 0, "type": 0},

--- a/bundle/regal/lsp/semantictokens/vars/imports/imports.rego
+++ b/bundle/regal/lsp/semantictokens/vars/imports/imports.rego
@@ -6,16 +6,48 @@
 #   - input.params: schema.regal.lsp.semantictokens
 package regal.lsp.semantictokens.vars.imports
 
+import data.regal.util
+
 # METADATA
 # description: Get the module from workspace
 module := data.workspace.parsed[input.params.textDocument.uri]
 
 # METADATA:
 # description: |
-#   Extract import tokens - return only last term of the path. Does not currently highlight aliased identifiers
-result contains last_term if {
+#   Extract import keywords, and the imported identifier (last term in path or alias)
+result contains token if {
 	some import_statement in module.imports
-	import_path := import_statement.path.value
 
-	last_term := regal.last(import_path)
+	keyword_location := util.to_location_object(import_statement.location)
+	line := keyword_location.row - 1
+
+	some token in [
+		{"line": line, "col": keyword_location.col - 1, "length": 6, "type": 3}, # "import" keyword
+		_identifer(import_statement, line), # identifier (last term in path or alias)
+	]
+}
+
+_identifer(import_statement, line) := token if {
+	not import_statement.alias
+
+	identifier := regal.last(import_statement.path.value)
+	identifier_location := util.to_location_object(identifier.location)
+
+	token := {
+		"line": line,
+		"col": identifier_location.col - 1,
+		"length": identifier_location.end.col - identifier_location.col,
+		"type": 2,
+	}
+}
+
+_identifer(import_statement, line) := token if {
+	import_statement.alias
+
+	token := {
+		"line": line,
+		"col": indexof(input.regal.file.lines[line], " as ") + 4,
+		"length": count(import_statement.alias),
+		"type": 2,
+	}
 }

--- a/bundle/regal/lsp/semantictokens/vars/imports/imports_test.rego
+++ b/bundle/regal/lsp/semantictokens/vars/imports/imports_test.rego
@@ -5,13 +5,36 @@ import data.regal.lsp.semantictokens.vars.imports
 test_imports if {
 	policy := `package regal.woo
 
+import data.regal.ast`
+
+	module := regal.parse_module("p.rego", policy)
+
+	tokens := imports.result with input.params as {"textDocument": {"uri": "file://p.rego"}}
+		with input.regal as module.regal
+		with data.workspace.parsed["file://p.rego"] as module
+
+	tokens == {
+		{"col": 0, "length": 6, "line": 2, "type": 3},
+		{"col": 18, "length": 3, "line": 2, "type": 2},
+	}
+}
+
+test_imports_with_alias if {
+	policy := `package regal.woo
+
 import data.regal.ast
+import data.other.identifier as alias`
 
-test_function(param1, param2) := result if {
-	ast.is_constant
-}`
-	tokens := imports.result with input as {"params": {"textDocument": {"uri": "file://p.rego"}}}
-		with data.workspace.parsed["file://p.rego"] as regal.parse_module("p.rego", policy)
+	module := regal.parse_module("p.rego", policy)
 
-	{"location": "3:19:3:22", "type": "string", "value": "ast"} in tokens
+	tokens := imports.result with input.params as {"textDocument": {"uri": "file://p.rego"}}
+		with input.regal as module.regal
+		with data.workspace.parsed["file://p.rego"] as module
+
+	tokens == {
+		{"col": 0, "length": 6, "line": 2, "type": 3},
+		{"col": 18, "length": 3, "line": 2, "type": 2},
+		{"col": 0, "length": 6, "line": 3, "type": 3},
+		{"col": 32, "length": 5, "line": 3, "type": 2},
+	}
 }

--- a/internal/lsp/semantictokens/semantictokens.go
+++ b/internal/lsp/semantictokens/semantictokens.go
@@ -113,27 +113,22 @@ type VarsSection struct {
 
 // Represents the structured result from the Rego query
 type SemanticTokensResult struct {
-	PackageTokens []Token       `json:"packages"`
-	ImportTokens  []ASTLocation `json:"imports"`
-	Vars          VarsSection   `json:"vars"`
-	DebugInfo     any           `json:"debug_info"`
+	PackageTokens []Token     `json:"packages"`
+	ImportTokens  []Token     `json:"imports"`
+	Vars          VarsSection `json:"vars"`
+	DebugInfo     any         `json:"debug_info"`
 }
 
 func Full(ctx context.Context, result SemanticTokensResult) (*types.SemanticTokens, error) {
-	tokens := make([]Token, 0, len(result.PackageTokens))
-	tokens = append(tokens, result.PackageTokens...)
-
 	varTokens, err := processVariableTokens(result.Vars)
 	if err != nil {
 		return nil, err
 	}
-	tokens = append(tokens, varTokens...)
 
-	importTokens, err := processImportTokens(result.ImportTokens)
-	if err != nil {
-		return nil, err
-	}
-	tokens = append(tokens, importTokens...)
+	tokens := make([]Token, 0, len(result.PackageTokens)+len(result.ImportTokens)+len(varTokens))
+	tokens = append(tokens, result.PackageTokens...)
+	tokens = append(tokens, result.ImportTokens...)
+	tokens = append(tokens, varTokens...)
 
 	return encodeTokens(tokens), nil
 }
@@ -183,20 +178,6 @@ func processTokenCategory(category ArgTokenCategory, categoryName string) ([]Tok
 		token, err := extractTokens(refToken, Variable, ModifierReference)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create %s reference token: %w", categoryName, err)
-		}
-		tokens = append(tokens, token)
-	}
-
-	return tokens, nil
-}
-
-func processImportTokens(importTokens []ASTLocation) ([]Token, error) {
-	tokens := make([]Token, 0)
-
-	for _, importToken := range importTokens {
-		token, err := extractTokens(importToken, Import, 0)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create import token: %w", err)
 		}
 		tokens = append(tokens, token)
 	}

--- a/internal/lsp/semantictokens_test.go
+++ b/internal/lsp/semantictokens_test.go
@@ -62,19 +62,15 @@ test_function(param1) := result if {
 			policy: `package regal.woo
 
 import data.regal.ast
-
-test_function(param1) := result if {
-      calc3 := 1
-      calc3 == param1
-	  ast.is_constant
-}
+import data.regal.util as uuuuutil
 `,
 			expectedTokens: []semanticTokenInstance{
 				{Length: 7, Type: 3},
 				{DeltaLine: 0, DeltaCol: 14, Length: 3},
-				{DeltaLine: 2, DeltaCol: 18, Length: 3, Type: 2},
-				{DeltaLine: 2, DeltaCol: 14, Length: 6, Type: 1, Modifier: 1},
-				{DeltaLine: 2, DeltaCol: 15, Length: 6, Type: 1, Modifier: 2},
+				{DeltaLine: 2, Length: 6, Type: 3},
+				{DeltaCol: 18, Length: 3, Type: 2},
+				{DeltaLine: 1, Length: 6, Type: 3},
+				{DeltaCol: 26, Length: 8, Type: 2},
 			},
 		},
 		"full policy with package, declarations and references": {


### PR DESCRIPTION
As with the package rewrite, also return a token for the `import` keyword.

Now also handles aliased imports, and will treat the alias as the imported identifier rather than the last path component. We really ought to have the RoAST encoder encode an alias as a proper term with location, but that will have to come as a separate change as it touches quite many components. 