### PR TITLE
Move location of LSP storage helpers

### DIFF
--- a/internal/lsp/lint.go
+++ b/internal/lsp/lint.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-policy-agent/regal/internal/lsp/cache"
 	"github.com/open-policy-agent/regal/internal/lsp/clients"
 	"github.com/open-policy-agent/regal/internal/lsp/completions/refs"
+	"github.com/open-policy-agent/regal/internal/lsp/store"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	rparse "github.com/open-policy-agent/regal/internal/parse"
@@ -79,7 +80,7 @@ func updateParse(ctx context.Context, opts updateParseOpts) (bool, error) {
 		opts.Cache.SetModule(opts.FileURI, module)
 		opts.Cache.SetSuccessfulParseLineCount(opts.FileURI, numLines)
 
-		if err := PutFileMod(ctx, opts.Store, opts.FileURI, module); err != nil {
+		if err := store.PutFileMod(ctx, opts.Store, opts.FileURI, module); err != nil {
 			return false, fmt.Errorf("failed to update rego store with parsed module: %w", err)
 		}
 
@@ -92,7 +93,7 @@ func updateParse(ctx context.Context, opts updateParseOpts) (bool, error) {
 			}
 		}
 
-		if err = PutFileRefs(ctx, opts.Store, opts.FileURI, ruleRefs); err != nil {
+		if err = store.PutFileRefs(ctx, opts.Store, opts.FileURI, ruleRefs); err != nil {
 			return false, fmt.Errorf("failed to update rego store with defined refs: %w", err)
 		}
 

--- a/internal/lsp/lint_test.go
+++ b/internal/lsp/lint_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/open-policy-agent/regal/internal/lsp/cache"
 	"github.com/open-policy-agent/regal/internal/lsp/clients"
+	"github.com/open-policy-agent/regal/internal/lsp/store"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/test/assert"
 	"github.com/open-policy-agent/regal/internal/test/must"
@@ -96,7 +97,7 @@ allow[msg] { 1 == 1; msg := "hello" }
 
 			success := must.Return(updateParse(t.Context(), updateParseOpts{
 				Cache:            c,
-				Store:            NewRegalStore(),
+				Store:            store.NewRegalStore(),
 				FileURI:          testData.fileURI,
 				Builtins:         ast.BuiltinMap,
 				RegoVersion:      testData.regoVersion,

--- a/internal/lsp/rego/router_test.go
+++ b/internal/lsp/rego/router_test.go
@@ -19,10 +19,10 @@ import (
 	"github.com/open-policy-agent/opa/v1/storage"
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
 
-	"github.com/open-policy-agent/regal/internal/lsp"
 	"github.com/open-policy-agent/regal/internal/lsp/rego"
 	"github.com/open-policy-agent/regal/internal/lsp/rego/query"
 	"github.com/open-policy-agent/regal/internal/lsp/semantictokens"
+	"github.com/open-policy-agent/regal/internal/lsp/store"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/parse"
 	"github.com/open-policy-agent/regal/internal/roast/transforms/module"
@@ -167,15 +167,15 @@ func storeForDocument(tb testing.TB, doc document, jsonData []byte) storage.Stor
 		}
 	}
 
-	store := inmem.NewWithOpts(inmem.OptReturnASTValuesOnRead(true))
-	if err := storage.WriteOne(tb.Context(), store, storage.AddOp, storage.RootPath, data); err != nil {
+	stg := inmem.NewWithOpts(inmem.OptReturnASTValuesOnRead(true))
+	if err := storage.WriteOne(tb.Context(), stg, storage.AddOp, storage.RootPath, data); err != nil {
 		tb.Fatalf("failed to write to store: %v", err)
 	}
 
 	bis := rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion())
-	must.Equal(tb, nil, lsp.PutBuiltins(tb.Context(), store, bis), "failed to update builtins in storage")
+	must.Equal(tb, nil, store.PutBuiltins(tb.Context(), stg, bis), "failed to update builtins in storage")
 
-	return store
+	return stg
 }
 
 func handlerTests(tb testing.TB) iter.Seq2[string, testCase] {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/open-policy-agent/regal/internal/lsp/rego"
 	"github.com/open-policy-agent/regal/internal/lsp/rego/query"
 	"github.com/open-policy-agent/regal/internal/lsp/semantictokens"
+	"github.com/open-policy-agent/regal/internal/lsp/store"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	"github.com/open-policy-agent/regal/internal/update"
@@ -192,17 +193,17 @@ func NewLanguageServer(ctx context.Context, opts *LanguageServerOptions) *Langua
 func NewLanguageServerMinimal(ctx context.Context, opts *LanguageServerOptions, cfg *config.Config) *LanguageServer {
 	c := cache.NewCache()
 	qc := query.NewCache()
-	store := NewRegalStore()
+	rstore := store.NewRegalStore()
 
 	featureFlags := util.Or(opts.FeatureFlags, DefaultServerFeatureFlags)
 
-	_ = PutServer(ctx, store, types.ServerContext{FeatureFlags: *featureFlags, Version: version.Version})
+	_ = store.PutServer(ctx, rstore, types.ServerContext{FeatureFlags: *featureFlags, Version: version.Version})
 
 	ls := &LanguageServer{
 		cache:              c,
 		queryCache:         qc,
 		loadedConfig:       cfg,
-		regoStore:          store,
+		regoStore:          rstore,
 		log:                opts.Logger,
 		featureFlags:       *featureFlags,
 		initializationGate: make(chan struct{}),
@@ -220,7 +221,7 @@ func NewLanguageServerMinimal(ctx context.Context, opts *LanguageServerOptions, 
 		loadedConfigAllRegoVersions: concurrent.MapOf(make(map[string]ast.RegoVersion)),
 	}
 
-	ls.regoRouter = rego.NewRegoRouter(ctx, store, qc, rego.Providers{
+	ls.regoRouter = rego.NewRegoRouter(ctx, rstore, qc, rego.Providers{
 		ContextProvider:              ls.regalContext,
 		IgnoredProvider:              ls.ignoreURI,
 		ContentProvider:              ls.cache.GetFileContents,
@@ -613,7 +614,7 @@ func (l *LanguageServer) setClient(ctx context.Context, client types.Client) {
 	l.clientLock.Lock()
 	l.client = client
 
-	if err := PutClient(ctx, l.regoStore, client); err != nil {
+	if err := store.PutClient(ctx, l.regoStore, client); err != nil {
 		l.clientLock.Unlock()
 		panic(fmt.Sprintf("failed to store client in rego store: %s", err))
 	}
@@ -636,7 +637,7 @@ func (l *LanguageServer) loadConfig(ctx context.Context, conf config.Config) {
 	l.loadedConfig = &conf
 	l.loadedConfigLock.Unlock()
 
-	if err := PutConfig(ctx, l.regoStore, &conf); err != nil {
+	if err := store.PutConfig(ctx, l.regoStore, &conf); err != nil {
 		l.log.Message("failed to update config in storage: %v", err)
 	}
 
@@ -668,7 +669,7 @@ func (l *LanguageServer) loadConfig(ctx context.Context, conf config.Config) {
 
 	l.loadedBuiltins.Set(capsURL, bis)
 
-	if err := PutBuiltins(ctx, l.regoStore, bis); err != nil {
+	if err := store.PutBuiltins(ctx, l.regoStore, bis); err != nil {
 		l.log.Message("failed to update builtins in storage: %v", err)
 	}
 
@@ -687,7 +688,7 @@ func (l *LanguageServer) loadConfig(ctx context.Context, conf config.Config) {
 			l.cache.SetIgnoredFileContents(k, contents)
 		}
 
-		if err := RemoveFileMod(ctx, l.regoStore, k); err != nil {
+		if err := store.RemoveFileMod(ctx, l.regoStore, k); err != nil {
 			l.log.Message("failed to remove mod from store: %s", err)
 		}
 	}

--- a/internal/lsp/store/store.go
+++ b/internal/lsp/store/store.go
@@ -1,4 +1,4 @@
-package lsp
+package store
 
 import (
 	"context"

--- a/internal/lsp/store/store_test.go
+++ b/internal/lsp/store/store_test.go
@@ -1,4 +1,4 @@
-package lsp
+package store
 
 import (
 	"encoding/json"


### PR DESCRIPTION
The `lsp` namespace is bloated enough as it is, and the store did not depend on it.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->