### PR TITLE
feat(pre-commit): add regal-fix hooks for auto-fixing rules

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -18,3 +18,24 @@
   description: policy file linting with Regal downloaded from Github
   entry: build/download-and-run.sh lint
   files: (\.rego)$
+
+- id: regal-fix
+  language: golang
+  name: policy file fixing
+  description: auto-fix policy files with Regal from Styra built from source
+  entry: regal fix --force
+  files: (\.rego)$
+
+- id: regal-fix-use-path
+  language: system
+  name: policy file fixing
+  description: auto-fix policy files with Regal from Styra using system $PATH
+  entry: regal fix --force
+  files: (\.rego)$
+
+- id: regal-fix-download
+  language: script
+  name: policy file fixing
+  description: auto-fix policy files with Regal downloaded from Github
+  entry: build/download-and-run.sh fix --force
+  files: (\.rego)$

--- a/docs/pre-commit-hooks.md
+++ b/docs/pre-commit-hooks.md
@@ -40,3 +40,33 @@ Runs Regal against all staged `.rego` files, aborting the commit if any fail.
 Runs Regal against all staged `.rego` files, aborting the commit if any fail.
 
 - Downloads the latest `regal` binary from Github.
+
+### `regal-fix`
+
+![commit-msg hook](https://img.shields.io/badge/hook-pre--commit-informational?logo=git)
+
+Runs `regal fix --force` against all staged `.rego` files, applying any
+auto-fixable rule violations in place. Use this alongside `regal-lint` when you
+want the hook to repair style-level issues automatically rather than asking the
+contributor to re-run `regal fix` themselves. `--force` is required because
+pre-commit invokes hooks against files staged in a dirty git tree.
+
+- requires the `go` build chain is installed and available on `$PATH`
+- will build and install the tagged version of Regal in an isolated `GOPATH`
+- ensures compatibility between versions
+
+### `regal-fix-use-path`
+
+![commit-msg hook](https://img.shields.io/badge/hook-pre--commit-informational?logo=git)
+
+Same as `regal-fix`, but uses the `regal` binary already on `$PATH`.
+
+- requires the `regal` package is already installed and available on `$PATH`.
+
+### `regal-fix-download`
+
+![commit-msg hook](https://img.shields.io/badge/hook-pre--commit-informational?logo=git)
+
+Same as `regal-fix`, but downloads the latest `regal` binary from GitHub instead of building or relying on `$PATH`.
+
+- Downloads the latest `regal` binary from Github.


### PR DESCRIPTION
## Summary

Closes #1847.

The existing pre-commit hooks (`regal-lint`, `regal-lint-use-path`, `regal-download`) all run `regal lint`, which only reports. The reporter wanted pre-commit to also auto-fix what `regal fix` can repair, and was working around the gap with a `repo: local` hook that called `regal fix --force .` directly.

This adds three hook IDs that mirror the lint trio but invoke `regal fix --force`:

- `regal-fix` - `language: golang`, builds Regal from source
- `regal-fix-use-path` - `language: system`, uses `regal` on `$PATH`
- `regal-fix-download` - `language: script`, runs `build/download-and-run.sh fix --force`

`--force` is required because pre-commit invokes hooks against files staged in a dirty git tree, which `regal fix` would otherwise refuse without `--force` (per `cmd/fix.go`).

## Files

- `.pre-commit-hooks.yaml` - three new hook entries.
- `docs/pre-commit-hooks.md` - documentation sections mirroring the lint sections.

## Usage

```yaml
repos:
  - repo: https://github.com/open-policy-agent/regal
    rev: v0.40.0
    hooks:
      - id: regal-fix       # auto-fix what can be fixed
      - id: regal-lint      # then lint anything left
```

The `regal-download` script (`build/download-and-run.sh`) already accepts the subcommand as `$@`, so the new download hook works with no script changes.

## Test plan

- [x] `.pre-commit-hooks.yaml` parses as valid YAML and lists 6 hooks.
- [x] Each new hook entry has matching `id`, `language`, `entry`, `files` fields consistent with its lint counterpart.
- [x] Documentation entries mirror the existing lint sections.
- [x] Manual smoke test by a maintainer in their own pre-commit config (no automated test infra here).

No new dependencies. No code changes to Regal itself.