### PR TITLE
Improved handling of input.(json|yaml) files

### DIFF
--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -152,6 +152,7 @@ rules:
         - data.schema.**
         - data.client.**
         - data.server.**
+        - data.workspace
         - data.workspace.**
         - data.regal.config.provided**
         - data.custom.regal**

--- a/bundle/regal/lsp/completion/main.rego
+++ b/bundle/regal/lsp/completion/main.rego
@@ -28,10 +28,15 @@ result["response"] := {
 	not _default_edit_range_supported
 }
 
-# Client supports setting a default edit range for completion items.
+# METADATA
+# description: |
+#   Client supports setting a default edit range for completion items.
+#   We consider our response "complete" in any case where we have at least
+#   one character building a ref to the left of the caret.
+# scope: rule
 result["response"] := {
 	"items": items,
-	"isIncomplete": false,
+	"isIncomplete": ref.text == "",
 	"itemDefaults": {"editRange": range},
 } if {
 	input.method == "textDocument/completion"

--- a/bundle/regal/lsp/completion/providers/inputdotjson/inputdotjson.rego
+++ b/bundle/regal/lsp/completion/providers/inputdotjson/inputdotjson.rego
@@ -18,43 +18,42 @@ import data.regal.lsp.location
 # METADATA
 # description: items contains found suggestions from `input.json`
 items contains item if {
-	input.regal.environment.input_dot_json_path
+	input.regal.environment.input_path != ""
 
 	line := input.regal.file.lines[input.params.position.line]
-	word := location.ref_at(line, input.params.position.character + 1)
+	line != ""
+	location.in_rule_body(line)
 
-	some [suggestion, type] in _matching_input_suggestions
+	word := location.ref_at(line, input.params.position.character + 1)
+	startswith(word.text, "i")
+
+	edit := location.word_range(word, input.params.position)
+
+	some [suggestion, type] in _input_paths
+
+	startswith(suggestion, word.text)
 
 	item := {
 		"label": suggestion,
 		"kind": kind.variable,
 		"detail": type,
-		"documentation": {
-			"kind": "markdown",
-			"value": $"(inferred from [`input.json`]({input.regal.environment.input_dot_json_path}))",
-		},
+		"documentation": _documentation,
 		"textEdit": {
-			"range": location.word_range(word, input.params.position),
+			"range": edit,
 			"newText": suggestion,
 		},
 	}
 }
 
-_matching_input_suggestions contains [suggestion, type] if {
-	line := input.regal.file.lines[input.params.position.line]
-
-	line != ""
-	location.in_rule_body(line)
-
-	word := location.ref_at(line, input.params.position.character + 1)
-
-	some [suggestion, type] in _input_paths
-
-	startswith(suggestion, word.text)
+_documentation := {
+	"kind": "markdown",
+	"value": $"(inferred from [`input.json`]({input.regal.environment.input_path}))",
 }
 
 _input_paths contains [$"input.{concat(".", path)}", type_name(value)] if {
-	walk(input.regal.environment.input_dot_json, [path, value])
+	input_doc := data.workspace.inputs[input.regal.environment.input_path]
+
+	walk(input_doc, [path, value])
 
 	path != []
 

--- a/bundle/regal/lsp/completion/providers/inputdotjson/inputdotjson_test.rego
+++ b/bundle/regal/lsp/completion/providers/inputdotjson/inputdotjson_test.rego
@@ -3,7 +3,10 @@ package regal.lsp.completion.providers.inputdotjson_test
 import data.regal.lsp.completion.providers.inputdotjson as provider
 
 test_matching_input_suggestions if {
-	items := provider.items with input as input_obj
+	items := provider.items
+		with input as input_obj
+		with data.workspace as workspace_obj
+
 	items == {
 		{
 			"detail": "object",
@@ -11,7 +14,7 @@ test_matching_input_suggestions if {
 			"label": "input.request",
 			"documentation": {
 				"kind": "markdown",
-				"value": "(inferred from [`input.json`](/foo/bar/input.json))",
+				"value": "(inferred from [`input.json`](foo/bar/input.json))",
 			},
 			"textEdit": {
 				"newText": "input.request",
@@ -27,7 +30,7 @@ test_matching_input_suggestions if {
 			"label": "input.request.method",
 			"documentation": {
 				"kind": "markdown",
-				"value": "(inferred from [`input.json`](/foo/bar/input.json))",
+				"value": "(inferred from [`input.json`](foo/bar/input.json))",
 			},
 			"textEdit": {
 				"newText": "input.request.method",
@@ -43,7 +46,7 @@ test_matching_input_suggestions if {
 			"label": "input.request.url",
 			"documentation": {
 				"kind": "markdown",
-				"value": "(inferred from [`input.json`](/foo/bar/input.json))",
+				"value": "(inferred from [`input.json`](foo/bar/input.json))",
 			},
 			"textEdit": {
 				"newText": "input.request.url",
@@ -61,7 +64,10 @@ test_not_matching_input_suggestions if {
 		"textDocument": {"uri": "file:///example.rego"},
 		"position": {"line": 0, "character": 0},
 	}})
-	items := provider.items with input as input_obj_new_loc
+	items := provider.items
+		with input as input_obj_new_loc
+		with data.workspace as workspace_obj
+
 	items == set()
 }
 
@@ -71,23 +77,7 @@ input_obj := {
 		"position": {"line": 5, "character": 11},
 	},
 	"regal": {
-		"environment": {
-			"input_dot_json": {
-				"user": {
-					"name": {
-						"first": "John",
-						"last": "Doe",
-					},
-					"email": "john@doe.com",
-					"roles": [{"name": "admin"}, {"name": "user"}],
-				},
-				"request": {
-					"method": "GET",
-					"url": "https://example.com",
-				},
-			},
-			"input_dot_json_path": "/foo/bar/input.json",
-		},
+		"environment": {"input_path": "foo/bar/input.json"},
 		"file": {"lines": [
 			"package p",
 			"",
@@ -99,3 +89,18 @@ input_obj := {
 		]},
 	},
 }
+
+workspace_obj := {"inputs": {"foo/bar/input.json": {
+	"user": {
+		"name": {
+			"first": "John",
+			"last": "Doe",
+		},
+		"email": "john@doe.com",
+		"roles": [{"name": "admin"}, {"name": "user"}],
+	},
+	"request": {
+		"method": "GET",
+		"url": "https://example.com",
+	},
+}}}

--- a/bundle/regal/lsp/initialize/initialize.rego
+++ b/bundle/regal/lsp/initialize/initialize.rego
@@ -39,10 +39,20 @@ _capabilities.diagnosticProvider := {
 }
 
 _capabilities.workspace.fileOperations[operation].filters := filters if {
-	filters := [{
-		"scheme": "file",
-		"pattern": {"glob": "**/*.rego"},
-	}]
+	filters := [
+		{
+			"scheme": "file",
+			"pattern": {"glob": "**/*.rego"},
+		},
+		{
+			"scheme": "file",
+			"pattern": {"glob": "**/input.json"},
+		},
+		{
+			"scheme": "file",
+			"pattern": {"glob": "**/input.yaml"},
+		},
+	]
 	some operation in ["didCreate", "didRename", "didDelete"]
 }
 

--- a/bundle/regal/lsp/initialized/initialized.rego
+++ b/bundle/regal/lsp/initialized/initialized.rego
@@ -1,0 +1,31 @@
+# METADATA
+# description: |
+#   This module contains the logic for handling parts of the 'initialized'
+#   notification from the client. The response from this module will be passed
+#   to the response handler for the 'initialized' notification, which does some
+#   additional work necessarily done in Go. The Rego part of the handler currently
+#   does nothing but conditionally register additional workspace/didChangeWatchedFiles
+#   watchers if the client supports it. Hopefully we can expand that in the future.
+# schemas:
+#   - input: schema.regal.lsp.common
+package regal.lsp.initialized
+
+import data.regal.lsp.client
+
+# METADATA
+# entrypoint: true
+default result["response"] := null
+
+# METADATA
+# description:
+result["response"] := {"registrations": [{
+	"id": "regal-watched-files",
+	"method": "workspace/didChangeWatchedFiles",
+	"registerOptions": {"watchers": [
+		{"globPattern": "**/*.rego"},
+		{"globPattern": "**/*.json"},
+		{"globPattern": "**/*.yaml"},
+	]},
+}]} if {
+	client.capabilities.workspace.didChangeWatchedFiles.dynamicRegistration
+}

--- a/bundle/regal/lsp/main/main.rego
+++ b/bundle/regal/lsp/main/main.rego
@@ -26,6 +26,7 @@ eval := response if {
 
 _handlers := {
 	"initialize": "initialize",
+	"initialized": "initialized",
 	"textDocument/codeAction": "codeaction",
 	"textDocument/codeLens": "codelens",
 	"textDocument/completion": "completion",

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/sourcegraph/jsonrpc2 v0.2.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
+	go.yaml.in/yaml/v2 v2.4.4
 	golang.org/x/sync v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -112,7 +113,6 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/yashtewari/glob-intersection v0.2.0 // indirect
 	github.com/zclconf/go-cty v1.16.3 // indirect
-	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect

--- a/internal/embeds/schemas/regal/ast.json
+++ b/internal/embeds/schemas/regal/ast.json
@@ -370,12 +370,6 @@
             "workspace_root": {
               "type": "string"
             },
-            "input_dot_json": {
-              "type": "object"
-            },
-            "input_dot_json_path": {
-              "type": "string"
-            },
             "rego_version": {
               "type": "integer",
               "minimum": 0,

--- a/internal/embeds/schemas/regal/lsp/common.json
+++ b/internal/embeds/schemas/regal/lsp/common.json
@@ -29,19 +29,12 @@
               "type": "string",
               "description": "File system path of the workspace root"
             },
-            "input_dot_json_path": {
+            "input_path": {
               "type": [
                 "string",
                 "null"
               ],
-              "description": "Path to the input.json file, if found"
-            },
-            "input_dot_json": {
-              "type": [
-                "object",
-                "null"
-              ],
-              "description": "Content of the input.json file, if found"
+              "description": "Path to the closest input.json or input.yaml file, if found"
             },
             "path_separator": {
               "type": "string",

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"sync"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/bundle"
 	ofilter "github.com/open-policy-agent/opa/v1/loader/filter"
@@ -22,7 +20,6 @@ import (
 	"github.com/open-policy-agent/regal/internal/io/files/filter"
 	"github.com/open-policy-agent/regal/internal/util"
 	"github.com/open-policy-agent/regal/pkg/roast/encoding"
-	"github.com/open-policy-agent/regal/pkg/roast/transform"
 
 	_ "github.com/open-policy-agent/regal/pkg/builtins/regal"
 )
@@ -175,54 +172,6 @@ func WithCreateRecursive(path string, fn func(f *os.File) error) error {
 	defer CloseIgnore(file)
 
 	return fn(file)
-}
-
-// FindInputPath consults the filesystem and returns the location of the input.json
-// or input.yaml closest to the file provided.
-func FindInputPath(file, workspacePath string) string {
-	relative := strings.TrimPrefix(file, workspacePath)
-	components := strings.Split(filepath.Dir(relative), string(os.PathSeparator))
-	supported := []string{"input.json", "input.yaml"}
-
-	for i := range components {
-		current := components[:len(components)-i]
-
-		prefix := filepath.Join(append([]string{workspacePath}, current...)...)
-		for _, name := range supported {
-			inputPath := filepath.Join(prefix, name)
-			if _, err := os.Stat(inputPath); err == nil {
-				return inputPath
-			}
-		}
-	}
-
-	return ""
-}
-
-// FindInput finds input.json or input.yaml file in workspace closest to the file, and returns
-// both the location and the contents of the file (as map), or an empty string and nil if not found.
-// Note that:
-// - This function doesn't do error handling. If the file can't be read, nothing is returned.
-// - While the input data theoretically could be anything JSON/YAML value, we only support an object.
-func FindInput(file, workspacePath string) (inputPath string, input ast.Value) {
-	inputPath = FindInputPath(file, workspacePath)
-	if content, err := os.ReadFile(inputPath); err == nil {
-		switch filepath.Base(inputPath) {
-		case "input.json":
-			value, _ := encoding.OfValue().Decode(content)
-
-			return inputPath, value
-		case "input.yaml", "input.yml":
-			var raw any
-			if err = yaml.Unmarshal(content, &raw); err == nil {
-				value, _ := transform.AnyToValue(raw)
-
-				return inputPath, value
-			}
-		}
-	}
-
-	return "", nil
 }
 
 // FindManifestLocations walks the file system rooted at root, and returns the

--- a/internal/lsp/eval.go
+++ b/internal/lsp/eval.go
@@ -39,48 +39,41 @@ var (
 	regalEvalUseAsInputComment = regexp.MustCompile(`^\s*regal eval:\s*use-as-input`)
 )
 
-type EvalResult struct {
-	Value       any                         `json:"value"`
-	PrintOutput map[string]map[int][]string `json:"printOutput"`
-	IsUndefined bool                        `json:"isUndefined"`
-}
-
-type PrintHook struct {
-	Output map[string]map[int][]string
-	// FileNameBase if set, is prepended to filenames in print output. Needed
-	// because rego files are evaluated with relative paths (so errors match
-	// OPA CLI format) but print hook output consumers need full URIs.
-	FileNameBase string
-}
+type (
+	EvalResult struct {
+		Value       any                         `json:"value"`
+		PrintOutput map[string]map[int][]string `json:"printOutput"`
+		IsUndefined bool                        `json:"isUndefined"`
+	}
+	PrintHook struct {
+		Output map[string]map[int][]string
+		// FileNameBase if set, is prepended to filenames in print output. Needed
+		// because rego files are evaluated with relative paths (so errors match
+		// OPA CLI format) but print hook output consumers need full URIs.
+		FileNameBase string
+	}
+)
 
 func (l *LanguageServer) handleEvalCommand(ctx context.Context, args types.CommandArgs) error {
 	if args.Target == "" || args.Query == "" {
-		l.log.Message("expected command target and query, got target %q, query %q", args.Target, args.Query)
-
-		return nil
+		return fmt.Errorf("expected command target and query, got target %q, query %q", args.Target, args.Query)
 	}
 
 	contents, module, ok := l.cache.GetContentAndModule(args.Target)
 	if !ok {
-		l.log.Message("failed to get content or module for file %q", args.Target)
-
-		return nil
+		return fmt.Errorf("failed to get content or module for file %q", args.Target)
 	}
 
 	pq, err := l.queryCache.GetOrSet(ctx, l.regoStore, rquery.RuleHeadLocations)
 	if err != nil {
-		l.log.Message("failed to prepare query %s", rquery.RuleHeadLocations, err)
-
-		return nil
+		return fmt.Errorf("failed to prepare query %s: %w", rquery.RuleHeadLocations, err)
 	}
 
 	file := filepath.Base(uri.ToPath(args.Target))
 
 	allRuleHeadLocations, err := rrego.AllRuleHeadLocations(ctx, pq, file, contents, module)
 	if err != nil {
-		l.log.Message("failed to get rule head locations: %s", err)
-
-		return nil
+		return fmt.Errorf("failed to get rule head locations: %w", err)
 	}
 
 	// if there are none, then it's a package evaluation
@@ -98,19 +91,15 @@ func (l *LanguageServer) handleEvalCommand(ctx context.Context, args types.Comma
 	if len(module.Comments) > 0 && regalEvalUseAsInputComment.Match(module.Comments[0].Text) {
 		inputValue, err = transform.ToAST(l.toRelativePath(args.Target), contents, module, false)
 		if err != nil {
-			l.log.Message("failed to prepare module: %s", err)
-
-			return nil
+			return fmt.Errorf("failed to prepare module: %w", err)
 		}
 	} else {
 		// Normal mode — try to find the input.json/yaml file in the workspace and use as input
 		// NOTE that we don't break on missing input, as some rules don't depend on that, and should
 		// still be evaluable. We may consider returning some notice to the user though.
-		inputPath, inputValue = rio.FindInput(uri.ToPath(args.Target), l.workspacePath())
-
-		ruleName := strings.TrimPrefix(args.Query, module.Package.Path.String()+".")
-
+		inputPath = l.input.FindForPath(args.Target)
 		if inputPath == "" && !l.supressInputPrompt {
+			ruleName := strings.TrimPrefix(args.Query, module.Package.Path.String()+".")
 			created, err := l.handleInputSkeletonPrompt(ctx, args.Target, ruleName, args.Row)
 			// Bubbling up an error here if input.json creation fails for any reason.
 			if err != nil {
@@ -120,6 +109,8 @@ func (l *LanguageServer) handleEvalCommand(ctx context.Context, args types.Comma
 			if created {
 				return nil
 			}
+		} else if inputPath != "" {
+			inputValue = l.input.Get(ctx, inputPath)
 		}
 	}
 
@@ -345,14 +336,11 @@ func inputSkeletonFromRule(rule *ast.Rule, compiler *ast.Compiler) map[string]an
 		return root
 	}
 
-	refs = append(refs, headRefs...)
+	refs = util.Filter(append(refs, headRefs...), func(ref ast.Ref) bool {
+		return ref.HasPrefix(ast.InputRootRef) && len(ref) > 1
+	})
 
 	for _, ref := range refs {
-		// We only want input refs
-		if len(ref) < 2 || !ref[0].Equal(ast.InputRootDocument) {
-			continue
-		}
-
 		node := root
 
 		for _, term := range ref[1 : len(ref)-1] {

--- a/internal/lsp/eval_test.go
+++ b/internal/lsp/eval_test.go
@@ -1,15 +1,12 @@
 package lsp
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
-	rio "github.com/open-policy-agent/regal/internal/io"
 	"github.com/open-policy-agent/regal/internal/lsp/log"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	rparse "github.com/open-policy-agent/regal/internal/parse"
@@ -75,83 +72,4 @@ func TestEvalWorkspacePathInternalData(t *testing.T) {
 	act := util.Sorted(must.Return(util.AnySliceTo[string](val))(t))
 
 	assert.SlicesEqual(t, []string{"capabilities", "combined_config", "user_config"}, act)
-}
-
-func TestFindInputPath(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct{ fileExt, fileContent string }{{"json", `{"x": true}`}, {"yaml", "x: true"}}
-
-	for _, tc := range cases {
-		t.Run(tc.fileExt, func(t *testing.T) {
-			t.Parallel()
-
-			tmpDir := t.TempDir()
-			workspacePath := filepath.Join(tmpDir, "workspace")
-			file := filepath.Join(tmpDir, "workspace", "foo", "bar", "baz.rego")
-
-			must.MkdirAll(t, workspacePath, "foo", "bar")
-			must.Equal(t, "", rio.FindInputPath(file, workspacePath), "expected no input path to be found")
-
-			inputPath := filepath.Join(workspacePath, "foo", "bar", "input."+tc.fileExt)
-			createWithContent(t, inputPath, tc.fileContent)
-
-			assert.Equal(t, inputPath, rio.FindInputPath(file, workspacePath), "input")
-			must.Remove(t, inputPath)
-
-			workspaceInputPath := filepath.Join(workspacePath, "input."+tc.fileExt)
-			createWithContent(t, workspaceInputPath, tc.fileContent)
-
-			assert.Equal(t, workspaceInputPath, rio.FindInputPath(file, workspacePath), "input")
-		})
-	}
-}
-
-func TestFindInput(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct{ fileType, fileContent string }{{"json", `{"x": true}`}, {"yaml", "x: true"}}
-
-	for _, tc := range cases {
-		t.Run(tc.fileType, func(t *testing.T) {
-			t.Parallel()
-
-			tmpDir := t.TempDir()
-			workspacePath := filepath.Join(tmpDir, "workspace")
-			file := filepath.Join(tmpDir, "workspace", "foo", "bar", "baz.rego")
-
-			must.MkdirAll(t, workspacePath, "foo", "bar")
-
-			path, value := rio.FindInput(file, workspacePath)
-			must.Equal(t, "", path, "expected no input path to be found")
-			must.Equal(t, nil, value)
-
-			inputPath := filepath.Join(workspacePath, "foo", "bar", "input."+tc.fileType)
-
-			createWithContent(t, inputPath, tc.fileContent)
-
-			path, value = rio.FindInput(file, workspacePath)
-			assert.Equal(t, inputPath, path, "input path")
-			assert.Equal(t, 0, ast.NewObject(rast.Item("x", ast.InternedTerm(true))).Compare(value))
-
-			must.Remove(t, inputPath)
-
-			workspaceInputPath := filepath.Join(workspacePath, "input."+tc.fileType)
-			createWithContent(t, workspaceInputPath, tc.fileContent)
-
-			path, value = rio.FindInput(file, workspacePath)
-			assert.Equal(t, workspaceInputPath, path, "input path")
-			assert.Equal(t, 0, ast.NewObject(rast.Item("x", ast.InternedTerm(true))).Compare(value))
-		})
-	}
-}
-
-func createWithContent(t *testing.T, path, content string) {
-	t.Helper()
-
-	must.Equal(t, nil, rio.WithCreateRecursive(path, func(f *os.File) error {
-		_, err := f.WriteString(content)
-
-		return err
-	}))
 }

--- a/internal/lsp/input/input.go
+++ b/internal/lsp/input/input.go
@@ -1,0 +1,191 @@
+package input
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"go.yaml.in/yaml/v2"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/storage"
+
+	"github.com/open-policy-agent/regal/internal/io/files"
+	"github.com/open-policy-agent/regal/internal/io/files/filter"
+	"github.com/open-policy-agent/regal/internal/lsp/log"
+	"github.com/open-policy-agent/regal/internal/lsp/store"
+	"github.com/open-policy-agent/regal/internal/lsp/uri"
+	"github.com/open-policy-agent/regal/internal/util"
+	"github.com/open-policy-agent/regal/pkg/roast/encoding"
+	"github.com/open-policy-agent/regal/pkg/roast/transform"
+)
+
+type (
+	// Manager manages input files in the workspace, allowing for fast retrieval of the most specific input for a given
+	// path, whether in Go (via [*Manager.FindForPath] and [*Manager.Get]) or in Rego (via `data.workspace.inputs`).
+	Manager struct {
+		rootPath string
+		rootFS   fs.FS
+		store    storage.Store
+		inputs   map[string]file
+		log      *log.Logger
+		mut      sync.RWMutex
+	}
+	file struct {
+		dir  string
+		raw  []byte
+		path storage.Path
+	}
+)
+
+func NewManager(store storage.Store, log *log.Logger) *Manager {
+	return &Manager{
+		store:  store,
+		inputs: make(map[string]file),
+		log:    log,
+		mut:    sync.RWMutex{},
+	}
+}
+
+func (m *Manager) LoadFromRoot(ctx context.Context, rootPath string) error {
+	root, err := os.OpenRoot(rootPath)
+	if err != nil {
+		return fmt.Errorf("failed to open workspace root: %w", err)
+	}
+
+	return m.LoadFromFS(ctx, rootPath, root.FS())
+}
+
+func (m *Manager) LoadFromFS(ctx context.Context, rootPath string, rootFS fs.FS) error {
+	m.mut.Lock()
+	m.rootPath = rootPath
+	m.rootFS = rootFS
+	m.mut.Unlock()
+
+	return files.DefaultWalker(".").
+		WithFilters(filter.Not(filter.Suffixes("input.json", "input.yaml"))).
+		WalkFS(rootFS, func(path string) error {
+			return m.Update(ctx, path, nil)
+		})
+}
+
+// FindForPath returns the most specific input path for the given path
+// relative to the workspace root, or an empty string if no input file is found.
+func (m *Manager) FindForPath(pathOrURI string) string {
+	path := m.internalPath(pathOrURI)
+
+	m.mut.RLock()
+	defer m.mut.RUnlock()
+
+	var closestDir, closestPath string
+	for inputPath, file := range m.inputs {
+		if strings.HasPrefix(path, file.dir) && len(file.dir) >= len(closestDir) {
+			closestDir, closestPath = file.dir, inputPath
+		}
+	}
+
+	return closestPath
+}
+
+// Get returns the input value for the given input path, as retrieved by FindForPath.
+func (m *Manager) Get(ctx context.Context, inputPath string) ast.Value {
+	inputPath = strings.Trim(filepath.ToSlash(inputPath), "/")
+
+	m.mut.RLock()
+	defer m.mut.RUnlock()
+
+	if file, exists := m.inputs[inputPath]; exists {
+		if inputAny, err := storage.ReadOne(ctx, m.store, file.path); err == nil {
+			if inputValue, ok := inputAny.(ast.Value); ok {
+				return inputValue
+			}
+		}
+	}
+
+	return ast.InternedEmptyObjectValue
+}
+
+// Update updates the input value for the given path or URI, caching it in the store for retrieval with Get.
+// If content is nil, it will attempt to load it from disk.
+func (m *Manager) Update(ctx context.Context, pathOrURI string, content []byte) (err error) {
+	path := m.internalPath(pathOrURI)
+
+	m.mut.Lock()
+	defer m.mut.Unlock()
+
+	if content == nil {
+		if content, err = fs.ReadFile(m.rootFS, path); err != nil {
+			return err
+		}
+
+		if len(content) == 0 {
+			content = append(content, '{', '}') // file likely just created
+		}
+	}
+
+	if curr, exists := m.inputs[path]; exists && bytes.Equal(curr.raw, content) {
+		return nil
+	}
+
+	var val ast.Value
+
+	suffix := path[strings.LastIndexByte(path, '.')+1:]
+	switch suffix {
+	case "json":
+		val, err = encoding.OfValue().Decode(content)
+	case "yaml":
+		var res map[string]any
+		if err = yaml.Unmarshal(content, &res); err == nil {
+			val, err = transform.AnyToValue(res)
+		}
+	}
+
+	if err == nil {
+		storePath := m.storagePathFor(path)
+		if err = store.Put(ctx, m.store, storePath, val); err == nil {
+			dir := strings.TrimSuffix(strings.TrimSuffix(strings.TrimSuffix(path, suffix), "input."), "/")
+
+			m.inputs[path] = file{raw: content, path: storePath, dir: dir}
+		}
+	}
+
+	return err
+}
+
+func (m *Manager) Delete(ctx context.Context, pathOrURI string) error {
+	path := m.internalPath(pathOrURI)
+
+	m.mut.Lock()
+	defer m.mut.Unlock()
+
+	err := store.Remove(ctx, m.store, m.storagePathFor(path))
+	delete(m.inputs, path)
+
+	return err
+}
+
+func (*Manager) HasInputSuffix(path string) bool {
+	return util.HasAnySuffix(path, "input.json", "input.yaml")
+}
+
+// NOTE: must be called with m.mut held!
+func (m *Manager) storagePathFor(path string) storage.Path {
+	if existing, ok := m.inputs[path]; ok {
+		return existing.path
+	}
+
+	return storage.Path{"workspace", "inputs", path}
+}
+
+func (m *Manager) internalPath(pathOrURI string) string {
+	m.mut.RLock()
+	rootPath := m.rootPath
+	m.mut.RUnlock()
+
+	return strings.TrimPrefix(strings.TrimPrefix(uri.ToPath(pathOrURI), rootPath), "/")
+}

--- a/internal/lsp/input/input_test.go
+++ b/internal/lsp/input/input_test.go
@@ -1,0 +1,52 @@
+package input_test
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/open-policy-agent/opa/v1/storage/inmem"
+
+	"github.com/open-policy-agent/regal/internal/lsp/input"
+	"github.com/open-policy-agent/regal/internal/lsp/log"
+	"github.com/open-policy-agent/regal/internal/test/must"
+)
+
+func TestFindForPath(t *testing.T) {
+	t.Parallel()
+
+	st := inmem.NewFromObject(map[string]any{"workspace": map[string]any{"inputs": map[string]any{}}})
+	im := input.NewManager(st, log.NewLogger(log.LevelDebug, t.Output()))
+
+	inputJSON, inputYAML := []byte(`{"foo": "bar"}`), []byte(`foo: bar`)
+
+	must.Equal(t, nil, im.LoadFromFS(t.Context(), "", fstest.MapFS{
+		"input.json":             {Data: inputJSON},
+		"foo/bar/input.yaml":     {Data: inputYAML},
+		"foo/bar/baz/input.json": {Data: inputJSON},
+	}))
+
+	for _, tc := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "most specific match", path: "foo/bar/baz/p.rego", want: "foo/bar/baz/input.json"},
+		{name: "less specific match", path: "foo/bar/p.rego", want: "foo/bar/input.yaml"},
+		{name: "workspace root match", path: "p.rego", want: "input.json"},
+		{name: "no file match", path: "foo/baz/p.rego", want: "input.json"},
+		{name: "most specific directory match", path: "foo/bar/baz", want: "foo/bar/baz/input.json"},
+		{name: "less specific directory match", path: "foo/bar", want: "foo/bar/input.yaml"},
+		{name: "workspace root directory match", path: "", want: "input.json"},
+		{name: "directory trailing slash match", path: "foo/bar/baz/", want: "foo/bar/baz/input.json"},
+		{name: "directory leading slash match", path: "/foo/bar/baz", want: "foo/bar/baz/input.json"},
+		{name: "match from uri", path: "file:///foo/bar/baz", want: "foo/bar/baz/input.json"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if path := im.FindForPath(tc.path); path != tc.want {
+				t.Errorf("expected path %q, got %q", tc.want, path)
+			}
+		})
+	}
+}

--- a/internal/lsp/rego/rego.go
+++ b/internal/lsp/rego/rego.go
@@ -52,11 +52,10 @@ type (
 	}
 
 	Environment struct {
-		PathSeparator     string    `json:"path_separator"`
-		WorkspaceRootURI  string    `json:"workspace_root_uri"`
-		WorkspaceRootPath string    `json:"workspace_root_path"`
-		InputDotJSON      ast.Value `json:"input_dot_json,omitempty"`
-		InputDotJSONPath  *string   `json:"input_dot_json_path,omitempty"`
+		PathSeparator     string `json:"path_separator"`
+		WorkspaceRootURI  string `json:"workspace_root_uri"`
+		WorkspaceRootPath string `json:"workspace_root_path"`
+		InputPath         string `json:"input_path,omitempty"`
 	}
 
 	RegalContext struct {
@@ -67,8 +66,8 @@ type (
 	}
 
 	Requirements struct {
-		File         FileRequirements `json:"file"`
-		InputDotJSON bool             `json:"input_dot_json"`
+		File      FileRequirements `json:"file"`
+		InputPath bool             `json:"input_path"`
 	}
 
 	FileRequirements struct {

--- a/internal/lsp/rego/router.go
+++ b/internal/lsp/rego/router.go
@@ -15,7 +15,6 @@ import (
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/storage"
 
-	"github.com/open-policy-agent/regal/internal/io"
 	"github.com/open-policy-agent/regal/internal/lsp/rego/query"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	ruri "github.com/open-policy-agent/regal/internal/lsp/uri"
@@ -78,6 +77,7 @@ type (
 		IgnoredProvider              func(uri string) bool
 		ParseErrorsProvider          func(uri string) ([]types.Diagnostic, bool)
 		SuccessfulParseCountProvider func(uri string) (uint, bool)
+		InputPathProvider            func(path string) string
 	}
 
 	RegoRouter struct {
@@ -123,7 +123,7 @@ func NewRegoRouter(ctx context.Context, store storage.Store, qc *query.Cache, pr
 			SuccessfulParseLineCount: true,
 			ParseErrors:              true,
 		}}},
-		"textDocument/completion":          {requires: Requirements{File: FileRequirements{Lines: true}, InputDotJSON: true}},
+		"textDocument/completion":          {requires: Requirements{File: FileRequirements{Lines: true}, InputPath: true}},
 		"textDocument/documentLink":        {requires: fileLines},
 		"textDocument/documentHighlight":   {requires: fileLines},
 		"textDocument/foldingRange":        {requires: fileLines},
@@ -135,6 +135,8 @@ func NewRegoRouter(ctx context.Context, store storage.Store, qc *query.Cache, pr
 		"textDocument/signatureHelp":       {requires: fileLines},
 		"completionItem/resolve":           {resolver: passthrough},
 		"inlayHint/resolve":                {resolver: passthrough},
+
+		"initialized": {}, // special case
 	}
 
 	return &RegoRouter{routes: routes, providers: prvs, qc: qc}
@@ -152,7 +154,7 @@ func (m *RegoRouter) RegisterResultHandler(method string, handler ResultHandler)
 	m.resultHandlers[method] = handler
 }
 
-func (m *RegoRouter) Handle(ctx context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (any, error) {
+func (m *RegoRouter) Handle(ctx context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
 	pq := m.qc.Get(query.MainEval)
 	if pq == nil {
 		return nil, fmt.Errorf("no prepared query for %s", query.MainEval)
@@ -173,23 +175,22 @@ func (m *RegoRouter) Handle(ctx context.Context, _ *jsonrpc2.Conn, req *jsonrpc2
 	}
 
 	if route, ok := m.routes[req.Method]; ok {
-		if strings.HasSuffix(req.Method, "/resolve") && route.resolver != nil {
-			rctx := m.providers.ContextProvider("", Requirements{}) // No requirements for resolvers yet
+		if strings.HasPrefix(req.Method, "textDocument/") {
+			result, err = textDocumentPassthroughHandlerFor(route)(ctx, pq, m.providers, req)
+		} else {
+			rctx := m.providers.ContextProvider("", route.requires) // No requirements for resolvers yet
 			rctx.Query = pq
 
-			return passthrough(ctx, rctx, req)
+			result, err = passthrough(ctx, rctx, req)
 		}
 
-		result, err := textDocumentPassthroughHandlerFor(route)(ctx, pq, m.providers, req)
-		if err != nil {
-			return nil, err
+		if err == nil {
+			if resultHandler, ok := m.resultHandlers[req.Method]; ok {
+				result, err = resultHandler(ctx, result)
+			}
 		}
 
-		if handler, ok := m.resultHandlers[req.Method]; ok {
-			return handler(ctx, result)
-		}
-
-		return result, nil
+		return result, err
 	}
 
 	return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeMethodNotFound, Message: "method not supported: " + req.Method}
@@ -205,7 +206,7 @@ func textDocumentPassthroughHandlerFor(route Route) regoHandler {
 		}
 
 		docURI := maybeURI.ToString()
-		if prvs.IgnoredProvider != nil && prvs.IgnoredProvider(docURI) {
+		if prvs.IgnoredProvider != nil && prvs.IgnoredProvider(docURI) || !strings.HasSuffix(docURI, ".rego") {
 			// This is not an error, but perhaps we should wire in some debug logging later
 			return nil, nil
 		}
@@ -262,21 +263,13 @@ func regalContextForRequirements(prvs Providers, uri string, reqs Requirements) 
 		}
 	}
 
-	if reqs.InputDotJSON {
-		path := ruri.ToPath(uri)
-		root := ruri.ToPath(rctx.Environment.WorkspaceRootURI)
-
-		// TODO: Avoid the intermediate map[string]any step and unmarshal directly into ast.Value.
-		inputDotJSONPath, inputDotJSONContent := io.FindInput(path, root)
-		if inputDotJSONPath != "" && inputDotJSONContent != nil {
-			inputDotJSONValue, err := transform.ToOPAInputValue(inputDotJSONContent)
-			if err != nil {
-				return nil, fmt.Errorf("failed to convert input.json to value: %w", err)
-			}
-
-			rctx.Environment.InputDotJSONPath = &inputDotJSONPath
-			rctx.Environment.InputDotJSON = inputDotJSONValue
+	if reqs.InputPath {
+		if prvs.InputPathProvider == nil {
+			return nil, errors.New("input.json path provider required but not provided")
 		}
+
+		path := ruri.ToRelativePath(uri, rctx.Environment.WorkspaceRootURI)
+		rctx.Environment.InputPath = prvs.InputPathProvider(path)
 	}
 
 	return rctx, nil

--- a/internal/lsp/rego/router_test.go
+++ b/internal/lsp/rego/router_test.go
@@ -214,6 +214,9 @@ func providersForTest(tb testing.TB, test testCase) rego.Providers {
 		SuccessfulParseCountProvider: func(string) (uint, bool) {
 			return 1, true
 		},
+		InputPathProvider: func(string) string {
+			return "input.json"
+		},
 	}
 }
 

--- a/internal/lsp/semantictokens/semantictokens.go
+++ b/internal/lsp/semantictokens/semantictokens.go
@@ -78,6 +78,10 @@ func Full(result SemanticTokensResult) (*types.SemanticTokens, error) {
 }
 
 func ResultHandler(_ context.Context, result any) (any, error) {
+	if result == nil {
+		return nil, nil //nolint:nilnil
+	}
+
 	if raw, ok := result.(*json.RawMessage); ok {
 		var semTokRes SemanticTokensResult
 		// this looks like a false positive as the struct fields are tagged

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -34,6 +34,7 @@ import (
 	lsconfig "github.com/open-policy-agent/regal/internal/lsp/config"
 	"github.com/open-policy-agent/regal/internal/lsp/documentsymbol"
 	"github.com/open-policy-agent/regal/internal/lsp/handler"
+	"github.com/open-policy-agent/regal/internal/lsp/input"
 	"github.com/open-policy-agent/regal/internal/lsp/log"
 	"github.com/open-policy-agent/regal/internal/lsp/rego"
 	"github.com/open-policy-agent/regal/internal/lsp/rego/query"
@@ -41,6 +42,7 @@ import (
 	"github.com/open-policy-agent/regal/internal/lsp/store"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
+	"github.com/open-policy-agent/regal/internal/lsp/window"
 	"github.com/open-policy-agent/regal/internal/update"
 	"github.com/open-policy-agent/regal/internal/util"
 	"github.com/open-policy-agent/regal/internal/web"
@@ -55,6 +57,12 @@ import (
 )
 
 const (
+	noInputFoundMsg = "No input.json/yaml file was found. " +
+		"This file is used to provide input data for rule evaluation. " +
+		"Would you like to create one?"
+
+	inputCreateSuccessMsg      = "input.json created successfully! Running Evaluate will now pull from this file."
+	crlfWarnMsg                = "CRLF line ending detected. Please change editor setting to use LF for line endings."
 	methodTdPublishDiagnostics = "textDocument/publishDiagnostics"
 	methodWsApplyEdit          = "workspace/applyEdit"
 
@@ -129,6 +137,7 @@ type LanguageServer struct {
 
 	regoStore storage.Store
 	conn      *jsonrpc2.Conn
+	window    *window.Window
 
 	configWatcher               *lsconfig.Watcher
 	loadedConfig                *config.Config
@@ -159,6 +168,8 @@ type LanguageServer struct {
 	testLocationJobs chan fileJob
 	prepareQueryJobs chan struct{}
 	commandRequest   chan types.ExecuteCommandParams
+
+	input *input.Manager
 
 	// templatingFiles tracks files currently being templated to ensure
 	// other updates are not processed while the file is being updated.
@@ -194,7 +205,6 @@ func NewLanguageServerMinimal(ctx context.Context, opts *LanguageServerOptions, 
 	c := cache.NewCache()
 	qc := query.NewCache()
 	rstore := store.NewRegalStore()
-
 	featureFlags := util.Or(opts.FeatureFlags, DefaultServerFeatureFlags)
 
 	_ = store.PutServer(ctx, rstore, types.ServerContext{FeatureFlags: *featureFlags, Version: version.Version})
@@ -206,6 +216,7 @@ func NewLanguageServerMinimal(ctx context.Context, opts *LanguageServerOptions, 
 		regoStore:          rstore,
 		log:                opts.Logger,
 		featureFlags:       *featureFlags,
+		input:              input.NewManager(rstore, opts.Logger),
 		initializationGate: make(chan struct{}),
 		lintJobs:           make(chan lintJob, 10),
 		commandRequest:     make(chan types.ExecuteCommandParams, 10),
@@ -227,9 +238,11 @@ func NewLanguageServerMinimal(ctx context.Context, opts *LanguageServerOptions, 
 		ContentProvider:              ls.cache.GetFileContents,
 		ParseErrorsProvider:          ls.cache.GetParseErrors,
 		SuccessfulParseCountProvider: ls.cache.GetSuccessfulParseLineCount,
+		InputPathProvider:            ls.input.FindForPath,
 	})
 
 	ls.regoRouter.RegisterResultHandler("initialize", ls.initializeResultHandler)
+	ls.regoRouter.RegisterResultHandler("initialized", ls.initializedResultHandler)
 	ls.regoRouter.RegisterResultHandler("textDocument/semanticTokens/full", semantictokens.ResultHandler)
 
 	merged, _ := config.WithDefaultsFromBundle(bundle.Embedded(), cfg)
@@ -251,8 +264,6 @@ func (l *LanguageServer) Handle(ctx context.Context, _ *jsonrpc2.Conn, req *json
 	}
 
 	switch req.Method {
-	case "initialized":
-		return l.handleInitialized(ctx)
 	case "textDocument/definition":
 		return handler.WithParams(req, l.handleTextDocumentDefinition)
 	case "textDocument/diagnostic":
@@ -299,7 +310,10 @@ func (l *LanguageServer) Handle(ctx context.Context, _ *jsonrpc2.Conn, req *json
 		return handler.WithParams(req, func(params types.TraceParams) (any, error) {
 			if level, err := log.TraceValueToLevel(params.Value); err != nil {
 				return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams, Message: err.Error()}
-			} else {
+			} else if level != log.LevelOff {
+				// VS Code sets this to "off" a few seconds after initialization,
+				// for no apparent reason. Perhaps we shouldn't use this level to
+				// determine logging, but what else is it for?
 				l.log.SetLevel(level)
 			}
 
@@ -311,28 +325,13 @@ func (l *LanguageServer) Handle(ctx context.Context, _ *jsonrpc2.Conn, req *json
 		return emptyStruct, nil
 	}
 
-	// Handles:
-	// - initialize
-	// - textDocument/codeAction
-	// - textDocument/codeLens
-	// - textDocument/completion
-	//   - completionItem/resolve
-	// - textDocument/documentLink
-	// - textDocument/documentHighlight
-	// - textDocument/foldingRange
-	// - textDocument/hover
-	// - textDocument/inlayHint
-	//   - inlayHint/resolve
-	// - textDocument/linkedEditingRange
-	// - textDocument/selectionRange
-	// - textDocument/signatureHelp
-	//
 	// returns jsonrpc2.Error with code jsonrpc2.CodeMethodNotFound if provided unknown method.
 	return l.regoRouter.Handle(ctx, l.conn, req)
 }
 
 func (l *LanguageServer) SetConn(conn *jsonrpc2.Conn) {
 	l.conn = conn
+	l.window = window.New(conn, l.log)
 }
 
 // Shutdown waits for all worker goroutines to complete. The context can be
@@ -385,7 +384,7 @@ func (l *LanguageServer) StartDiagnosticsWorker(ctx context.Context) {
 				case <-ctx.Done():
 					return
 				case job := <-l.lintJobs:
-					l.log.Debug("linting: %s", job.Reason)
+					l.log.Message("linting: %s", job.Reason)
 
 					select {
 					case work <- struct{}{}:
@@ -493,7 +492,6 @@ func (l *LanguageServer) StartConfigWorker(ctx context.Context) {
 						update.CheckAndWarn(ctx, update.Options{
 							CurrentVersion: version.Version,
 							CurrentTime:    time.Now().UTC(),
-							Debug:          false,
 							StateDir:       config.GlobalConfigDir(true),
 						}, os.Stderr)
 					}
@@ -933,11 +931,8 @@ func (l *LanguageServer) handleTextDocumentDidOpen(
 ) (any, error) {
 	// then we have started the server, and not yet received a suitable root to use.
 	if l.getWorkspaceRootURI() == "" {
-		err := l.updateRootURI(
-			// get the URI of the file's immediate parent
-			l.fromPath(filepath.Dir(uri.ToPath(params.TextDocument.URI))),
-		)
-		if err != nil {
+		// get the URI of the file's immediate parent
+		if err := l.updateRootURI(ctx, l.fromPath(filepath.Dir(uri.ToPath(params.TextDocument.URI)))); err != nil {
 			l.log.Message("failed to update server root URI: %w", err)
 		}
 	}
@@ -1002,15 +997,22 @@ func (l *LanguageServer) handleTextDocumentDidChange(
 		}
 	}
 
-	if ignored := l.setMaybeIgnoredContents(params.TextDocument.URI, contents); !ignored {
-		parseSuccess, err := updateParse(ctx, l.parseOpts(params.TextDocument.URI, l.builtinsForCurrentCapabilities()))
-		if err != nil {
-			l.log.Message("failed to update module for %s: %s", params.TextDocument.URI, err)
-		} else if l.getClient().InitOptions.EnableServerTesting && parseSuccess {
-			l.testLocationJobs <- fileJob{URI: params.TextDocument.URI}
-		}
+	ignored := l.setMaybeIgnoredContents(params.TextDocument.URI, contents)
+	if !ignored {
+		// handle async as we want to acknowledge we handled the change to the client ASAP,
+		// regardless of whether parsing / linting was successful or not
+		go func() {
+			opts := l.parseOpts(params.TextDocument.URI, l.builtinsForCurrentCapabilities())
 
-		l.lintJobs <- lintJob{Reason: "textDocument/didChange"}
+			parseSuccess, err := updateParse(ctx, opts)
+			if err != nil {
+				l.log.Message("failed to update module for %s: %s", params.TextDocument.URI, err)
+			} else if l.getClient().InitOptions.EnableServerTesting && parseSuccess {
+				l.testLocationJobs <- fileJob{URI: params.TextDocument.URI}
+			}
+
+			l.lintJobs <- lintJob{Reason: "textDocument/didChange"}
+		}()
 	}
 
 	return emptyStruct, nil
@@ -1066,14 +1068,7 @@ func (l *LanguageServer) handleTextDocumentDidSave(
 	}
 
 	if slices.ContainsFunc(enabled, util.EqualsAny(ruleNameOPAFmt, ruleNameUseRegoV1)) {
-		resp := types.ShowMessageParams{
-			Type:    2, // warning
-			Message: "CRLF line ending detected. Please change editor setting to use LF for line endings.",
-		}
-
-		if err := l.conn.Notify(ctx, "window/showMessage", resp); err != nil {
-			l.log.Message("failed to notify: %s", err)
-		}
+		l.window.ShowMessage(ctx, types.WarningMessage, crlfWarnMsg)
 	}
 
 	return emptyStruct, nil
@@ -1318,7 +1313,7 @@ func (l *LanguageServer) initializeResultHandler(ctx context.Context, result any
 
 	l.setClient(ctx, response.Regal.Client)
 
-	if err := l.updateRootURI(response.Regal.Workspace.URI); err != nil {
+	if err := l.updateRootURI(ctx, response.Regal.Workspace.URI); err != nil {
 		l.log.Message("failed to set rootURI: %w", err)
 	}
 
@@ -1329,12 +1324,11 @@ func (l *LanguageServer) initializeResultHandler(ctx context.Context, result any
 	return response.Response, nil
 }
 
-func (l *LanguageServer) updateRootURI(rootURI string) error {
+func (l *LanguageServer) updateRootURI(ctx context.Context, rootURI string) error {
 	l.loadedConfigLock.Lock()
 	defer l.loadedConfigLock.Unlock()
 
-	// rootURI not expected to have a trailing slash, remove if present for
-	// consistency
+	// rootURI not expected to have a trailing slash, remove if present for consistency
 	normalizedRootURI := strings.TrimSuffix(rootURI, string(os.PathSeparator))
 
 	configRoots, err := lsconfig.FindConfigRoots(uri.ToPath(normalizedRootURI))
@@ -1386,7 +1380,7 @@ func (l *LanguageServer) updateRootURI(rootURI string) error {
 		l.log.Message("no config file found for workspace")
 	}
 
-	return nil
+	return l.input.LoadFromRoot(ctx, workspaceRootPath)
 }
 
 type fileToLoad struct {
@@ -1402,10 +1396,9 @@ func (l *LanguageServer) loadWorkspaceContents(ctx context.Context, newOnly bool
 		return nil, nil, nil
 	}
 
-	fileCh := make(chan fileToLoad, 1000)
-
 	// Walk the workspace and enqueue files that need loading from disk.
 	walkErr := make(chan error, 1)
+	fileCh := make(chan fileToLoad, 1000)
 
 	go func() {
 		defer close(fileCh)
@@ -1455,7 +1448,7 @@ func (l *LanguageServer) loadWorkspaceContents(ctx context.Context, newOnly bool
 				}
 
 				if _, err := updateParse(ctx, l.parseOpts(f.uri, l.builtinsForCurrentCapabilities())); err != nil {
-					fmt.Fprintln(os.Stderr, "error parse", f.uri)
+					l.log.Message("error parsing file %s", f.uri)
 					mu.Lock()
 
 					failed = append(failed,
@@ -1487,7 +1480,15 @@ func (l *LanguageServer) loadWorkspaceContents(ctx context.Context, newOnly bool
 	return changedOrNewURIs, failed, nil
 }
 
-func (l *LanguageServer) handleInitialized(ctx context.Context) (any, error) {
+func (l *LanguageServer) initializedResultHandler(ctx context.Context, result any) (any, error) {
+	// If the client supports dynamic registration, register for any the Rego
+	// handler returned. Currently this is workspace/didChangeWatchedFiles only.
+	if raw, ok := result.(*json.RawMessage); ok && len(*raw) > 4 { // = len("null")
+		if err := l.conn.Call(ctx, "client/registerCapability", &raw, nil); err != nil {
+			l.log.Message("failed to register workspace/didChangeWatchedFiles capability: %s", err)
+		}
+	}
+
 	// Load workspace contents and start jobs asynchronously
 	// This allows us to respond to the client immediately while workspace
 	// loading happens in the background
@@ -1506,8 +1507,10 @@ func (l *LanguageServer) handleInitialized(ctx context.Context) (any, error) {
 		// must start other workers here otherwise the test locations block
 		l.initializationGateOnce.Do(func() { close(l.initializationGate) })
 
+		builtins := l.builtinsForCurrentCapabilities()
+
 		for _, cnURI := range newURIs {
-			parseSuccess, err := updateParse(ctx, l.parseOpts(cnURI, l.builtinsForCurrentCapabilities()))
+			parseSuccess, err := updateParse(ctx, l.parseOpts(cnURI, builtins))
 			if err != nil {
 				l.log.Message("failed to update module for %s: %s", cnURI, err)
 			} else if l.getClient().InitOptions.EnableServerTesting && parseSuccess {
@@ -1515,9 +1518,7 @@ func (l *LanguageServer) handleInitialized(ctx context.Context) (any, error) {
 			}
 		}
 
-		l.lintJobs <- lintJob{
-			Reason: "Workspace Initialization",
-		}
+		l.lintJobs <- lintJob{Reason: "Workspace Initialization"}
 	}()
 
 	return emptyStruct, nil
@@ -1536,31 +1537,40 @@ func (l *LanguageServer) handleWorkspaceDidChangeWatchedFiles(
 ) (any, error) {
 	changes := false
 
-	for _, change := range params.Changes {
-		// this handles the case of a new config file being created when one did not exist before
-		if util.HasAnySuffix(change.URI, filepath.Join(".regal", "config.yaml"), ".regal.yaml") {
-			if configFile, err := config.Find(l.workspacePath()); err == nil {
-				l.configWatcher.Watch(configFile.Name())
-				rio.CloseIgnore(configFile)
+	for _, change := range slices.Compact(params.Changes) {
+		switch {
+		case change.URI == "":
+		case l.ignoreURI(change.URI):
+			if l.input.HasInputSuffix(change.URI) {
+				switch change.Type {
+				case 1, 2:
+					if err := l.input.Update(ctx, change.URI, nil); err != nil {
+						l.log.Message("failed to update input for %s: %s", change.URI, err)
+					}
+				case 3:
+					if err := l.input.Delete(ctx, change.URI); err != nil {
+						l.log.Message("failed to delete input entry for %s: %s", change.URI, err)
+					}
+				}
+			} else if change.Type == 1 && config.HasConfigSuffix(change.URI) {
+				// this handles the case of a new config file being created when one did not exist before
+				if configFile, err := config.Find(l.workspacePath()); err == nil {
+					l.configWatcher.Watch(configFile.Name())
+					rio.CloseIgnore(configFile)
+				}
+			}
+		case strings.HasSuffix(change.URI, ".rego"):
+			parseSuccess, err := updateParse(ctx, l.parseOpts(change.URI, l.builtinsForCurrentCapabilities()))
+			if err == nil {
+				if l.getClient().InitOptions.EnableServerTesting && parseSuccess {
+					l.testLocationJobs <- fileJob{URI: change.URI}
+				}
+
+				changes = true
+			} else {
+				l.log.Message("failed to update module for %s: %s", change.URI, err)
 			}
 		}
-
-		if change.URI == "" || l.ignoreURI(change.URI) {
-			continue
-		}
-
-		parseSuccess, err := updateParse(ctx, l.parseOpts(change.URI, l.builtinsForCurrentCapabilities()))
-		if err != nil {
-			l.log.Message("failed to update module for %s: %s", change.URI, err)
-
-			continue
-		}
-
-		if l.getClient().InitOptions.EnableServerTesting && parseSuccess {
-			l.testLocationJobs <- fileJob{URI: change.URI}
-		}
-
-		changes = true
 	}
 
 	if changes {
@@ -1730,26 +1740,12 @@ func (l *LanguageServer) handleInputSkeletonPrompt(
 		return false, nil
 	}
 
-	var action types.MessageActionItem
-
-	showMsgCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	msgCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	if err := l.conn.Call(showMsgCtx, "window/showMessageRequest", types.ShowMessageRequestParams{
-		Type: 3, // info
-		Message: "No input.json/yaml file was found. " +
-			"This file is used to provide input data for rule evaluation. " +
-			"Would you like to create one?",
-		Actions: []types.MessageActionItem{
-			{Title: "Yes"},
-			{Title: "No"},
-			{Title: "Ignore"},
-		},
-	}, &action); err != nil {
-		return false, fmt.Errorf("window/showMessageRequest failed: %w", err)
-	}
+	action := l.window.ShowMessageRequest(msgCtx, types.InfoMessage, noInputFoundMsg, "Yes", "No", "Ignore")
 
-	switch action.Title {
+	switch action {
 	case "Yes":
 		data, err := json.MarshalIndent(skeleton, "", "  ")
 		if err != nil {
@@ -1761,25 +1757,9 @@ func (l *LanguageServer) handleInputSkeletonPrompt(
 			return false, fmt.Errorf("failed to create input.json: %w", err)
 		}
 
-		var openAction types.MessageActionItem
-		if err = l.conn.Call(ctx, "window/showMessageRequest", types.ShowMessageRequestParams{
-			Type:    3,
-			Message: "input.json created successfully! Running Evaluate will now pull from this file.",
-			Actions: []types.MessageActionItem{{Title: "Open"}},
-		}, &openAction); err != nil {
-			return true, fmt.Errorf("window/showMessageRequest failed: %w", err)
-		}
-
-		if openAction.Title == "Open" {
-			takeFocus := false
-
-			var showResult types.ShowDocumentResult
-			if err = l.conn.Call(ctx, "window/showDocument", types.ShowDocumentParams{
-				URI:       uri.FromPath(l.getClient().Identifier, inputFile),
-				TakeFocus: &takeFocus,
-			}, &showResult); err != nil {
-				l.log.Message("window/showDocument failed: %v", err)
-			}
+		openAction := l.window.ShowMessageRequest(ctx, types.InfoMessage, inputCreateSuccessMsg, "Open")
+		if openAction == "Open" {
+			l.window.ShowDocument(ctx, uri.FromPath(l.getClient().Identifier, inputFile), false)
 		}
 
 		return true, nil

--- a/internal/lsp/server_command.go
+++ b/internal/lsp/server_command.go
@@ -136,7 +136,7 @@ func (l *LanguageServer) StartCommandWorker(ctx context.Context) {
 						"query":       args.Query,
 						"enablePrint": true,
 						"stopOnEntry": true,
-						"inputPath":   rio.FindInputPath(uri.ToPath(args.Target), l.workspacePath()),
+						"inputPath":   l.input.FindForPath(args.Target),
 					}
 
 					responseResult := map[string]any{}
@@ -160,18 +160,8 @@ func (l *LanguageServer) StartCommandWorker(ctx context.Context) {
 
 				if err != nil {
 					l.log.Message("command failed: %s", err)
-
-					if err := l.conn.Notify(ctx, "window/showMessage", types.ShowMessageParams{
-						Type:    1, // error
-						Message: err.Error(),
-					}); err != nil {
-						l.log.Message("failed to notify client of command error: %s", err)
-					}
-
-					break
-				}
-
-				if fixed {
+					l.window.ShowMessage(ctx, types.ErrorMessage, err.Error())
+				} else if fixed {
 					// Use a timeout context for RPC to ensure it completes during graceful shutdown
 					rpcCtx, rpcCancel := context.WithTimeout(context.Background(), rpcTimeout)
 
@@ -359,11 +349,7 @@ func (l *LanguageServer) handleIgnoreRuleCommand(_ context.Context, args types.C
 	// TODO: we need to trigger a config reload so that the server starts using
 	// the new config immediately. Currently, the server will pick up the config
 	// change through file system watchers only.
-	if err := os.WriteFile(configPath, []byte(newContent), 0o600); err != nil {
-		return fmt.Errorf("failed to write config file: %w", err)
-	}
-
-	return nil
+	return util.WrapErr(os.WriteFile(configPath, []byte(newContent), 0o600), "failed to write config file")
 }
 
 func (l *LanguageServer) handleExplorerCommand(ctx context.Context, params types.ExecuteCommandParams) error {
@@ -378,12 +364,10 @@ func (l *LanguageServer) handleExplorerCommand(ctx context.Context, params types
 	if len(params.Arguments) > 0 {
 		arg, ok := params.Arguments[0].(map[string]any)
 		if !ok {
-			l.log.Message(
+			return fmt.Errorf(
 				"failed to unmarshal regal.explorer command arguments, expected object, got %T",
 				params.Arguments[0],
 			)
-
-			return errors.New("failed to parse explorer arguments")
 		}
 
 		args = types.ExplorerCommandArgs{
@@ -396,9 +380,7 @@ func (l *LanguageServer) handleExplorerCommand(ctx context.Context, params types
 	}
 
 	if args.Target == "" {
-		l.log.Message("expected command target, got empty string")
-
-		return errors.New("target file URI is required")
+		return errors.New("explorer: target file URI is required")
 	}
 
 	contents, ok := l.cache.GetFileContents(args.Target)
@@ -441,9 +423,7 @@ func (l *LanguageServer) handleExplorerCommand(ctx context.Context, params types
 			stages = append(stages, stage)
 		}
 
-		responseParams := types.ExplorerResult{
-			Stages: stages,
-		}
+		responseParams := types.ExplorerResult{Stages: stages}
 
 		if !hasErrors {
 			if plan, err := explorer.Plan(ctx, path, contents, args.Print); err == nil {
@@ -507,21 +487,11 @@ func (l *LanguageServer) handleExplorerCommand(ctx context.Context, params types
 	}
 
 	for _, filename := range filesToOpen {
-		showParams := types.ShowDocumentParams{
-			URI:       uri.FromPath(l.getClient().Identifier, filename),
-			TakeFocus: new(false),
-		}
-
-		var result types.ShowDocumentResult
-
 		// Use a timeout context for RPC to ensure it completes during graceful shutdown
 		rpcCtx, rpcCancel := context.WithTimeout(context.Background(), rpcTimeout)
 
 		//nolint:contextcheck
-		if err := l.conn.Call(rpcCtx, "window/showDocument", showParams, &result); err != nil {
-			l.log.Message("window/showDocument failed for %s: %s", filename, err)
-		}
-
+		l.window.ShowDocument(rpcCtx, uri.FromPath(l.getClient().Identifier, filename), false)
 		rpcCancel()
 	}
 
@@ -531,21 +501,11 @@ func (l *LanguageServer) handleExplorerCommand(ctx context.Context, params types
 			if err := os.WriteFile(planFile, []byte(plan), 0o600); err != nil {
 				l.log.Message("failed to write plan file: %s", err)
 			} else {
-				showParams := types.ShowDocumentParams{
-					URI:       uri.FromPath(l.getClient().Identifier, planFile),
-					TakeFocus: new(false),
-				}
-
-				var result types.ShowDocumentResult
-
 				// Use a timeout context for RPC to ensure it completes during graceful shutdown
 				rpcCtx, rpcCancel := context.WithTimeout(context.Background(), rpcTimeout)
 
 				//nolint:contextcheck
-				if err := l.conn.Call(rpcCtx, "window/showDocument", showParams, &result); err != nil {
-					l.log.Message("window/showDocument failed for plan: %s", err)
-				}
-
+				l.window.ShowDocument(rpcCtx, uri.FromPath(l.getClient().Identifier, planFile), false)
 				rpcCancel()
 			}
 		}

--- a/internal/lsp/server_command_test.go
+++ b/internal/lsp/server_command_test.go
@@ -2,6 +2,7 @@ package lsp
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -227,19 +228,18 @@ func TestExecuteCommandEvalCreatesInputJSON(t *testing.T) {
 	clientHandler := func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (any, error) {
 		switch req.Method {
 		case "window/showMessageRequest":
-			params := must.Return(encoding.JSONUnmarshalTo[types.ShowMessageRequestParams](*req.Params))(t)
-
-			if strings.Contains(params.Message, "No input.json/yaml file was found.") {
+			message := encoding.JSON().Get(*req.Params, "message").ToString()
+			if strings.Contains(message, "No input.json/yaml file was found.") {
 				t.Log("create input.json prompt received, replied to")
 
-				return types.MessageActionItem{Title: "Yes"}, nil
-			} else if strings.Contains(params.Message, "created successfully") {
+				return new(json.RawMessage(`{"title":"Yes"}`)), nil
+			} else if strings.Contains(message, "created successfully") {
 				t.Log("input.json created successfully")
 
 				inputJSONCreated <- struct{}{}
 
 				// The success notification and prompt to open the file
-				return types.MessageActionItem{Title: "Open"}, nil
+				return new(json.RawMessage(`{"title":"Open"}`)), nil
 			}
 
 		case "window/showDocument":
@@ -247,7 +247,7 @@ func TestExecuteCommandEvalCreatesInputJSON(t *testing.T) {
 
 			t.Log("window/showDocument received")
 
-			return types.ShowDocumentResult{Success: true}, nil
+			return new(json.RawMessage(`{"success":true}`)), nil
 		}
 
 		return struct{}{}, nil
@@ -289,11 +289,7 @@ allow if {
 	case <-inputJSONCreated:
 		for {
 			if _, err := os.Stat(filepath.Join(tempDir, "input.json")); err == nil {
-				contents, err := os.ReadFile(filepath.Join(tempDir, "input.json"))
-				if err != nil {
-					t.Fatalf("failed to read input.json: %s", err)
-				}
-
+				contents := must.Return(os.ReadFile(filepath.Join(tempDir, "input.json")))(t)
 				must.Equal(t, `{
   "foo": {
     "bar": "changeme",

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -2,6 +2,7 @@ package lsp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -162,16 +163,18 @@ func createAndInitServerWithClientName(
 		rootURI = uri.FromPath(clientIdentifier, tempDir)
 	}
 
-	request := types.InitializeParams{
-		RootURI:    rootURI,
-		ClientInfo: types.ClientInfo{Name: clientName},
-		InitializationOptions: &types.InitializationOptions{
-			EnableDebugCodelens:       true,
-			EnableExplorer:            true,
-			EvalCodelensDisplayInline: true,
-			EnableServerTesting:       true,
+	request := new(json.RawMessage(fmt.Sprintf(`{
+		"rootUri": %q,
+		"clientInfo": {
+			"name": %q
 		},
-	}
+		"initializationOptions": {
+			"enableDebugCodelens": true,
+			"enableExplorer": true,
+			"evalCodelensDisplayInline": true,
+			"enableServerTesting": true
+		}
+	}`, rootURI, clientName)))
 
 	var response struct {
 		Capabilities any              `json:"capabilities"`

--- a/internal/lsp/store/store.go
+++ b/internal/lsp/store/store.go
@@ -33,6 +33,7 @@ func NewRegalStore() storage.Store {
 			// we'll need to conform to the most basic "JSON" format understood by the store
 			"defined_refs": map[string]any{},
 			"builtins":     map[string]any{},
+			"inputs":       map[string]any{},
 		},
 		"client": map[string]any{},
 		"server": map[string]any{},
@@ -82,11 +83,26 @@ func Put[T any](ctx context.Context, store storage.Store, path storage.Path, val
 	})
 }
 
-func write[T any](ctx context.Context, store storage.Store, txn storage.Transaction, path storage.Path, value T) error {
-	var stErr *storage.Error
+func Get(ctx context.Context, store storage.Store, path storage.Path) (val ast.Value, err error) {
+	var res any
+	if res, err = storage.ReadOne(ctx, store, path); err == nil {
+		if v, ok := res.(ast.Value); ok {
+			val = v
+		}
+	}
 
+	return val, err
+}
+
+func Remove(ctx context.Context, store storage.Store, path storage.Path) error {
+	return storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
+		return remove(ctx, store, txn, path)
+	})
+}
+
+func write[T any](ctx context.Context, store storage.Store, txn storage.Transaction, path storage.Path, value T) error {
 	err := store.Write(ctx, txn, storage.ReplaceOp, path, value)
-	if errors.As(err, &stErr) && stErr.Code == storage.NotFoundErr {
+	if stErr, ok := errors.AsType[*storage.Error](err); ok && stErr.Code == storage.NotFoundErr {
 		if err = store.Write(ctx, txn, storage.AddOp, path, value); err != nil {
 			return fmt.Errorf("failed to add value at path %s in store: %w", path, err)
 		}

--- a/internal/lsp/types/message.go
+++ b/internal/lsp/types/message.go
@@ -1,0 +1,16 @@
+package types
+
+import "strconv"
+
+const (
+	ErrorMessage Message = iota + 1
+	WarningMessage
+	InfoMessage
+	LogMessage
+)
+
+type Message uint8
+
+func (m Message) AppendText(buf []byte) []byte {
+	return strconv.AppendUint(buf, uint64(m), 10)
+}

--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"encoding/json"
-
 	"github.com/open-policy-agent/regal/internal/lsp/types/symbols"
 )
 
@@ -39,33 +37,6 @@ type (
 		EnableServerTesting bool `json:"enableServerTesting,omitempty"`
 	}
 
-	InitializeParams struct {
-		InitializationOptions *InitializationOptions `json:"initializationOptions,omitempty"`
-		ClientInfo            ClientInfo             `json:"clientInfo"`
-		Locale                string                 `json:"locale"`
-		RootPath              string                 `json:"rootPath"`
-		RootURI               string                 `json:"rootUri"`
-		Trace                 string                 `json:"trace"`
-		WorkspaceFolders      *[]WorkspaceFolder     `json:"workspaceFolders"`
-		Capabilities          *json.RawMessage       `json:"capabilities,omitempty"`
-		ProcessID             int                    `json:"processId"`
-	}
-
-	WorkspaceFolder struct {
-		URI  string `json:"uri"`
-		Name string `json:"name"`
-	}
-
-	ClientInfo struct {
-		Name    string `json:"name"`
-		Version string `json:"version"`
-	}
-
-	ShowMessageParams struct {
-		Message string `json:"message"`
-		Type    uint   `json:"type"`
-	}
-
 	ServerInfo struct {
 		Name    string `json:"name"`
 		Version string `json:"version"`
@@ -77,17 +48,6 @@ type (
 	}
 	DefinitionParams = TextDocumentPositionParams
 	HoverParams      = TextDocumentPositionParams
-
-	WorkspaceFoldersServerCapabilities struct {
-		Supported bool `json:"supported"`
-	}
-
-	Command struct {
-		Arguments *[]any `json:"arguments,omitempty"`
-		Title     string `json:"title"`
-		Tooltip   string `json:"tooltip"`
-		Command   string `json:"command"`
-	}
 
 	ExecuteCommandParams struct {
 		Command   string `json:"command"`
@@ -334,27 +294,6 @@ type (
 	ExplorerResult struct {
 		Stages []ExplorerStageResult `json:"stages"`
 		Plan   string                `json:"plan,omitempty"`
-	}
-
-	ShowDocumentParams struct {
-		URI       string `json:"uri"`
-		External  *bool  `json:"external,omitempty"`
-		TakeFocus *bool  `json:"takeFocus,omitempty"`
-		Selection *Range `json:"selection,omitempty"`
-	}
-
-	ShowDocumentResult struct {
-		Success bool `json:"success"`
-	}
-
-	MessageActionItem struct {
-		Title string `json:"title"`
-	}
-
-	ShowMessageRequestParams struct {
-		Type    uint                `json:"type"`
-		Message string              `json:"message"`
-		Actions []MessageActionItem `json:"actions"`
 	}
 
 	iuint interface{ ~int | ~uint }

--- a/internal/lsp/window/window.go
+++ b/internal/lsp/window/window.go
@@ -1,0 +1,95 @@
+package window
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+
+	"github.com/sourcegraph/jsonrpc2"
+
+	"github.com/open-policy-agent/regal/internal/lsp/log"
+	"github.com/open-policy-agent/regal/internal/lsp/types"
+)
+
+// Window provides convenience methods for sending window-related notifications and requests to the client.
+// Errors are logged using the provided logger but they are *not* returned, as there is typically nothing
+// meaningful the server can do with them other than to log them, and handling them clutter the call sites.
+type Window struct {
+	conn *jsonrpc2.Conn
+	log  *log.Logger
+}
+
+func New(conn *jsonrpc2.Conn, log *log.Logger) *Window {
+	return &Window{conn: conn, log: log}
+}
+
+// ShowMessage sends a message to be displayed in the user's editor.
+func (w *Window) ShowMessage(ctx context.Context, typ types.Message, msg string) {
+	if err := w.conn.Notify(ctx, "window/showMessage", rawMessageParams(typ, msg)); err != nil {
+		w.log.Message("window/showMessage notify failed: %s", err)
+	}
+}
+
+// ShowMessageRequest sends a message to be displayed in the user's editor, along with a set of actions
+// for them to choose from. The returned string is the title of the action selected.
+func (w *Window) ShowMessageRequest(ctx context.Context, typ types.Message, msg string, actions ...string) string {
+	var res struct {
+		Title string `json:"title"`
+	}
+	if err := w.conn.Call(ctx, "window/showMessageRequest", rawMessageParams(typ, msg, actions...), &res); err != nil {
+		w.log.Message("window/showMessageRequest call failed: %s", err)
+	}
+
+	return res.Title
+}
+
+// ShowDocument attempts to open the given URI in the user's editor.
+func (w *Window) ShowDocument(ctx context.Context, uri string, takeFocus bool) bool {
+	var res struct {
+		Success bool `json:"success"`
+	}
+
+	if err := w.conn.Call(ctx, "window/showDocument", rawShowDocumentParams(uri, takeFocus), &res); err != nil {
+		w.log.Message("window/showDocument failed: %s", err)
+	}
+
+	return res.Success
+}
+
+func rawShowDocumentParams(uri string, takeFocus bool) *json.RawMessage {
+	alloc := 10 + len(uri) // {"uri":""}
+	if takeFocus {
+		alloc += 17 // ,"takeFocus":true
+	}
+
+	buf := strconv.AppendQuote(append(make([]byte, 0, alloc), `{"uri":`...), uri)
+	if takeFocus {
+		buf = append(buf, `,"takeFocus":true`...)
+	}
+
+	return new(json.RawMessage(append(buf, '}')))
+}
+
+func rawMessageParams(typ types.Message, msg string, actions ...string) *json.RawMessage {
+	alloc := 23 + len(msg)
+	if len(actions) > 0 {
+		alloc += 12 // ,"actions":[], minus one comma
+		for _, action := range actions {
+			alloc += len(action) + 13 // ,{"title":""}
+		}
+	}
+
+	buf := typ.AppendText(append(make([]byte, 0, alloc), `{"type":`...))
+	buf = strconv.AppendQuote(append(buf, `,"message":`...), msg)
+
+	if len(actions) > 0 {
+		buf = append(strconv.AppendQuote(append(append(buf, `,"actions":[`...), `{"title":`...), actions[0]), '}')
+		for _, action := range actions[1:] {
+			buf = append(strconv.AppendQuote(append(buf, `,{"title":`...), action), '}')
+		}
+
+		buf = append(buf, ']')
+	}
+
+	return new(json.RawMessage(append(buf, '}')))
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -115,6 +115,10 @@ type (
 	}
 )
 
+func HasConfigSuffix(path string) bool {
+	return util.HasAnySuffix(path, standaloneConfigFileName, ".regal/config.yaml", ".regal\\config.yaml")
+}
+
 func (d *Default) mapToConfig(result any) error {
 	resultMap, ok := result.(map[string]any)
 	if !ok {


### PR DESCRIPTION
**Important:**
- State of input files in a workspace now kept track of, and updates to them get parsed and cached whenever one is saved. Previously each eval/debug command invoked would involve both finding all potential input filess in the workspace, as well as to parse them *every time*, even when nothing changed. The language serer now instead includes a manager responsible for doing this only when needed.
- Parsed input data is now placed in the store rather than provided as part of `input`, making it easily available to any other handlers that may have a use for it, like e.g. the completion handlers.
- The server configuration now tells clients that it wants to be notified about input.(json|yaml) file updates in addition to `.rego` files. This allows us to track these via updates from the clients without having a watcher process running on the server as well.

**Less important:**
- Moved `initialized` handler to Rego. It doesn't do much at the moment, and we still need some Go code to persist the initial state of the server. But
- The input_dot_json completion handler was made simpler
- New `window` package providing a nicer abstraction for the various `window/*` calls the server may send the client
- Remove more Go types we no longer need

**What's left:**
- The input file generator that @SeanLedford built should be integrated into the new input manager

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->