### PR TITLE
fixer: Apply linter fixes in deterministic order

### DIFF
--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -458,38 +458,34 @@ allow if { true }
 	}
 
 	td := testutil.TempDirectoryOf(t, initialState)
-	exp := fmt.Sprintf(`16 fixes applied:
+	exp := fmt.Sprintf(`12 fixes applied:
 In project root: %[1]s
 bar/main.rego -> wow/foo-bar/baz/main.rego:
 - directory-package-mismatch
 
 bar/main_test.rego -> wow/foo-bar/baz/main_test.rego:
 - directory-package-mismatch
-- constant-condition
 - opa-fmt
 
 foo/main.rego -> wow/main.rego:
 - directory-package-mismatch
-- constant-condition
-- no-whitespace-comment
 - opa-fmt
+- no-whitespace-comment
 
 foo/main_test.rego -> wow/main_test.rego:
 - directory-package-mismatch
-- constant-condition
 - opa-fmt
 
 
 In project root: %[2]s
 main.rego:
-- use-rego-v1
+- opa-fmt
 - no-whitespace-comment
 
 In project root: %[3]s
 main.rego:
-- constant-condition
-- no-whitespace-comment
 - opa-fmt
+- no-whitespace-comment
 `, td, filepath.Join(td, "v0"), filepath.Join(td, "v1"))
 
 	expectedState := map[string]string{
@@ -505,17 +501,17 @@ allow if {
 `,
 		filepath.FromSlash("wow/foo-bar/baz/main_test.rego"): `package wow["foo-bar"].baz_test
 
-test_allow if {}
+test_allow := true
 `,
 		"wow/main.rego": `package wow
 
 # comment
 
-allow if {}
+allow := true
 `,
 		"wow/main_test.rego": `package wow_test
 
-test_allow if {}
+test_allow := true
 `,
 		"v0/main.rego": `package v0
 
@@ -527,7 +523,7 @@ allow if input == 1
 		"v1/main.rego": `package v1
 
 # comment
-allow if {}
+allow := true
 `,
 		"unrelated.txt": `foobar`,
 	}

--- a/pkg/fixer/fixer.go
+++ b/pkg/fixer/fixer.go
@@ -26,7 +26,7 @@ const (
 
 // Fixer must be instantiated via NewFixer.
 type Fixer struct {
-	registeredFixes     map[string]fixes.Fix
+	registeredFixes     []fixes.Fix
 	onConflictOperation OnConflictOperation
 	registeredRoots     []string
 	versionsMap         map[string]ast.RegoVersion
@@ -35,7 +35,7 @@ type Fixer struct {
 // NewFixer instantiates a Fixer.
 func NewFixer() *Fixer {
 	return &Fixer{
-		registeredFixes:     make(map[string]fixes.Fix),
+		registeredFixes:     make([]fixes.Fix, 0),
 		registeredRoots:     make([]string, 0),
 		onConflictOperation: OnConflictError,
 	}
@@ -59,9 +59,7 @@ func (f *Fixer) SetRegoVersionsMap(versionsMap map[string]ast.RegoVersion) *Fixe
 // RegisterFixes sets the fixes that will be fixed if there are related linter
 // violations that can be fixed by fixes.
 func (f *Fixer) RegisterFixes(fixes ...fixes.Fix) *Fixer {
-	for _, fix := range fixes {
-		f.registeredFixes[fix.Name()] = fix
-	}
+	f.registeredFixes = append(f.registeredFixes, fixes...)
 
 	return f
 }
@@ -78,8 +76,10 @@ func (f *Fixer) RegisterRoots(roots ...string) *Fixer {
 }
 
 func (f *Fixer) GetFixForName(name string) (fixes.Fix, bool) {
-	if fix, ok := f.registeredFixes[name]; ok {
-		return fix, true
+	for _, fix := range f.registeredFixes {
+		if fix.Name() == name {
+			return fix, true
+		}
 	}
 
 	return nil, false
@@ -197,8 +197,6 @@ func (f *Fixer) applyLinterFixes(
 	}
 
 	for {
-		fixMadeInIteration := false
-
 		in, err := fp.ToInput(versionsMap)
 		if err != nil {
 			return fmt.Errorf("failed to create linter input: %w", err)
@@ -213,38 +211,56 @@ func (f *Fixer) applyLinterFixes(
 			break
 		}
 
-		for i := range rep.Violations {
-			fixInstance, ok := f.GetFixForName(rep.Violations[i].Title)
-			if !ok {
-				return fmt.Errorf("no fix for violation %s", rep.Violations[i].Title)
+		fixMade, err := f.applyOneFix(l, fp, fixReport, rep.Violations, startingFiles)
+		if err != nil {
+			return err
+		}
+
+		if !fixMade {
+			break
+		}
+	}
+
+	return nil
+}
+
+func (f *Fixer) applyOneFix(
+	l *linter.Linter,
+	fp fileprovider.FileProvider,
+	fixReport *Report,
+	violations []report.Violation,
+	startingFiles []string,
+) (bool, error) {
+	for _, fixInstance := range f.registeredFixes {
+		for i := range violations {
+			if violations[i].Title != fixInstance.Name() {
+				continue
 			}
 
 			config, err := l.GetConfig()
 			if err != nil {
-				return fmt.Errorf("failed to get config: %w", err)
+				return false, fmt.Errorf("failed to get config: %w", err)
 			}
 
-			file := rep.Violations[i].Location.File
+			file := violations[i].Location.File
 
 			abs, err := filepath.Abs(file)
 			if err != nil {
-				return fmt.Errorf("failed to get absolute path for %s: %w", file, err)
+				return false, fmt.Errorf("failed to get absolute path for %s: %w", file, err)
 			}
 
 			fc, err := fp.Get(file)
 			if err != nil {
-				return fmt.Errorf("failed to get file %s: %w", file, err)
+				return false, fmt.Errorf("failed to get file %s: %w", file, err)
 			}
 
-			fixCandidate := fixes.FixCandidate{Filename: file, Contents: fc}
-
-			fixResults, err := fixInstance.Fix(&fixCandidate, &fixes.RuntimeOptions{
+			fixResults, err := fixInstance.Fix(&fixes.FixCandidate{Filename: file, Contents: fc}, &fixes.RuntimeOptions{
 				BaseDir:   util.FindClosestMatchingRoot(abs, f.registeredRoots),
 				Config:    config,
-				Locations: []report.Location{rep.Violations[i].Location},
+				Locations: []report.Location{violations[i].Location},
 			})
 			if err != nil {
-				return fmt.Errorf("failed to fix %s: %w", file, err)
+				return false, fmt.Errorf("failed to fix %s: %w", file, err)
 			}
 
 			if len(fixResults) == 0 {
@@ -255,30 +271,23 @@ func (f *Fixer) applyLinterFixes(
 
 			if fixResult.Rename != nil {
 				if err := f.handleRename(fp, fixReport, startingFiles, fixResult); err != nil {
-					return err
+					return false, err
 				}
 
-				fixMadeInIteration = true
-
-				break // Restart the loop after handling a rename
+				return true, nil
 			}
 
-			// Write the fixed content to the file
 			if err := fp.Put(file, fixResult.Contents); err != nil {
-				return fmt.Errorf("failed to write fixed content to file %s: %w", file, err)
+				return false, fmt.Errorf("failed to write fixed content to file %s: %w", file, err)
 			}
 
 			fixReport.AddFileFix(file, fixResult)
 
-			fixMadeInIteration = true
-		}
-
-		if !fixMadeInIteration {
-			break
+			return true, nil
 		}
 	}
 
-	return nil
+	return false, nil
 }
 
 // handleRename processes the rename operation and resolves conflicts if necessary.

--- a/pkg/fixer/fixer_test.go
+++ b/pkg/fixer/fixer_test.go
@@ -52,18 +52,16 @@ deny = true
 	}
 
 	expectedFileFixedViolations := map[string][]string{
-		// use-assigment-operator is correct in formatting so does not appear.
 		filepath.Join(rootPath, "test", "main.rego"): {
 			"directory-package-mismatch",
 			"no-whitespace-comment",
 			"opa-fmt",
-			"constant-condition",
 		},
 	}
 	expectedFileContents := map[string]string{
 		filepath.Join(rootPath, "test", "main.rego"): `package test
 
-allow if {}
+allow := true
 
 # no space
 
@@ -71,7 +69,7 @@ deny := true
 `,
 	}
 
-	if got, exp := fixReport.TotalFixes(), uint(4); got != exp {
+	if got, exp := fixReport.TotalFixes(), uint(3); got != exp {
 		t.Fatalf("expected a total of %d fixes, got %d", exp, got)
 	}
 
@@ -199,6 +197,48 @@ func TestFixViolations(t *testing.T) {
 		if !slices.Equal(expectedFixes, fixes) {
 			t.Fatalf("unexpected fixes for %s:\ngot: %v\nexpected: %v", file, fixes, expectedFixes)
 		}
+	}
+}
+
+// TestFixerWhereFixAltersFileLength tests fix ordering doesn't panic when a prior fix alters line count.
+// https://github.com/open-policy-agent/regal/issues/1996
+func TestFixerWhereFixAltersFileLength(t *testing.T) {
+	t.Parallel()
+
+	rootPath := must.Return(filepath.Abs(filepath.FromSlash("/root")))(t)
+	mainDir := filepath.Join(rootPath, "main")
+	mainRegoFile := filepath.Join(mainDir, "main.rego")
+
+	policies := map[string]string{
+		mainRegoFile: "package test\n\n\n\ndeny = true\n",
+	}
+
+	memfp := fileprovider.NewInMemoryFileProvider(policies)
+
+	input, err := memfp.ToInput(map[string]ast.RegoVersion{mainDir: ast.RegoV1})
+	if err != nil {
+		t.Fatalf("failed to create input: %v", err)
+	}
+
+	l := linter.NewLinter().WithEnableAll(true).WithInputModules(&input)
+
+	f := NewFixer().
+		RegisterFixes(&fixes.Fmt{}, &fixes.UseAssignmentOperator{}).
+		RegisterRoots(rootPath).
+		SetRegoVersionsMap(map[string]ast.RegoVersion{mainDir: ast.RegoV1})
+
+	if _, err = f.Fix(t.Context(), &l, memfp); err != nil {
+		t.Fatalf("failed to fix: %v", err)
+	}
+
+	content, err := memfp.Get(mainRegoFile)
+	if err != nil {
+		t.Fatalf("failed to get file: %v", err)
+	}
+
+	expected := "package test\n\ndeny := true\n"
+	if content != expected {
+		t.Fatalf("unexpected content:\ngot:\n%s---\nexpected:\n%s---", content, expected)
 	}
 }
 

--- a/pkg/fixer/fixes/useassignmentoperator.go
+++ b/pkg/fixer/fixes/useassignmentoperator.go
@@ -20,8 +20,12 @@ func (u *UseAssignmentOperator) Fix(fc *FixCandidate, opts *RuntimeOptions) ([]F
 	fixed := false
 
 	for _, loc := range opts.Locations {
+		if loc.Row < 1 || loc.Row > len(lines) {
+			continue
+		}
+
 		line := lines[loc.Row-1]
-		if loc.Row > len(lines) || loc.Column-1 < 0 || loc.Column-1 >= len(line) {
+		if loc.Column-1 < 0 || loc.Column-1 >= len(line) {
 			continue
 		}
 

--- a/pkg/fixer/fixes/useassignmentoperator_test.go
+++ b/pkg/fixer/fixes/useassignmentoperator_test.go
@@ -39,6 +39,14 @@ func TestUseAssignmentOperator(t *testing.T) {
 			fixExpected:     false,
 			runtimeOptions:  &RuntimeOptions{Locations: []report.Location{{Row: 1, Column: 1}}},
 		},
+		"row beyond file length": {
+			// row number from a violation may exceed the file length if another fix has already
+			// rewritten the file; the fix should skip rather than panic
+			fc:              &FixCandidate{Filename: "test.rego", Contents: "package test\n\nallow = true\n"},
+			contentAfterFix: "package test\n\nallow = true\n",
+			fixExpected:     false,
+			runtimeOptions:  &RuntimeOptions{Locations: []report.Location{{Row: 99, Column: 7}}},
+		},
 		"many changes": {
 			fc: &FixCandidate{
 				Filename: "test.rego",


### PR DESCRIPTION
Change registeredFixes from map to slice to preserve fix registration order. Fixes must run in a predictable sequence because to test bugs relating to their interations.

Resolves panic when opa-fmt runs first and reduces line count, causing use-assignment-operator to access out-of-bounds row numbers.

Fixes https://github.com/open-policy-agent/regal/issues/1996
