### PR TITLE
docs: Update setup-regal in docs

### DIFF
--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: open-policy-agent/setup-regal@v1
+    - uses: open-policy-agent/setup-regal@v2
       with:
         # For production workflows, use a specific version, like v0.22.0
         version: latest

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -19,7 +19,7 @@ jobs:
   lint-rego:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: open-policy-agent/setup-regal@v2
       with:
         # For production workflows, use a specific version, like v0.22.0


### PR DESCRIPTION
This pointed to a very old release of the setup action

https://github.com/open-policy-agent/setup-regal/releases/tag/v2.0.0

