### PR TITLE
Minor fixes

### DIFF
--- a/bundle/regal/rules/custom/one-liner-rule/one_liner_rule.rego
+++ b/bundle/regal/rules/custom/one-liner-rule/one_liner_rule.rego
@@ -60,10 +60,12 @@ _rule_body_brackets(lines) if {
 }
 
 _comment_in_body(rule_row, comments, lines) if {
+	num_lines := count(lines)
+
 	some comment in comments
 
 	comment_row := to_number(util.substring_to(comment.location, 0, ":"))
 
 	comment_row > rule_row
-	comment_row < rule_row + count(lines)
+	comment_row < rule_row + num_lines
 }

--- a/docs/rules/custom/naming-convention.md
+++ b/docs/rules/custom/naming-convention.md
@@ -32,18 +32,27 @@ rules:
       # one of "error", "warning", "ignore"
       level: error
       conventions:
-          # allow only "private" rules and functions, i.e. those starting with
-          # underscore, or rules named "deny" or "allow"
-        - pattern: '^_[a-z]+$|^deny$|^allow$'
+        # allow only "private" rules and functions, i.e. those starting with
+        # underscore, or rules named "deny" or "allow"
+        - pattern: "^_[a-z]+$|^deny$|^allow$"
           # one of "package", "rule", "function", "variable"
           targets:
             - rule
             - function
         # any number of naming rules may be added
         # package names must start with "acmecorp" or "system"
-        - pattern: '^acmecorp|^system'
+        - pattern: "^acmecorp|^system"
           targets:
             - package
+        # a list of names may be provided in addition to a pattern
+        # if both a pattern and a list of names are provided, identifiers
+        # must match either the pattern or one of the names in the list
+        - names:
+            - i
+            - j
+            - k
+          targets:
+            - var
 ```
 
 **Note:** In order to avoid characters accidentally getting escaped, always use single quotes to encode your regex


### PR DESCRIPTION
- Add missing docs on `names` config option for `naming-convention` rule
- Fix case of [repeated computation](https://github.com/open-policy-agent/regal/issues/1820)