### PR TITLE
[feature] First Pass at Automatic Test Generation in Regal

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "opa.dependency_paths.regal": "/Users/seanledford/regal/regal",
   "opa.env": {
     "OPA_CHECK_CAPABILITIES": "${workspacePath}/build/capabilities.json",
     "OPA_EVAL_CAPABILITIES": "${workspacePath}/build/capabilities.json"

--- a/bundle/regal/lsp/codeaction/codeaction.rego
+++ b/bundle/regal/lsp/codeaction/codeaction.rego
@@ -127,10 +127,7 @@ actions contains action if {
 			"title": "Create tests for this file",
 			"command": "regal.createTest",
 			"tooltip": "Create test cases for all rules in this file",
-			"arguments": [{
-				"target": input.params.textDocument.uri,
-				"row": input.params.range.start.line,
-			}],
+			"arguments": [{"target": input.params.textDocument.uri}],
 		},
 	}
 }

--- a/bundle/regal/lsp/codeaction/codeaction.rego
+++ b/bundle/regal/lsp/codeaction/codeaction.rego
@@ -115,6 +115,27 @@ actions contains action if {
 }
 
 # METADATA
+# description: |
+#   Code action to create a test from the current rule evaluation state.
+actions contains action if {
+	strings.any_prefix_match("source.createTest", only)
+
+	action := {
+		"title": "Create tests for this file",
+		"kind": "source.createTest",
+		"command": {
+			"title": "Create tests for this file",
+			"command": "regal.createTest",
+			"tooltip": "Create test cases for all rules in this file",
+			"arguments": [{
+				"target": input.params.textDocument.uri,
+				"row": input.params.range.start.line,
+			}],
+		},
+	}
+}
+
+# METADATA
 # description: All code actions for fixing reported diagnostics
 rules := {
 	"opa-fmt": ["Format using opa-fmt", ["target"]],
@@ -137,6 +158,6 @@ rules := {
 #   be hierarchical — if only contains "source" it matches all source actions,
 #   while "source.foo" matches only source actions with a "foo" prefix.
 # scope: document
-default only := ["quickfix", "source.explore"]
+default only := ["quickfix", "source.explore", "source.createTest"]
 
 only := input.params.context.only if input.params.context.only != []

--- a/bundle/regal/lsp/codeaction/codeaction_test.rego
+++ b/bundle/regal/lsp/codeaction/codeaction_test.rego
@@ -141,7 +141,7 @@ test_code_actions_only_source if {
 		with input.params.context.diagnostics as []
 		with input.params.context.only as ["source"]
 
-	count(r) == 1
+	count(r) == 2
 
 	some action in r
 
@@ -150,6 +150,27 @@ test_code_actions_only_source if {
 	action.command.command == "regal.explorer"
 	action.command.title == "Explore compiler stages for this policy"
 	action.command.tooltip == "Explore compiler stages for this policy"
+	count(action.command.arguments) == 1
+	action.command.arguments[0].target == "file:///workspace/policy.rego"
+}
+
+test_code_actions_source_create_test if {
+	r := codeaction.actions
+		with data.client.identifier as client.identifiers.generic
+		with input.regal.environment.workspace_root_uri as "file:///workspace"
+		with input.params.textDocument.uri as "file:///workspace/policy.rego"
+		with input.params.context.diagnostics as []
+		with input.params.context.only as ["source.createTest"]
+
+	count(r) == 1
+
+	some action in r
+
+	action.title == "Create tests for this file"
+	action.kind == "source.createTest"
+	action.command.command == "regal.createTest"
+	action.command.title == "Create tests for this file"
+	action.command.tooltip == "Create test cases for all rules in this file"
 	count(action.command.arguments) == 1
 	action.command.arguments[0].target == "file:///workspace/policy.rego"
 }
@@ -175,7 +196,7 @@ test_code_actions_empty_only_means_all if {
 		with input.params.context.only as []
 		with data.client.identifier as client.identifiers.vscode
 
-	count(r) == 4
+	count(r) == 5
 }
 
 _diagnostics["opa-fmt"] := {

--- a/bundle/regal/lsp/initialize/initialize.rego
+++ b/bundle/regal/lsp/initialize/initialize.rego
@@ -67,25 +67,17 @@ _capabilities.workspace.fileOperations[operation].filters := filters if {
 ## *there is no way* to support it here.
 _capabilities.workspace.workspaceFolders.supported := true
 
-_capabilities.inlayHintProvider := {
-	# inlayHint/resolve request supported
-	"resolveProvider": true,
-}
+_capabilities.inlayHintProvider := {"resolveProvider": true} # inlayHint/resolve request supported
 
 _capabilities.hoverProvider := true
 
-_capabilities.signatureHelpProvider := {
-	# In additional to the client's default trigger characters for signature help
-	"triggerCharacters": ["(", ","]
-}
+# In additional to the client's default trigger characters for signature help
+_capabilities.signatureHelpProvider := {"triggerCharacters": ["(", ","]}
 
-_capabilities.codeActionProvider := {
-	# Currently supported code action kinds
-	"codeActionKinds": [
-		"quickfix",
-		"source"
-	],
-}
+_capabilities.codeActionProvider := {"codeActionKinds": [
+	"quickfix", # Currently supported code action kinds
+	"source",
+]}
 
 _capabilities.executeCommandProvider.commands := _commands
 
@@ -102,6 +94,7 @@ _commands contains "regal.fix.redundant-existence-check"
 _commands contains "regal.config.disable-rule"
 _commands contains "regal.explorer" if data.server.feature_flags.explorer_provider
 _commands contains "regal.debug" if data.server.feature_flags.debug_provider
+_commands contains "regal.createTest" if data.server.feature_flags.test_creation_provider
 
 _capabilities.documentFormattingProvider := true
 
@@ -122,15 +115,9 @@ _capabilities.completionProvider := {
 	"completionItem": {"labelDetailsSupport": true},
 }
 
-_capabilities.codeLensProvider := {
-	# codeLens/resolve to be implemented
-	"resolveProvider": false,
-}
+_capabilities.codeLensProvider := {"resolveProvider": false} # codeLens/resolve to be implemented
 
-_capabilities.documentLinkProvider := {
-	# documentLink/resolve to be implemented
-	"resolveProvider": false,
-}
+_capabilities.documentLinkProvider := {"resolveProvider": false} # documentLink/resolve to be implemented
 
 _capabilities.documentHighlightProvider := true
 

--- a/bundle/regal/lsp/initialize/initialize.rego
+++ b/bundle/regal/lsp/initialize/initialize.rego
@@ -67,17 +67,25 @@ _capabilities.workspace.fileOperations[operation].filters := filters if {
 ## *there is no way* to support it here.
 _capabilities.workspace.workspaceFolders.supported := true
 
-_capabilities.inlayHintProvider := {"resolveProvider": true} # inlayHint/resolve request supported
+_capabilities.inlayHintProvider := {
+	# inlayHint/resolve request supported
+	"resolveProvider": true,
+}
 
 _capabilities.hoverProvider := true
 
-# In additional to the client's default trigger characters for signature help
-_capabilities.signatureHelpProvider := {"triggerCharacters": ["(", ","]}
+_capabilities.signatureHelpProvider := {
+	# In additional to the client's default trigger characters for signature help
+	"triggerCharacters": ["(", ","]
+}
 
-_capabilities.codeActionProvider := {"codeActionKinds": [
-	"quickfix", # Currently supported code action kinds
-	"source",
-]}
+_capabilities.codeActionProvider := {
+	# Currently supported code action kinds
+	"codeActionKinds": [
+		"quickfix",
+		"source"
+	],
+}
 
 _capabilities.executeCommandProvider.commands := _commands
 
@@ -115,9 +123,15 @@ _capabilities.completionProvider := {
 	"completionItem": {"labelDetailsSupport": true},
 }
 
-_capabilities.codeLensProvider := {"resolveProvider": false} # codeLens/resolve to be implemented
+_capabilities.codeLensProvider := {
+	# codeLens/resolve to be implemented
+	"resolveProvider": false,
+}
 
-_capabilities.documentLinkProvider := {"resolveProvider": false} # documentLink/resolve to be implemented
+_capabilities.documentLinkProvider := {
+	# documentLink/resolve to be implemented
+	"resolveProvider": false,
+}
 
 _capabilities.documentHighlightProvider := true
 

--- a/internal/embeds/schemas/regal/lsp/server.json
+++ b/internal/embeds/schemas/regal/lsp/server.json
@@ -30,6 +30,10 @@
             "opa_test_provider": {
               "type": "boolean",
               "description": "If the server is configured to operate as an OPA test API provider"
+            },
+            "test_creation_provider": {
+              "type": "boolean",
+              "description": "If the server is configured to operate as a test creation provider"
             }
           }
         }

--- a/internal/lsp/rego/testdata/router/textDocument/codeAction/diagnostic.md
+++ b/internal/lsp/rego/testdata/router/textDocument/codeAction/diagnostic.md
@@ -134,6 +134,20 @@ The response includes:
     },
     "kind": "source.explore",
     "title": "Explore compiler stages for this policy"
+  },
+  {
+    "command": {
+      "arguments": [
+        {
+          "target": "file:///workspace/policy.rego"
+        }
+      ],
+      "command": "regal.createTest",
+      "title": "Create tests for this file",
+      "tooltip": "Create test cases for all rules in this file"
+    },
+    "kind": "source.createTest",
+    "title": "Create tests for this file"
   }
 ]
 ```

--- a/internal/lsp/rego/testdata/router/textDocument/codeAction/explorer.md
+++ b/internal/lsp/rego/testdata/router/textDocument/codeAction/explorer.md
@@ -57,6 +57,20 @@ The response includes a source action for the OPA explorer command:
     },
     "kind": "source.explore",
     "title": "Explore compiler stages for this policy"
+  },
+  {
+    "command": {
+      "arguments": [
+        {
+          "target": "file:///workspace/policy.rego"
+        }
+      ],
+      "command": "regal.createTest",
+      "title": "Create tests for this file",
+      "tooltip": "Create test cases for all rules in this file"
+    },
+    "kind": "source.createTest",
+    "title": "Create tests for this file"
   }
 ]
 ```

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -112,6 +112,7 @@ func DefaultServerFeatureFlags() *types.ServerFeatureFlags {
 		InlineEvaluationProvider: true,
 		DebugProvider:            true,
 		OPATestProvider:          true,
+		TestCreationProvider:     true,
 	}
 }
 

