### PR TITLE
Various code quality improvements

### DIFF
--- a/bundle/regal/lsp/semantictokens/vars/imports/imports_test.rego
+++ b/bundle/regal/lsp/semantictokens/vars/imports/imports_test.rego
@@ -9,7 +9,8 @@ import data.regal.ast`
 
 	module := regal.parse_module("p.rego", policy)
 
-	tokens := imports.result with input.params as {"textDocument": {"uri": "file://p.rego"}}
+	tokens := imports.result
+		with input.params as {"textDocument": {"uri": "file://p.rego"}}
 		with input.regal as module.regal
 		with data.workspace.parsed["file://p.rego"] as module
 
@@ -27,7 +28,8 @@ import data.other.identifier as alias`
 
 	module := regal.parse_module("p.rego", policy)
 
-	tokens := imports.result with input.params as {"textDocument": {"uri": "file://p.rego"}}
+	tokens := imports.result
+		with input.params as {"textDocument": {"uri": "file://p.rego"}}
 		with input.regal as module.regal
 		with data.workspace.parsed["file://p.rego"] as module
 

--- a/bundle/regal/main/main_ignore_test.rego
+++ b/bundle/regal/main/main_ignore_test.rego
@@ -91,7 +91,8 @@ test_ignore_directive_multiple_success if {
 	default camelCase = "yes"
 	`
 	report := main.report
-		with input as regal.parse_module("p.rego", policy) with config.rules as {"style": {
+		with input as regal.parse_module("p.rego", policy)
+		with config.rules as {"style": {
 			"prefer-snake-case": {"level": "error"},
 			"use-assignment-operator": {"level": "error"},
 		}}
@@ -110,7 +111,8 @@ test_ignore_directive_multiple_mixed_success if {
 	default camelCase = "yes"
 	`
 	report := main.report
-		with input as regal.parse_module("p.rego", policy) with config.rules as {"style": {
+		with input as regal.parse_module("p.rego", policy)
+		with config.rules as {"style": {
 			"prefer-snake-case": {"level": "error"},
 			"use-assignment-operator": {"level": "error"},
 		}}

--- a/bundle/regal/main/main_test.rego
+++ b/bundle/regal/main/main_test.rego
@@ -15,7 +15,8 @@ test_multiple_failures if {
 	default camelCase = "yes"
 	`
 	report := main.report
-		with input as regal.parse_module("p.rego", policy) with config.rules as {"style": {
+		with input as regal.parse_module("p.rego", policy)
+		with config.rules as {"style": {
 			"prefer-snake-case": {"level": "error"},
 			"use-assignment-operator": {"level": "error"},
 		}}

--- a/bundle/regal/rules/bugs/var-shadows-builtin/var_shadows_builtin_test.rego
+++ b/bundle/regal/rules/bugs/var-shadows-builtin/var_shadows_builtin_test.rego
@@ -35,14 +35,18 @@ test_fail_var_shadows_builtin if {
 }
 
 test_success_var_does_not_shadow_builtin if {
-	r := rule.report with input as ast.policy(`allow if a := "yes"`) with config.capabilities as capabilities.provided
+	r := rule.report
+		with input as ast.policy(`allow if a := "yes"`)
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }
 
 # https://github.com/open-policy-agent/regal/issues/1163
 test_success_print_excluded if {
-	r := rule.report with input as ast.policy(`x if print([y - 1])`) with config.capabilities as capabilities.provided
+	r := rule.report
+		with input as ast.policy(`x if print([y - 1])`)
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }

--- a/bundle/regal/rules/testing/identically-named-tests/identically_named_tests_test.rego
+++ b/bundle/regal/rules/testing/identically-named-tests/identically_named_tests_test.rego
@@ -42,5 +42,6 @@ test_success_differently_named_tests if {
 	test_baz if { 1 == 1 }
 	`)
 	r := rule.report with input as ast
+
 	r == set()
 }

--- a/bundle/regal/rules/testing/test-outside-test-package/test_outside_test_package_test.rego
+++ b/bundle/regal/rules/testing/test-outside-test-package/test_outside_test_package_test.rego
@@ -5,7 +5,9 @@ import data.regal.ast
 import data.regal.rules.testing["test-outside-test-package"] as rule
 
 test_fail_test_outside_test_package if {
-	r := rule.report with input as ast.policy(`test_foo if { false }`) with input.regal.file.name as "p_test.rego"
+	r := rule.report
+		with input as ast.policy(`test_foo if { false }`)
+		with input.regal.file.name as "p_test.rego"
 
 	r == {{
 		"category": "testing",

--- a/internal/lsp/eval.go
+++ b/internal/lsp/eval.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/open-policy-agent/opa/v1/ast"
@@ -13,10 +16,15 @@ import (
 	"github.com/open-policy-agent/opa/v1/topdown/print"
 
 	rbundle "github.com/open-policy-agent/regal/bundle"
+	rio "github.com/open-policy-agent/regal/internal/io"
+	rrego "github.com/open-policy-agent/regal/internal/lsp/rego"
 	rquery "github.com/open-policy-agent/regal/internal/lsp/rego/query"
+	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
+	rparse "github.com/open-policy-agent/regal/internal/parse"
 	"github.com/open-policy-agent/regal/internal/util"
 	"github.com/open-policy-agent/regal/pkg/config"
+	"github.com/open-policy-agent/regal/pkg/roast/encoding"
 	"github.com/open-policy-agent/regal/pkg/roast/transform"
 
 	_ "github.com/open-policy-agent/regal/pkg/builtins"
@@ -29,6 +37,7 @@ var (
 		Roots:    &[]string{"workspace"}, // no data in this bundle so no roots are used, however, roots must be set
 		Metadata: map[string]any{"name": "workspace"},
 	}
+	regalEvalUseAsInputComment = regexp.MustCompile(`^\s*regal eval:\s*use-as-input`)
 )
 
 type EvalResult struct {
@@ -43,6 +52,131 @@ type PrintHook struct {
 	// because rego files are evaluated with relative paths (so errors match
 	// OPA CLI format) but print hook output consumers need full URIs.
 	FileNameBase string
+}
+
+func (l *LanguageServer) handleEvalCommand(ctx context.Context, args types.CommandArgs) error {
+	if args.Target == "" || args.Query == "" {
+		l.log.Message("expected command target and query, got target %q, query %q", args.Target, args.Query)
+
+		return nil
+	}
+
+	contents, module, ok := l.cache.GetContentAndModule(args.Target)
+	if !ok {
+		l.log.Message("failed to get content or module for file %q", args.Target)
+
+		return nil
+	}
+
+	var pq *rquery.Prepared
+
+	pq, err := l.queryCache.GetOrSet(ctx, l.regoStore, rquery.RuleHeadLocations)
+	if err != nil {
+		l.log.Message("failed to prepare query %s", rquery.RuleHeadLocations, err)
+
+		return nil
+	}
+
+	var allRuleHeadLocations rrego.RuleHeads
+
+	allRuleHeadLocations, err = rrego.AllRuleHeadLocations(
+		ctx, pq, filepath.Base(uri.ToPath(args.Target)), contents, module,
+	)
+	if err != nil {
+		l.log.Message("failed to get rule head locations: %s", err)
+
+		return nil
+	}
+
+	// if there are none, then it's a package evaluation
+	ruleHeadLocations := allRuleHeadLocations[args.Query]
+
+	var inputMap map[string]any
+
+	var inputPath string
+
+	// When the first comment in the file is `regal eval: use-as-input`, the AST of that module is
+	// used as the input rather than the contents of input.json/yaml. This is a development feature for
+	// working on rules (built-in or custom), allowing querying the AST of the module directly.
+	if len(module.Comments) > 0 && regalEvalUseAsInputComment.Match(module.Comments[0].Text) {
+		//nolint:staticcheck
+		inputMap, err = rparse.PrepareAST(l.toRelativePath(args.Target), contents, module)
+		if err != nil {
+			l.log.Message("failed to prepare module: %s", err)
+
+			return nil
+		}
+	} else {
+		// Normal mode — try to find the input.json/yaml file in the workspace and use as input
+		// NOTE that we don't break on missing input, as some rules don't depend on that, and should
+		// still be evaluable. We may consider returning some notice to the user though.
+		inputPath, inputMap = rio.FindInput(uri.ToPath(args.Target), l.workspacePath())
+
+		ruleName := strings.TrimPrefix(args.Query, module.Package.Path.String()+".")
+
+		if inputPath == "" && !l.supressInputPrompt {
+			created, err := l.handleInputSkeletonPrompt(ctx, args.Target, ruleName, args.Row)
+			// Bubbling up an error here if input.json creation fails for any reason.
+			if err != nil {
+				return err
+			}
+
+			if created {
+				return nil
+			}
+		}
+	}
+
+	var result EvalResult
+
+	if result, err = l.EvalInWorkspace(ctx, args.Query, inputMap); err != nil {
+		return fmt.Errorf("failed to evaluate workspace path: %w", err)
+	}
+
+	target := "package"
+	if len(ruleHeadLocations) > 0 {
+		target = strings.TrimPrefix(args.Query, module.Package.Path.String()+".")
+	}
+
+	if l.featureFlags.InlineEvaluationProvider && l.getClient().SupportsEvalCodelensDisplayInline() {
+		responseParams := map[string]any{
+			"result": result,
+			"line":   args.Row,
+			"target": target,
+			// only used when the target is 'package'
+			"package": strings.TrimPrefix(module.Package.Path.String(), "data."),
+			// only used when the target is a rule
+			"rule_head_locations": ruleHeadLocations,
+		}
+
+		responseResult := map[string]any{}
+
+		// Use a timeout context for RPC to ensure it completes during graceful shutdown
+		rpcCtx, rpcCancel := context.WithTimeout(context.Background(), rpcTimeout)
+
+		//nolint:contextcheck
+		if err = l.conn.Call(rpcCtx, "regal/showEvalResult", responseParams, &responseResult); err != nil {
+			l.log.Message("regal/showEvalResult failed: %v", err.Error())
+		}
+
+		rpcCancel()
+	} else {
+		output := filepath.Join(l.workspacePath(), "output.json")
+
+		var f *os.File
+		if f, err = os.OpenFile(output, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o755); err == nil {
+			value := result.Value
+			if result.IsUndefined {
+				value = emptyStringAnyMap // undefined displays as an empty object
+			}
+
+			err = encoding.NewIndentEncoder(f, "", "  ").Encode(value)
+
+			rio.CloseIgnore(f)
+		}
+	}
+
+	return err
 }
 
 func (l *LanguageServer) Eval(

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -43,7 +43,6 @@ import (
 	"github.com/open-policy-agent/regal/internal/lsp/semantictokens"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
-	rparse "github.com/open-policy-agent/regal/internal/parse"
 	"github.com/open-policy-agent/regal/internal/roast/transforms"
 	"github.com/open-policy-agent/regal/internal/update"
 	"github.com/open-policy-agent/regal/internal/util"
@@ -83,8 +82,7 @@ var (
 	noDiagnostics = make([]types.Diagnostic, 0)
 	orc           = oracle.New()
 
-	regalEvalUseAsInputComment = regexp.MustCompile(`^\s*regal eval:\s*use-as-input`)
-	validPathComponentPattern  = regexp.MustCompile(`^\w+[\w\-]*\w+$`)
+	validPathComponentPattern = regexp.MustCompile(`^\w+[\w\-]*\w+$`)
 
 	fixFmt                    = &fixes.Fmt{OPAFmtOpts: format.Opts{}}
 	fixUseRegoV1              = &fixes.Fmt{OPAFmtOpts: format.Opts{RegoVersion: ast.RegoV0CompatV1}}
@@ -144,7 +142,6 @@ type LanguageServer struct {
 	loadedConfig  *config.Config
 	// this is also used to lock the updates to the cache of enabled rules
 	loadedConfigLock            sync.RWMutex
-	loadedConfigEnabledRules    []string
 	loadedConfigAllRegoVersions *concurrent.Map[string, ast.RegoVersion]
 	loadedBuiltins              *concurrent.Map[string, map[string]*ast.Builtin]
 
@@ -208,10 +205,7 @@ func NewLanguageServerMinimal(ctx context.Context, opts *LanguageServerOptions, 
 	store := NewRegalStore()
 
 	// Use provided feature flags, or defaults if not set
-	featureFlags := opts.FeatureFlags
-	if featureFlags == nil {
-		featureFlags = DefaultServerFeatureFlags()
-	}
+	featureFlags := util.Or(opts.FeatureFlags, DefaultServerFeatureFlags)
 
 	ls := &LanguageServer{
 		cache:              c,
@@ -420,7 +414,6 @@ func (l *LanguageServer) StartDiagnosticsWorker(ctx context.Context) {
 						Cache:            l.cache,
 						RegalConfig:      l.getLoadedConfig(),
 						WorkspaceRootURI: l.getWorkspaceRootURI(),
-						UpdateForRules:   l.getEnabledRules(),
 						CustomRulesPath:  l.getCustomRulesPath(),
 					})
 					if err != nil {
@@ -654,13 +647,11 @@ func (l *LanguageServer) StartCommandWorker(ctx context.Context) {
 
 					rpcCancel()
 				case "regal.config.disable-rule":
-					err = l.handleIgnoreRuleCommand(ctx, args)
-					if err != nil {
+					if err = l.handleIgnoreRuleCommand(ctx, args); err != nil {
 						l.log.Message("failed to ignore rule: %s", err)
 					}
 
-					// handle this ourselves as it's a config edit
-					fixed = false
+					fixed = false // handle this ourselves as it's a config edit
 				}
 
 				if err != nil {
@@ -796,13 +787,6 @@ func (l *LanguageServer) setClient(client types.Client) {
 	l.client = client
 }
 
-func (l *LanguageServer) getEnabledRules() []string {
-	l.loadedConfigLock.RLock()
-	defer l.loadedConfigLock.RUnlock()
-
-	return l.loadedConfigEnabledRules
-}
-
 func (l *LanguageServer) getCustomRulesPath() string {
 	if l.getWorkspaceRootURI() != "" {
 		if customRulesPath := filepath.Join(l.workspacePath(), ".regal", "rules"); rio.IsDir(customRulesPath) {
@@ -834,11 +818,6 @@ func (l *LanguageServer) loadConfig(ctx context.Context, conf config.Config) {
 				l.loadedConfigAllRegoVersions.Set(k, v)
 			}
 		}
-	}
-
-	// Enabled rules might have changed with the new config, so reload.
-	if err := l.loadEnabledRulesFromConfig(ctx, conf); err != nil {
-		l.log.Message("failed to cache enabled rules: %s", err)
 	}
 
 	// Capabilities URL may have changed, so we should reload it.
@@ -900,24 +879,6 @@ func (l *LanguageServer) loadConfig(ctx context.Context, conf config.Config) {
 
 		l.cache.ClearIgnoredFileContents(k)
 	}
-}
-
-// loadEnabledRulesFromConfig is used to cache the enabled rules for the current
-// config. These take some time to compute and only change when config changes,
-// so we can store them on the server to speed up diagnostic runs.
-func (l *LanguageServer) loadEnabledRulesFromConfig(ctx context.Context, cfg config.Config) error {
-	lint := linter.NewLinter().WithUserConfig(cfg).WithCustomRulesPaths(l.getCustomRulesPath())
-
-	rules, err := lint.DetermineEnabledRules(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to determine enabled rules: %w", err)
-	}
-
-	l.loadedConfigLock.Lock()
-	l.loadedConfigEnabledRules = rules
-	l.loadedConfigLock.Unlock()
-
-	return nil
 }
 
 // processTemplateJob handles the templating of a newly created Rego file.
@@ -1713,7 +1674,7 @@ func (l *LanguageServer) handleWorkspaceDiagnostic() (any, error) {
 	}}}, nil
 }
 
-func (l *LanguageServer) handleInitialize(ctx context.Context, params types.InitializeParams) (any, error) {
+func (l *LanguageServer) handleInitialize(_ context.Context, params types.InitializeParams) (any, error) {
 	if bundle.DevModeEnabled() {
 		path := os.Getenv("REGAL_BUNDLE_PATH")
 		fmt.Fprintln(os.Stderr, "Development mode enabled. Will attempt to build bundle from:", path)
@@ -1862,10 +1823,6 @@ func (l *LanguageServer) handleInitialize(ctx context.Context, params types.Init
 	l.loadedConfigLock.Lock()
 	l.loadedConfig = &defaultConfig
 	l.loadedConfigLock.Unlock()
-
-	if err := l.loadEnabledRulesFromConfig(ctx, defaultConfig); err != nil {
-		l.log.Message("failed to cache enabled rules: %s", err)
-	}
 
 	if params.RootURI != "" {
 		err := l.updateRootURI(params.RootURI)
@@ -2540,131 +2497,6 @@ func (l *LanguageServer) handleInputSkeletonPrompt(
 	}
 
 	return false, nil
-}
-
-func (l *LanguageServer) handleEvalCommand(ctx context.Context, args types.CommandArgs) error {
-	if args.Target == "" || args.Query == "" {
-		l.log.Message("expected command target and query, got target %q, query %q", args.Target, args.Query)
-
-		return nil
-	}
-
-	contents, module, ok := l.cache.GetContentAndModule(args.Target)
-	if !ok {
-		l.log.Message("failed to get content or module for file %q", args.Target)
-
-		return nil
-	}
-
-	var pq *query.Prepared
-
-	pq, err := l.queryCache.GetOrSet(ctx, l.regoStore, query.RuleHeadLocations)
-	if err != nil {
-		l.log.Message("failed to prepare query %s", query.RuleHeadLocations, err)
-
-		return nil
-	}
-
-	var allRuleHeadLocations rego.RuleHeads
-
-	allRuleHeadLocations, err = rego.AllRuleHeadLocations(
-		ctx, pq, filepath.Base(uri.ToPath(args.Target)), contents, module,
-	)
-	if err != nil {
-		l.log.Message("failed to get rule head locations: %s", err)
-
-		return nil
-	}
-
-	// if there are none, then it's a package evaluation
-	ruleHeadLocations := allRuleHeadLocations[args.Query]
-
-	var inputMap map[string]any
-
-	var inputPath string
-
-	// When the first comment in the file is `regal eval: use-as-input`, the AST of that module is
-	// used as the input rather than the contents of input.json/yaml. This is a development feature for
-	// working on rules (built-in or custom), allowing querying the AST of the module directly.
-	if len(module.Comments) > 0 && regalEvalUseAsInputComment.Match(module.Comments[0].Text) {
-		//nolint:staticcheck
-		inputMap, err = rparse.PrepareAST(l.toRelativePath(args.Target), contents, module)
-		if err != nil {
-			l.log.Message("failed to prepare module: %s", err)
-
-			return nil
-		}
-	} else {
-		// Normal mode — try to find the input.json/yaml file in the workspace and use as input
-		// NOTE that we don't break on missing input, as some rules don't depend on that, and should
-		// still be evaluable. We may consider returning some notice to the user though.
-		inputPath, inputMap = rio.FindInput(uri.ToPath(args.Target), l.workspacePath())
-
-		ruleName := strings.TrimPrefix(args.Query, module.Package.Path.String()+".")
-
-		if inputPath == "" && !l.supressInputPrompt {
-			created, err := l.handleInputSkeletonPrompt(ctx, args.Target, ruleName, args.Row)
-			// Bubbling up an error here if input.json creation fails for any reason.
-			if err != nil {
-				return err
-			}
-
-			if created {
-				return nil
-			}
-		}
-	}
-
-	var result EvalResult
-
-	if result, err = l.EvalInWorkspace(ctx, args.Query, inputMap); err != nil {
-		return fmt.Errorf("failed to evaluate workspace path: %w", err)
-	}
-
-	target := "package"
-	if len(ruleHeadLocations) > 0 {
-		target = strings.TrimPrefix(args.Query, module.Package.Path.String()+".")
-	}
-
-	if l.featureFlags.InlineEvaluationProvider && l.getClient().SupportsEvalCodelensDisplayInline() {
-		responseParams := map[string]any{
-			"result": result,
-			"line":   args.Row,
-			"target": target,
-			// only used when the target is 'package'
-			"package": strings.TrimPrefix(module.Package.Path.String(), "data."),
-			// only used when the target is a rule
-			"rule_head_locations": ruleHeadLocations,
-		}
-
-		responseResult := map[string]any{}
-
-		// Use a timeout context for RPC to ensure it completes during graceful shutdown
-		rpcCtx, rpcCancel := context.WithTimeout(context.Background(), rpcTimeout)
-
-		//nolint:contextcheck
-		if err = l.conn.Call(rpcCtx, "regal/showEvalResult", responseParams, &responseResult); err != nil {
-			l.log.Message("regal/showEvalResult failed: %v", err.Error())
-		}
-
-		rpcCancel()
-	} else {
-		output := filepath.Join(l.workspacePath(), "output.json")
-
-		var f *os.File
-		if f, err = os.OpenFile(output, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o755); err == nil {
-			value := result.Value
-			if result.IsUndefined {
-				value = emptyStringAnyMap // undefined displays as an empty object
-			}
-
-			err = encoding.NewIndentEncoder(f, "", "  ").Encode(value)
-
-			rio.CloseIgnore(f)
-		}
-	}
-
-	return err
 }
 
 func positionToOffset(text string, p types.Position) int {

--- a/internal/lsp/server_config_test.go
+++ b/internal/lsp/server_config_test.go
@@ -1,17 +1,11 @@
 package lsp
 
 import (
-	"context"
 	"path/filepath"
-	"slices"
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/jsonrpc2"
-
-	"github.com/open-policy-agent/regal/internal/lsp/clients"
 	"github.com/open-policy-agent/regal/internal/lsp/log"
-	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	"github.com/open-policy-agent/regal/internal/test/must"
 	"github.com/open-policy-agent/regal/internal/testutil"
@@ -79,139 +73,4 @@ allow := true
 	timeout.Reset(determineTimeout())
 
 	waitForViolations(t, "main.rego", []string{}, []string{}, timeout, receivedMessages)
-}
-
-func TestLanguageServerCachesEnabledRulesAndUsesDefaultConfig(t *testing.T) {
-	t.Parallel()
-
-	tempDir := testutil.TempDirectoryOf(t, map[string]string{
-		".regal/config.yaml": `
-rules:
-  idiomatic:
-    directory-package-mismatch:
-      level: ignore
-  imports:
-    unresolved-import:
-      level: ignore
-`,
-	})
-
-	// no op handler
-	clientHandler := func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
-		t.Logf("message received: %s", req.Method)
-
-		return struct{}{}, nil
-	}
-
-	ls, connClient, ctx := createAndInitServer(t, tempDir, clientHandler)
-
-	ls.StartConfigWorker(ctx)
-
-	if got, exp := ls.workspaceRootURI, uri.FromPath(ls.getClient().Identifier, tempDir); exp != got {
-		t.Fatalf("expected client root URI to be %s, got %s", exp, got)
-	}
-
-	timeout := time.NewTimer(determineTimeout())
-	ticker := time.NewTicker(testPollInterval)
-	pollCount := 0
-
-	for success := false; !success; {
-		select {
-		case <-ticker.C:
-			pollCount++
-
-			if len(ls.getEnabledRules()) == 0 {
-				t.Logf("no enabled rules yet... (poll %d)", pollCount)
-
-				continue
-			}
-
-			success = true
-		case <-timeout.C:
-			t.Fatalf("timed out waiting for enabled rules to be correct after %d polls", pollCount)
-		}
-	}
-
-	// this event is sent to allow the server to detect the new config
-	if err := connClient.Notify(ctx, "workspace/didChangeWatchedFiles", types.WorkspaceDidChangeWatchedFilesParams{
-		Changes: []types.FileEvent{{
-			URI:  uri.FromPath(clients.IdentifierGoTest, filepath.Join(tempDir, ".regal", "config.yaml")),
-			Type: 1, // created
-		}},
-	}, nil); err != nil {
-		t.Fatalf("failed to send didChange notification: %s", err)
-	}
-
-	timeout.Reset(determineTimeout())
-
-	pollCount = 0
-
-	for success := false; !success; {
-		select {
-		case <-ticker.C:
-			pollCount++
-			enabledRules := ls.getEnabledRules()
-
-			if slices.Contains(enabledRules, "directory-package-mismatch") {
-				t.Logf("enabledRules still contains directory-package-mismatch (poll %d)", pollCount)
-
-				continue
-			}
-
-			if slices.Contains(enabledRules, "unresolved-import") {
-				t.Logf("enabledRules still contains unresolved-import (poll %d)", pollCount)
-
-				continue
-			}
-
-			success = true
-		case <-timeout.C:
-			t.Fatalf("timed out waiting for enabled rules to be correct after %d polls", pollCount)
-		}
-	}
-
-	configContents2 := `
-rules:
-  style:
-    opa-fmt:
-      level: ignore
-  idiomatic:
-    directory-package-mismatch:
-      level: error
-  imports:
-    unresolved-import:
-      level: error
-`
-
-	must.WriteFile(t, filepath.Join(tempDir, ".regal", "config.yaml"), []byte(configContents2))
-	timeout.Reset(determineTimeout())
-
-	for success := false; !success; {
-		select {
-		case <-ticker.C:
-			enabledRules := ls.getEnabledRules()
-
-			if slices.Contains(enabledRules, "opa-fmt") {
-				t.Log("enabledRules still contains opa-fmt")
-
-				continue
-			}
-
-			if !slices.Contains(enabledRules, "directory-package-mismatch") {
-				t.Log("enabledRules must contain directory-package-mismatch")
-
-				continue
-			}
-
-			if !slices.Contains(enabledRules, "unresolved-import") {
-				t.Log("enabledRules must contain unresolved-import")
-
-				continue
-			}
-
-			success = true
-		case <-timeout.C:
-			t.Fatalf("timed out waiting for enabled rules to be correct")
-		}
-	}
 }

--- a/internal/lsp/server_testing.go
+++ b/internal/lsp/server_testing.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"sync"
 	"time"
 
+	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/runtime/info"
 	"github.com/open-policy-agent/opa/v1/storage"
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
@@ -13,15 +15,22 @@ import (
 
 	"github.com/open-policy-agent/regal/internal/compile"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
+	"github.com/open-policy-agent/regal/internal/util"
 	"github.com/open-policy-agent/regal/pkg/config"
 )
 
+var runtimeInfo = sync.OnceValue(func() *ast.Term {
+	info, err := info.New()
+	if err != nil {
+		info = ast.InternedEmptyObject
+	}
+
+	return info
+})
+
 // handleRunTests handles the regal/runTests LSP request.
 // It runs OPA tests based on the provided parameters and returns results.
-func (l *LanguageServer) handleRunTests(
-	ctx context.Context,
-	params types.RunTestsParams,
-) (any, error) {
+func (l *LanguageServer) handleRunTests(ctx context.Context, params types.RunTestsParams) (any, error) {
 	// Ensure the target file is parsed before running tests.
 	// This handles the case where regal/runTests is called immediately after
 	// textDocument/didOpen, before the async diagnostics worker has parsed the file.
@@ -32,58 +41,19 @@ func (l *LanguageServer) handleRunTests(
 		}
 	}
 
-	// Create new isolated store for this test run (NO SHARED STATE)
-	testStore := inmem.NewWithOpts(
-		inmem.OptRoundTripOnWrite(false),
-		inmem.OptReturnASTValuesOnRead(true),
-	)
+	store, txn := newStoreAndTxn(ctx, l.getLoadedConfig())
 
-	txn, err := testStore.NewTransaction(ctx, storage.WriteParams)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create transaction: %w", err)
-	}
-
-	defer testStore.Abort(ctx, txn)
-
-	// TODO: make the loading of config and regal built-ins only happen
-	// in Regal repo
-	cfg := l.getLoadedConfig()
-
-	var caps *config.Capabilities
-	if cfg != nil && cfg.Capabilities != nil {
-		caps = cfg.Capabilities
-	} else {
-		caps = config.CapabilitiesForThisVersion()
-	}
-
-	_ = testStore.Write(ctx, txn, storage.AddOp, storage.MustParsePath("/internal"), map[string]any{})
-
-	if err := testStore.Write(
-		ctx,
-		txn,
-		storage.AddOp,
-		storage.MustParsePath("/internal/capabilities"),
-		caps,
-	); err != nil {
-		return nil, fmt.Errorf("failed to write capabilities: %w", err)
-	}
-
-	runtimeInfo, err := info.New()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create runtime info: %w", err)
-	}
+	defer store.Abort(ctx, txn)
 
 	filter := fmt.Sprintf("%s.%s$", regexp.QuoteMeta(params.Package), regexp.QuoteMeta(params.Name))
 
-	compiler := compile.NewCompilerWithRegalBuiltins().
-		WithEnablePrintStatements(true).
-		WithUseTypeCheckAnnotations(true)
-
 	runner := tester.NewRunner().
-		SetCompiler(compiler).
-		SetStore(testStore).
+		SetCompiler(compile.NewCompilerWithRegalBuiltins().
+			WithEnablePrintStatements(true).
+			WithUseTypeCheckAnnotations(true)).
+		SetStore(store).
 		SetBundles(l.assembleBundles()).
-		SetRuntime(runtimeInfo).
+		SetRuntime(runtimeInfo()).
 		CapturePrintOutput(true).
 		SetTimeout(5 * time.Second).
 		Filter(filter)
@@ -93,9 +63,7 @@ func (l *LanguageServer) handleRunTests(
 		return nil, fmt.Errorf("failed to run tests: %w", err)
 	}
 
-	results := collectTestResults(ch)
-
-	return results, nil
+	return collectTestResults(ch), nil
 }
 
 // collectTestResults collects test results from the runner's channel.
@@ -109,4 +77,16 @@ func collectTestResults(ch chan *tester.Result) []tester.Result {
 	}
 
 	return results
+}
+
+func newStoreAndTxn(ctx context.Context, cfg *config.Config) (storage.Store, storage.Transaction) {
+	store := inmem.NewFromObjectWithOpts(map[string]any{
+		"internal": map[string]any{
+			"capabilities": util.Or(cfg.Capabilities, config.CapabilitiesForThisVersion),
+		},
+	}, inmem.OptRoundTripOnWrite(false), inmem.OptReturnASTValuesOnRead(true))
+
+	txn, _ := store.NewTransaction(ctx, storage.WriteParams)
+
+	return store, txn
 }

--- a/internal/lsp/store.go
+++ b/internal/lsp/store.go
@@ -23,6 +23,7 @@ var (
 func NewRegalStore() storage.Store {
 	return inmem.NewFromObjectWithOpts(map[string]any{
 		"workspace": map[string]any{
+			"config": map[string]any{},
 			"parsed": map[string]any{},
 			// should map[string][]string{}, but since we don't round trip on write,
 			// we'll need to conform to the most basic "JSON" format understood by the store

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -318,6 +318,22 @@ func Reversed[T any](s []T) []T {
 	return s
 }
 
+// Or works like [cmp.Or] but allows supplier functions to be tried rather than
+// alternative values. This allows deferring computation of the alternatives to
+// only when needed.
+func Or[T comparable](val T, suppliers ...func() T) T {
+	var zero T
+	if val == zero {
+		for _, f := range suppliers {
+			if alt := f(); alt != zero {
+				return alt
+			}
+		}
+	}
+
+	return val
+}
+
 // LineContents returns the contents on line lineNum (0-indexed) from document.
 // This function assumes the lineNum is known to be contained within the document.
 func LineContents(document []byte, lineNum uint) []byte {


### PR DESCRIPTION
- Fix a few remaining `with` chains not found before
- Move eval handler into eval.go to reduce size of server.go
- Add util.Or convenience function
- Remove unused "loaded rules" logic
- Test runner API improvements before upcoming overhaul

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->