--- a/internal/lsp/server_command.go
+++ b/internal/lsp/server_command.go
@@ -560,9 +560,8 @@ func (l *LanguageServer) handleCreateTestCommand(ctx context.Context, params typ
 		return errors.New("target file URI is required")
 	}
 
-	filePath := uri.ToPath(args.Target)
-
-	inputPath, inputValue := rio.FindInput(filePath, l.workspacePath())
+	inputPath := l.input.FindForPath(args.Target)
+	inputValue := l.input.Get(ctx, inputPath)
 
 	inputEmpty := inputValue == nil
 	if obj, ok := inputValue.(ast.Object); ok {
@@ -570,14 +569,13 @@ func (l *LanguageServer) handleCreateTestCommand(ctx context.Context, params typ
 	}
 
 	if inputPath == "" || inputEmpty {
-		if err := l.conn.Notify(ctx, "window/showMessage", types.ShowMessageParams{
-			Type:    3,
-			Message: "No input.json or input.yaml file found. Create one to provide test input data.",
-		}); err != nil {
-			l.log.Message("failed to show input.json missing message: %v", err)
-		}
+		l.window.ShowMessage(
+			ctx,
+			types.InfoMessage,
+			"No input.json or input.yaml file found. Create one to provide test input data.",
+		)
 
-		return errors.New("no input.json found in workspace")
+		return nil
 	}
 
 	_, module, ok := l.cache.GetContentAndModule(args.Target)
@@ -585,18 +583,18 @@ func (l *LanguageServer) handleCreateTestCommand(ctx context.Context, params typ
 		return fmt.Errorf("could not get file contents for uri %q", args.Target)
 	}
 
-	combinedTest, ruleErrs, err := testgen.CreateTestModule(testgen.TestModuleOptions{
+	combinedTest, err := testgen.CreateTestModule(ctx, testgen.TestModuleOptions{
 		Module:        module,
 		AllModules:    l.cache.GetAllModules(),
 		WorkspacePath: l.workspacePath(),
 		FileURI:       args.Target,
+		InputManager:  l.input,
 	})
-
-	for _, re := range ruleErrs {
-		l.log.Message("failed to create test for rule %s: %v", re.RuleName, re.Err)
+	if err != nil {
+		l.log.Message("errors creating tests: %v", err)
 	}
 
-	if err != nil {
+	if combinedTest == "" {
 		return err
 	}
 
@@ -618,20 +616,11 @@ func (l *LanguageServer) displayTestResult(testCode, sourceURI string) error {
 		return fmt.Errorf("failed to write test file: %w", err)
 	}
 
-	showParams := types.ShowDocumentParams{
-		URI:       uri.FromPath(l.getClient().Identifier, testFileName),
-		TakeFocus: new(true),
-	}
-
-	var result types.ShowDocumentResult
-
 	// Use a timeout context for RPC to ensure it completes during graceful shutdown
 	rpcCtx, rpcCancel := context.WithTimeout(context.Background(), rpcTimeout)
 	defer rpcCancel()
 
-	if err := l.conn.Call(rpcCtx, "window/showDocument", showParams, &result); err != nil {
-		return fmt.Errorf("window/showDocument failed: %w", err)
-	}
+	l.window.ShowDocument(rpcCtx, uri.FromPath(l.getClient().Identifier, testFileName), true)
 
 	return nil
 }

--- a/internal/lsp/server_command.go
+++ b/internal/lsp/server_command.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-policy-agent/regal/internal/explorer"
 	rio "github.com/open-policy-agent/regal/internal/io"
 	"github.com/open-policy-agent/regal/internal/lsp/clients"
+	"github.com/open-policy-agent/regal/internal/lsp/testgen"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	"github.com/open-policy-agent/regal/internal/util"
@@ -38,6 +39,14 @@ func (l *LanguageServer) StartCommandWorker(ctx context.Context) {
 				if params.Command == "regal.explorer" {
 					if err := l.handleExplorerCommand(ctx, params); err != nil {
 						l.log.Message("failed to handle explorer command: %s", err)
+					}
+
+					continue
+				}
+
+				if params.Command == "regal.createTest" {
+					if err := l.handleCreateTestCommand(ctx, params); err != nil {
+						l.log.Message("failed to handle createTest command: %s", err)
 					}
 
 					continue
@@ -523,4 +532,99 @@ func (l *LanguageServer) handleWorkspaceExecuteCommand(params types.ExecuteComma
 
 	// however, the contents of the response is not important
 	return emptyStruct, nil
+}
+
+func (l *LanguageServer) handleCreateTestCommand(ctx context.Context, params types.ExecuteCommandParams) error {
+	var args types.CommandArgs
+
+	if len(params.Arguments) > 0 {
+		arg, ok := params.Arguments[0].(map[string]any)
+		if !ok {
+			l.log.Message(
+				"failed to unmarshal regal.createTest command arguments, expected object, got %T",
+				params.Arguments[0],
+			)
+
+			return errors.New("failed to parse createTest arguments")
+		}
+
+		args = types.CommandArgs{
+			Target: util.GetMapValue[string](arg, "target"),
+		}
+	}
+
+	if args.Target == "" {
+		l.log.Message("expected command target, got empty string")
+
+		return errors.New("target file URI is required")
+	}
+
+	filePath := uri.ToPath(args.Target)
+
+	inputPath, inputMap := rio.FindInput(filePath, l.workspacePath())
+	if inputPath == "" || len(inputMap) == 0 {
+		if err := l.conn.Notify(ctx, "window/showMessage", types.ShowMessageParams{
+			Type:    3,
+			Message: "No input.json or input.yaml file found. Create one to provide test input data.",
+		}); err != nil {
+			l.log.Message("failed to show input.json missing message: %v", err)
+		}
+
+		return errors.New("no input.json found in workspace")
+	}
+
+	_, module, ok := l.cache.GetContentAndModule(args.Target)
+	if !ok {
+		return fmt.Errorf("could not get file contents for uri %q", args.Target)
+	}
+
+	combinedTest, ruleErrs, err := testgen.CreateTestModule(testgen.TestModuleOptions{
+		Module:        module,
+		AllModules:    l.cache.GetAllModules(),
+		WorkspacePath: l.workspacePath(),
+		FileURI:       args.Target,
+	})
+
+	for _, re := range ruleErrs {
+		l.log.Message("failed to create test for rule %s: %v", re.RuleName, re.Err)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	//nolint:contextcheck
+	if err := l.displayTestResult(combinedTest, args.Target); err != nil {
+		return fmt.Errorf("failed to display test result: %w", err)
+	}
+
+	return nil
+}
+
+func (l *LanguageServer) displayTestResult(testCode, sourceURI string) error {
+	sourceFile := uri.ToPath(sourceURI)
+	baseName := strings.TrimSuffix(filepath.Base(sourceFile), ".rego")
+
+	testFileName := filepath.Join(l.workspacePath(), baseName+"_test.rego")
+
+	if err := os.WriteFile(testFileName, []byte(testCode), 0o600); err != nil {
+		return fmt.Errorf("failed to write test file: %w", err)
+	}
+
+	showParams := types.ShowDocumentParams{
+		URI:       uri.FromPath(l.getClient().Identifier, testFileName),
+		TakeFocus: new(true),
+	}
+
+	var result types.ShowDocumentResult
+
+	// Use a timeout context for RPC to ensure it completes during graceful shutdown
+	rpcCtx, rpcCancel := context.WithTimeout(context.Background(), rpcTimeout)
+	defer rpcCancel()
+
+	if err := l.conn.Call(rpcCtx, "window/showDocument", showParams, &result); err != nil {
+		return fmt.Errorf("window/showDocument failed: %w", err)
+	}
+
+	return nil
 }

--- a/internal/lsp/server_command.go
+++ b/internal/lsp/server_command.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/open-policy-agent/opa/v1/ast"
 	outil "github.com/open-policy-agent/opa/v1/util"
 
 	"github.com/open-policy-agent/regal/internal/explorer"
@@ -549,7 +550,7 @@ func (l *LanguageServer) handleCreateTestCommand(ctx context.Context, params typ
 		}
 
 		args = types.CommandArgs{
-			Target: util.GetMapValue[string](arg, "target"),
+			Target: util.MapGet[string](arg, "target"),
 		}
 	}
 
@@ -561,8 +562,14 @@ func (l *LanguageServer) handleCreateTestCommand(ctx context.Context, params typ
 
 	filePath := uri.ToPath(args.Target)
 
-	inputPath, inputMap := rio.FindInput(filePath, l.workspacePath())
-	if inputPath == "" || len(inputMap) == 0 {
+	inputPath, inputValue := rio.FindInput(filePath, l.workspacePath())
+
+	inputEmpty := inputValue == nil
+	if obj, ok := inputValue.(ast.Object); ok {
+		inputEmpty = obj.Len() == 0
+	}
+
+	if inputPath == "" || inputEmpty {
 		if err := l.conn.Notify(ctx, "window/showMessage", types.ShowMessageParams{
 			Type:    3,
 			Message: "No input.json or input.yaml file found. Create one to provide test input data.",

--- a/internal/lsp/server_command_test.go
+++ b/internal/lsp/server_command_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sourcegraph/jsonrpc2"
 
+	rio "github.com/open-policy-agent/regal/internal/io"
 	"github.com/open-policy-agent/regal/internal/lsp/clients"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
@@ -372,7 +373,7 @@ allow if {
 			clientHandler := func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (any, error) {
 				switch req.Method {
 				case "window/showDocument":
-					return types.ShowDocumentResult{Success: true}, nil
+					return new(json.RawMessage(`{"success":true}`)), nil
 				case "window/showMessage":
 					return struct{}{}, nil
 				default:
@@ -412,7 +413,7 @@ allow if {
 
 			if tc.expectFile {
 				for {
-					if _, statErr := os.Stat(expectedTestFile); statErr == nil {
+					if rio.Exists(expectedTestFile) {
 						fileExists = true
 
 						break
@@ -428,8 +429,7 @@ allow if {
 			} else {
 				time.Sleep(100 * time.Millisecond)
 
-				_, statErr := os.Stat(expectedTestFile)
-				fileExists = statErr == nil
+				fileExists = rio.Exists(expectedTestFile)
 			}
 
 			if tc.expectFile && !fileExists {
@@ -439,14 +439,13 @@ allow if {
 			}
 
 			if fileExists {
-				contents, _ := os.ReadFile(expectedTestFile)
-				t.Logf("Created test file contents:\n%s", string(contents))
+				contents := must.ReadFile(t, expectedTestFile)
+				t.Logf("Created test file contents:\n%s", contents)
 
-				contentsStr := string(contents)
 				if tc.shouldSucceed {
-					must.Equal(t, true, strings.Contains(contentsStr, "package policy_test"), "should contain test package")
-					must.Equal(t, true, strings.Contains(contentsStr, "test_allow if"), "should contain test function")
-					must.Equal(t, true, strings.Contains(contentsStr, "policy.allow"), "should contain rule call")
+					must.Equal(t, true, strings.Contains(contents, "package policy_test"), "should contain test package")
+					must.Equal(t, true, strings.Contains(contents, "test_allow if"), "should contain test function")
+					must.Equal(t, true, strings.Contains(contents, "policy.allow"), "should contain rule call")
 				}
 			}
 		})

--- a/internal/lsp/server_command_test.go
+++ b/internal/lsp/server_command_test.go
@@ -332,3 +332,123 @@ allow if {
 		t.Fatal("timed out waiting for window/showDocument")
 	}
 }
+
+func TestExecuteCommandCreateTest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		policyContent string
+		inputJSON     string
+		shouldSucceed bool
+		expectFile    bool
+	}{
+		"simple allow rule with input": {
+			policyContent: `package policy
+
+allow if {
+	input.foo == "woo"
+	input.bar == "wee"
+}`,
+			inputJSON:     `{"foo": "woo", "bar": "wee"}`,
+			shouldSucceed: true,
+			expectFile:    true,
+		},
+		"no input.json should fail": {
+			policyContent: `package policy
+
+allow if {
+	input.foo == "woo"
+}`,
+			inputJSON:     "",
+			shouldSucceed: false,
+			expectFile:    false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			clientHandler := func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (any, error) {
+				switch req.Method {
+				case "window/showDocument":
+					return types.ShowDocumentResult{Success: true}, nil
+				case "window/showMessage":
+					return struct{}{}, nil
+				default:
+					return struct{}{}, nil
+				}
+			}
+
+			files := map[string]string{"policy.rego": tc.policyContent}
+			if tc.inputJSON != "" {
+				files["input.json"] = tc.inputJSON
+			}
+
+			tempDir := testutil.TempDirectoryOf(t, files)
+			_, connClient, ctx := createAndInitServer(t, tempDir, clientHandler)
+
+			policyRegoURI := uri.FromPath(clients.IdentifierGoTest, filepath.Join(tempDir, "policy.rego"))
+
+			var executeResponse any
+			must.Equal(t, nil, connClient.Call(ctx, "workspace/executeCommand", types.ExecuteCommandParams{
+				Command: "regal.createTest",
+				Arguments: []any{
+					map[string]any{
+						"target": policyRegoURI,
+						"row":    1,
+					},
+				},
+			}, &executeResponse))
+
+			t.Logf("Command response: %v", executeResponse)
+
+			expectedTestFile := filepath.Join(tempDir, "policy_test.rego")
+
+			timeout := time.NewTimer(5 * time.Second)
+			defer timeout.Stop()
+
+			var fileExists bool
+
+			if tc.expectFile {
+				for {
+					if _, statErr := os.Stat(expectedTestFile); statErr == nil {
+						fileExists = true
+
+						break
+					}
+
+					select {
+					case <-timeout.C:
+						break
+					default:
+						time.Sleep(50 * time.Millisecond)
+					}
+				}
+			} else {
+				time.Sleep(100 * time.Millisecond)
+
+				_, statErr := os.Stat(expectedTestFile)
+				fileExists = statErr == nil
+			}
+
+			if tc.expectFile && !fileExists {
+				t.Errorf("Expected test file to be created, but it wasn't")
+			} else if !tc.expectFile && fileExists {
+				t.Errorf("Expected no test file, but one was created")
+			}
+
+			if fileExists {
+				contents, _ := os.ReadFile(expectedTestFile)
+				t.Logf("Created test file contents:\n%s", string(contents))
+
+				contentsStr := string(contents)
+				if tc.shouldSucceed {
+					must.Equal(t, true, strings.Contains(contentsStr, "package policy_test"), "should contain test package")
+					must.Equal(t, true, strings.Contains(contentsStr, "test_allow if"), "should contain test function")
+					must.Equal(t, true, strings.Contains(contentsStr, "policy.allow"), "should contain rule call")
+				}
+			}
+		})
+	}
+}

--- a/internal/lsp/testgen/testgen.go
+++ b/internal/lsp/testgen/testgen.go
@@ -104,7 +104,16 @@ func analyzeDependencies(opts TestCreationOptions) ([]string, error) {
 	refs = append(refs, headRefs...)
 
 	filePath := uri.ToPath(opts.FileURI)
-	_, inputData := rio.FindInput(filePath, opts.WorkspacePath)
+	_, inputValue := rio.FindInput(filePath, opts.WorkspacePath)
+
+	var inputData map[string]any
+
+	if inputValue != nil {
+		if raw, err := ast.JSON(inputValue); err == nil {
+			inputData, _ = raw.(map[string]any)
+		}
+	}
+
 	dataData := findDataFile(opts.WorkspacePath)
 
 	var withClauses []string

--- a/internal/lsp/testgen/testgen.go
+++ b/internal/lsp/testgen/testgen.go
@@ -1,0 +1,286 @@
+package testgen
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/dependencies"
+	"github.com/open-policy-agent/opa/v1/format"
+
+	"github.com/open-policy-agent/regal/internal/compile"
+	rio "github.com/open-policy-agent/regal/internal/io"
+	"github.com/open-policy-agent/regal/internal/lsp/uri"
+)
+
+type TestModuleOptions struct {
+	Module        *ast.Module
+	AllModules    map[string]*ast.Module
+	WorkspacePath string
+	FileURI       string
+}
+
+type RuleError struct {
+	RuleName string
+	Err      error
+}
+
+func CreateTestModule(opts TestModuleOptions) (string, []RuleError, error) {
+	if len(opts.Module.Rules) == 0 {
+		return "", nil, errors.New("no rules found in this file")
+	}
+
+	packagePath := opts.Module.Package.Path.String()
+
+	var b strings.Builder
+	b.WriteString(BuildTestHeader(packagePath))
+
+	var ruleErrs []RuleError
+
+	successCount := 0
+
+	for _, rule := range opts.Module.Rules {
+		ruleName := rule.Head.Name.String()
+
+		testFunction, err := CreateTestFunction(TestCreationOptions{
+			RuleName:      ruleName,
+			PackagePath:   packagePath,
+			WorkspacePath: opts.WorkspacePath,
+			FileURI:       opts.FileURI,
+			Rule:          rule,
+			AllModules:    opts.AllModules,
+		})
+		if err != nil {
+			ruleErrs = append(ruleErrs, RuleError{RuleName: ruleName, Err: err})
+
+			continue
+		}
+
+		b.WriteString("\n\n")
+		b.WriteString(testFunction)
+
+		successCount++
+	}
+
+	if successCount == 0 {
+		return "", ruleErrs, errors.New("failed to create any tests")
+	}
+
+	return b.String(), ruleErrs, nil
+}
+
+type TestCreationOptions struct {
+	RuleName      string
+	PackagePath   string
+	WorkspacePath string
+	FileURI       string
+	Rule          *ast.Rule
+	AllModules    map[string]*ast.Module
+}
+
+func analyzeDependencies(opts TestCreationOptions) ([]string, error) {
+	compiler := compile.NewCompilerWithRegalBuiltins()
+	compiler.Compile(opts.AllModules)
+
+	if compiler.Failed() {
+		return nil, fmt.Errorf("compilation failed: %w", compiler.Errors)
+	}
+
+	refs, err := dependencies.Base(compiler, opts.Rule)
+	if err != nil {
+		return nil, fmt.Errorf("failed to analyze rule dependencies: %w", err)
+	}
+
+	headRefs, err := dependencies.Base(compiler, opts.Rule.Head)
+	if err != nil {
+		return nil, fmt.Errorf("failed to analyze rule head dependencies: %w", err)
+	}
+
+	refs = append(refs, headRefs...)
+
+	filePath := uri.ToPath(opts.FileURI)
+	_, inputData := rio.FindInput(filePath, opts.WorkspacePath)
+	dataData := findDataFile(opts.WorkspacePath)
+
+	var withClauses []string
+
+	for _, ref := range refs {
+		if len(ref) < 2 {
+			continue
+		}
+
+		if ref[0].Equal(ast.InputRootDocument) {
+			path := buildRefPath("input", ref[1:])
+			if value := lookupValueFromData(inputData, ref[1:]); value != nil {
+				clause := fmt.Sprintf("%s as %s", path, formatValue(value))
+				withClauses = append(withClauses, clause)
+			}
+		}
+
+		if ref[0].Equal(ast.DefaultRootDocument) {
+			path := buildRefPath("data", ref[1:])
+			if value := lookupValueFromData(dataData, ref[1:]); value != nil {
+				clause := fmt.Sprintf("%s as %s", path, formatValue(value))
+				withClauses = append(withClauses, clause)
+			}
+		}
+	}
+
+	return withClauses, nil
+}
+
+func buildRefPath(root string, terms ast.Ref) string {
+	parts := make([]string, 0, 1+len(terms))
+
+	parts = append(parts, root)
+
+	for _, term := range terms {
+		key := strings.Trim(term.Value.String(), `"`)
+		parts = append(parts, key)
+	}
+
+	return strings.Join(parts, ".")
+}
+
+func lookupValueFromData(data map[string]any, terms ast.Ref) any {
+	if data == nil || len(terms) == 0 {
+		return nil
+	}
+
+	node := data
+
+	for _, term := range terms[:len(terms)-1] {
+		key := strings.Trim(term.Value.String(), `"`)
+		if child, ok := node[key].(map[string]any); ok {
+			node = child
+		} else {
+			return nil
+		}
+	}
+
+	leaf := strings.Trim(terms[len(terms)-1].Value.String(), `"`)
+
+	return node[leaf]
+}
+
+func formatValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return strconv.Quote(v)
+	case float64, bool:
+		return fmt.Sprintf("%v", v)
+	default:
+		if jsonBytes, err := json.Marshal(v); err == nil {
+			return string(jsonBytes)
+		}
+
+		return `"unknown"`
+	}
+}
+
+func buildTestFunction(opts TestCreationOptions, withClauses []string) string {
+	testName := createTestName(opts.RuleName)
+	ruleCall := createRuleCall(opts.PackagePath, opts.RuleName)
+
+	var withClause string
+	if len(withClauses) > 0 {
+		withClause = " with " + strings.Join(withClauses, " with ")
+	}
+
+	return fmt.Sprintf(`%s if {
+    %s%s
+}`, testName, ruleCall, withClause)
+}
+
+func BuildTestHeader(packagePath string) string {
+	testPackage := createTestPackage(packagePath)
+
+	return fmt.Sprintf(`package %s
+
+import %s`, testPackage, packagePath)
+}
+
+func CreateTestFunction(opts TestCreationOptions) (string, error) {
+	if opts.Rule == nil || opts.AllModules == nil {
+		return "", errors.New("dependency analysis requires Rule and AllModules to be provided")
+	}
+
+	withClauses, err := analyzeDependencies(opts)
+	if err != nil {
+		return "", fmt.Errorf("failed to analyze dependencies: %w", err)
+	}
+
+	testFunction := buildTestFunction(opts, withClauses)
+	completeTest := BuildTestHeader(opts.PackagePath) + "\n\n" + testFunction
+
+	formatted, err := format.Source("test.rego", []byte(completeTest))
+	if err != nil {
+		// Array access syntax like input.permissions[0] can cause parsing issues —
+		// fall back to a basic test skeleton without with-clauses.
+		// TODO: handle array access in withClause generation.
+		testFunction = buildTestFunction(opts, []string{})
+		completeTest = BuildTestHeader(opts.PackagePath) + "\n\n" + testFunction
+
+		formatted, err = format.Source("test.rego", []byte(completeTest))
+		if err != nil {
+			return "", fmt.Errorf("failed to format basic test: %w", err)
+		}
+	}
+
+	lines := strings.Split(string(formatted), "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "test_") {
+			return strings.Join(lines[i:], "\n"), nil
+		}
+	}
+
+	return testFunction, nil
+}
+
+func findDataFile(workspacePath string) map[string]any {
+	dataPath := filepath.Join(workspacePath, "data.json")
+	if content, err := os.ReadFile(dataPath); err == nil {
+		var data map[string]any
+		if err := json.Unmarshal(content, &data); err == nil {
+			return data
+		}
+	}
+
+	return nil
+}
+
+func getLastPackagePart(packagePath string) string {
+	parts := strings.Split(packagePath, ".")
+	if len(parts) == 0 {
+		return ""
+	}
+
+	return parts[len(parts)-1]
+}
+
+func createTestPackage(packagePath string) string {
+	lastPart := getLastPackagePart(packagePath)
+	if lastPart == "" {
+		return "test"
+	}
+
+	return lastPart + "_test"
+}
+
+func createTestName(ruleName string) string {
+	return "test_" + ruleName
+}
+
+func createRuleCall(packagePath, ruleName string) string {
+	packageName := getLastPackagePart(packagePath)
+	if packageName == "" {
+		return ruleName
+	}
+
+	return fmt.Sprintf("%s.%s", packageName, ruleName)
+}

--- a/internal/lsp/testgen/testgen.go
+++ b/internal/lsp/testgen/testgen.go
@@ -1,6 +1,7 @@
 package testgen
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,8 +15,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/format"
 
 	"github.com/open-policy-agent/regal/internal/compile"
-	rio "github.com/open-policy-agent/regal/internal/io"
-	"github.com/open-policy-agent/regal/internal/lsp/uri"
+	"github.com/open-policy-agent/regal/internal/lsp/input"
 )
 
 type TestModuleOptions struct {
@@ -23,16 +23,24 @@ type TestModuleOptions struct {
 	AllModules    map[string]*ast.Module
 	WorkspacePath string
 	FileURI       string
+	InputManager  *input.Manager
 }
 
-type RuleError struct {
-	RuleName string
-	Err      error
-}
-
-func CreateTestModule(opts TestModuleOptions) (string, []RuleError, error) {
+func CreateTestModule(ctx context.Context, opts TestModuleOptions) (string, error) {
 	if len(opts.Module.Rules) == 0 {
-		return "", nil, errors.New("no rules found in this file")
+		return "", errors.New("no rules found in this file")
+	}
+
+	compiler := compile.NewCompilerWithRegalBuiltins()
+	compiler.Compile(opts.AllModules)
+
+	if compiler.Failed() {
+		return "", fmt.Errorf("compilation failed: %w", compiler.Errors)
+	}
+
+	compiledModule, ok := compiler.Modules[opts.FileURI]
+	if !ok {
+		return "", fmt.Errorf("compiled module not found for %q", opts.FileURI)
 	}
 
 	packagePath := opts.Module.Package.Path.String()
@@ -40,23 +48,24 @@ func CreateTestModule(opts TestModuleOptions) (string, []RuleError, error) {
 	var b strings.Builder
 	b.WriteString(BuildTestHeader(packagePath))
 
-	var ruleErrs []RuleError
+	var ruleErrs []error
 
 	successCount := 0
 
-	for _, rule := range opts.Module.Rules {
+	for _, rule := range compiledModule.Rules {
 		ruleName := rule.Head.Name.String()
 
-		testFunction, err := CreateTestFunction(TestCreationOptions{
+		testFunction, err := CreateTestFunction(ctx, TestCreationOptions{
 			RuleName:      ruleName,
 			PackagePath:   packagePath,
 			WorkspacePath: opts.WorkspacePath,
 			FileURI:       opts.FileURI,
 			Rule:          rule,
-			AllModules:    opts.AllModules,
+			Compiler:      compiler,
+			InputManager:  opts.InputManager,
 		})
 		if err != nil {
-			ruleErrs = append(ruleErrs, RuleError{RuleName: ruleName, Err: err})
+			ruleErrs = append(ruleErrs, fmt.Errorf("rule %s: %w", ruleName, err))
 
 			continue
 		}
@@ -68,10 +77,10 @@ func CreateTestModule(opts TestModuleOptions) (string, []RuleError, error) {
 	}
 
 	if successCount == 0 {
-		return "", ruleErrs, errors.New("failed to create any tests")
+		return "", fmt.Errorf("failed to create any tests: %w", errors.Join(ruleErrs...))
 	}
 
-	return b.String(), ruleErrs, nil
+	return b.String(), errors.Join(ruleErrs...)
 }
 
 type TestCreationOptions struct {
@@ -80,37 +89,30 @@ type TestCreationOptions struct {
 	WorkspacePath string
 	FileURI       string
 	Rule          *ast.Rule
-	AllModules    map[string]*ast.Module
+	Compiler      *ast.Compiler
+	InputManager  *input.Manager
 }
 
-func analyzeDependencies(opts TestCreationOptions) ([]string, error) {
-	compiler := compile.NewCompilerWithRegalBuiltins()
-	compiler.Compile(opts.AllModules)
-
-	if compiler.Failed() {
-		return nil, fmt.Errorf("compilation failed: %w", compiler.Errors)
-	}
-
-	refs, err := dependencies.Base(compiler, opts.Rule)
+func analyzeDependencies(ctx context.Context, opts TestCreationOptions) ([]string, error) {
+	refs, err := dependencies.Base(opts.Compiler, opts.Rule)
 	if err != nil {
 		return nil, fmt.Errorf("failed to analyze rule dependencies: %w", err)
 	}
 
-	headRefs, err := dependencies.Base(compiler, opts.Rule.Head)
+	headRefs, err := dependencies.Base(opts.Compiler, opts.Rule.Head)
 	if err != nil {
 		return nil, fmt.Errorf("failed to analyze rule head dependencies: %w", err)
 	}
 
 	refs = append(refs, headRefs...)
 
-	filePath := uri.ToPath(opts.FileURI)
-	_, inputValue := rio.FindInput(filePath, opts.WorkspacePath)
-
 	var inputData map[string]any
 
-	if inputValue != nil {
-		if raw, err := ast.JSON(inputValue); err == nil {
-			inputData, _ = raw.(map[string]any)
+	if opts.InputManager != nil {
+		if inputPath := opts.InputManager.FindForPath(opts.FileURI); inputPath != "" {
+			if raw, err := ast.JSON(opts.InputManager.Get(ctx, inputPath)); err == nil {
+				inputData, _ = raw.(map[string]any)
+			}
 		}
 	}
 
@@ -214,12 +216,12 @@ func BuildTestHeader(packagePath string) string {
 import %s`, testPackage, packagePath)
 }
 
-func CreateTestFunction(opts TestCreationOptions) (string, error) {
-	if opts.Rule == nil || opts.AllModules == nil {
-		return "", errors.New("dependency analysis requires Rule and AllModules to be provided")
+func CreateTestFunction(ctx context.Context, opts TestCreationOptions) (string, error) {
+	if opts.Rule == nil || opts.Compiler == nil {
+		return "", errors.New("dependency analysis requires Rule and Compiler to be provided")
 	}
 
-	withClauses, err := analyzeDependencies(opts)
+	withClauses, err := analyzeDependencies(ctx, opts)
 	if err != nil {
 		return "", fmt.Errorf("failed to analyze dependencies: %w", err)
 	}
@@ -229,9 +231,12 @@ func CreateTestFunction(opts TestCreationOptions) (string, error) {
 
 	formatted, err := format.Source("test.rego", []byte(completeTest))
 	if err != nil {
-		// Array access syntax like input.permissions[0] can cause parsing issues —
-		// fall back to a basic test skeleton without with-clauses.
-		// TODO: handle array access in withClause generation.
+		// Array access syntax like input.permissions[0] can cause parsing issues:
+		// input skeleton doesn't handle arrays, so writing input.permissions.0
+		// would result in invalid rego. Falling back here if test generation creates
+		// invalid rego.
+		//
+		// TODO: handle array access in withClause generation and input.json skeleton
 		testFunction = buildTestFunction(opts, []string{})
 		completeTest = BuildTestHeader(opts.PackagePath) + "\n\n" + testFunction
 

--- a/internal/lsp/testgen/testgen_test.go
+++ b/internal/lsp/testgen/testgen_test.go
@@ -1,0 +1,148 @@
+package testgen_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+
+	"github.com/open-policy-agent/regal/internal/lsp/clients"
+	"github.com/open-policy-agent/regal/internal/lsp/testgen"
+	"github.com/open-policy-agent/regal/internal/lsp/uri"
+	rparse "github.com/open-policy-agent/regal/internal/parse"
+	"github.com/open-policy-agent/regal/internal/testutil"
+)
+
+func TestCreateTestModule(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		policy      string
+		inputJSON   string
+		expectedErr string
+		expected    []string
+	}{
+		{
+			name:        "empty module returns error",
+			policy:      `package policy`,
+			expectedErr: "no rules found in this file",
+		},
+		{
+			name: "single rule with no input deps creates basic test",
+			policy: `package policy
+
+allow if {
+	1 == 1
+}`,
+			expected: []string{
+				"package policy_test",
+				"import data.policy",
+				"test_allow if",
+				"policy.allow",
+			},
+		},
+		{
+			name: "single rule with input deps and input.json adds with-clauses",
+			policy: `package policy
+
+allow if {
+	input.foo == "woo"
+	input.bar == "wee"
+}`,
+			inputJSON: `{"foo": "woo", "bar": "wee"}`,
+			expected: []string{
+				"test_allow if",
+				"policy.allow",
+				`input.foo as "woo"`,
+				`input.bar as "wee"`,
+			},
+		},
+		{
+			name: "single rule with input deps but no input.json has no with-clauses",
+			policy: `package policy
+
+allow if {
+	input.foo == "woo"
+}`,
+			expected: []string{
+				"test_allow if",
+				"policy.allow",
+			},
+		},
+		{
+			name: "multi-rule module produces a test for each rule",
+			policy: `package policy
+
+allow if {
+	input.foo == "woo"
+}
+
+deny if {
+	input.foo == "wee"
+}`,
+			inputJSON: `{"foo": "woo"}`,
+			expected: []string{
+				"package policy_test",
+				"test_allow if",
+				"test_deny if",
+				"policy.allow",
+				"policy.deny",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			files := map[string]string{"policy.rego": tc.policy}
+			if tc.inputJSON != "" {
+				files["input.json"] = tc.inputJSON
+			}
+
+			workspacePath := testutil.TempDirectoryOf(t, files)
+			policyPath := filepath.Join(workspacePath, "policy.rego")
+			fileURI := uri.FromPath(clients.IdentifierGoTest, policyPath)
+
+			module, err := rparse.Module("policy.rego", tc.policy)
+			if err != nil {
+				t.Fatalf("failed to parse policy: %v", err)
+			}
+
+			result, ruleErrs, err := testgen.CreateTestModule(testgen.TestModuleOptions{
+				Module:        module,
+				AllModules:    map[string]*ast.Module{fileURI: module},
+				WorkspacePath: workspacePath,
+				FileURI:       fileURI,
+			})
+
+			if tc.expectedErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil (result=%q)", tc.expectedErr, result)
+				}
+
+				if !strings.Contains(err.Error(), tc.expectedErr) {
+					t.Fatalf("expected error containing %q, got %v", tc.expectedErr, err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for _, re := range ruleErrs {
+				t.Logf("rule %s failed (may or may not be intentional due to array access limitations): %v", re.RuleName, re.Err)
+			}
+
+			for _, want := range tc.expected {
+				if !strings.Contains(result, want) {
+					t.Errorf("result missing expected substring %q\n--- full output ---\n%s", want, result)
+				}
+			}
+		})
+	}
+}

--- a/internal/lsp/testgen/testgen_test.go
+++ b/internal/lsp/testgen/testgen_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/open-policy-agent/opa/v1/ast"
 
 	"github.com/open-policy-agent/regal/internal/lsp/clients"
+	"github.com/open-policy-agent/regal/internal/lsp/input"
+	"github.com/open-policy-agent/regal/internal/lsp/log"
+	"github.com/open-policy-agent/regal/internal/lsp/store"
 	"github.com/open-policy-agent/regal/internal/lsp/testgen"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	rparse "github.com/open-policy-agent/regal/internal/parse"
@@ -111,11 +114,17 @@ deny if {
 				t.Fatalf("failed to parse policy: %v", err)
 			}
 
-			result, ruleErrs, err := testgen.CreateTestModule(testgen.TestModuleOptions{
+			im := input.NewManager(store.NewRegalStore(), log.NewLogger(log.LevelDebug, t.Output()))
+			if err := im.LoadFromRoot(t.Context(), workspacePath); err != nil {
+				t.Fatalf("failed to load input manager: %v", err)
+			}
+
+			result, err := testgen.CreateTestModule(t.Context(), testgen.TestModuleOptions{
 				Module:        module,
 				AllModules:    map[string]*ast.Module{fileURI: module},
 				WorkspacePath: workspacePath,
 				FileURI:       fileURI,
+				InputManager:  im,
 			})
 
 			if tc.expectedErr != "" {
@@ -131,11 +140,7 @@ deny if {
 			}
 
 			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			for _, re := range ruleErrs {
-				t.Logf("rule %s failed (may or may not be intentional due to array access limitations): %v", re.RuleName, re.Err)
+				t.Logf("rule errors (may or may not be intentional due to array access limitations): %v", err)
 			}
 
 			for _, want := range tc.expected {

--- a/internal/lsp/types/server.go
+++ b/internal/lsp/types/server.go
@@ -16,4 +16,7 @@ type ServerFeatureFlags struct {
 	// OPATestProvider indicates whether the server supports testing-related features
 	// including running Rego tests via LSP command and test location notifications.
 	OPATestProvider bool `json:"opa_test_provider"`
+	// TestCreationProvider indicates whether the server supports the regal.createTest
+	// command for creating tests from rule dependencies.
+	TestCreationProvider bool `json:"test_creation_provider"`
 }


### PR DESCRIPTION
A new lsp feature for automatically creating tests for rules in a policy, based on what's provided in input/data.json, and what is actually referenced from those files in the rules.

Currently facing several limitations, mainly how to handle more complex dependencies like array access, but will work to support those eventually as well!

Fixes #1928 
<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->