### PR TITLE
OPA v1.16.2

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,1 +1,0 @@
-comment: false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,25 +105,3 @@ jobs:
       - run: |
           go run .
         working-directory: e2e/testbuild
-
-  code_coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-      - uses: open-policy-agent/setup-opa@b2b258e089860efaadaaf71bf6e3aecb4a3eeff1 # v2.4.0
-        with:
-          version: edge
-          static: true
-      - run: |
-          go run main.go test --coverage bundle \
-          | opa eval -f raw -I -d build/simplecov/simplecov.rego data.build.simplecov.from_opa \
-          > coverage.json
-      - uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          fail_ci_if_error: false
-          files: ./coverage.json
-          name: regal
-          token: ${{ secrets.CODECOV_TOKEN }} # required

--- a/README.md
+++ b/README.md
@@ -4,14 +4,11 @@
 
 # Regal
 
-
 <!-- markdownlint-disable MD041 -->
 
 [![Build Status](https://github.com/open-policy-agent/regal/workflows/Build/badge.svg)](https://github.com/open-policy-agent/regal/actions)
-![OPA v1.16.1](https://www.openpolicyagent.org/badge/v1.16.1)
-[![codecov](https://codecov.io/github/open-policy-agent/regal/graph/badge.svg?token=EQK01YF3X3)](https://codecov.io/github/StyraInc/regal)
+![OPA v1.16.2](https://www.openpolicyagent.org/badge/v1.16.2)
 [![Downloads](https://img.shields.io/github/downloads/open-policy-agent/regal/total.svg)](https://github.com/open-policy-agent/regal/releases)
-
 
 <!-- markdownlint-disable MD041 -->
 
@@ -20,7 +17,6 @@ making your Rego magnificent, and you the ruler of rules!
 
 With its extensive set of linter rules, documentation and editor integrations, Regal is the perfect companion for policy
 development, whether you're an experienced Rego developer or just starting out.
-
 
 <!-- markdownlint-disable MD033 -->
 <!-- markdownlint-disable MD041 -->
@@ -36,7 +32,6 @@ development, whether you're an experienced Rego developer or just starting out.
 
 \- [Merriam Webster](https://www.merriam-webster.com/dictionary/regal)
 
-
 <!-- markdownlint-disable MD041 -->
 
 ## Goals
@@ -45,7 +40,6 @@ development, whether you're an experienced Rego developer or just starting out.
 - Identify common mistakes, bugs and inefficiencies in Rego policies, and suggest better approaches
 - Provide advice on [best practices](https://www.openpolicyagent.org/docs/style-guide), coding style, and tooling
 - Allow users, teams and organizations to enforce custom rules on their policy code
-
 
 <!-- markdownlint-disable MD041 -->
 
@@ -69,7 +63,6 @@ development, whether you're an experienced Rego developer or just starting out.
 — Jimmy Ray, [Boeing](https://www.boeing.com/)
 
 See the [adopters](https://www.openpolicyagent.org/projects/regal/adopters) file for more Regal users.
-
 
 <!-- markdownlint-disable MD041 -->
 
@@ -127,7 +120,6 @@ page, and published Docker images at the [packages](https://github.com/open-poli
 page.
 
 </details>
-
 
 <!-- markdownlint-disable MD041 -->
 
@@ -215,7 +207,6 @@ we've made it easy to run Regal as part of your builds.
 See the docs on [Using Regal in your build pipeline](https://www.openpolicyagent.org/projects/regal/cicd) to learn more
 about how to set up Regal to lint your policies on every commit or pull request.
 
-
 <!-- markdownlint-disable MD041 -->
 
 ## Next Steps
@@ -241,7 +232,6 @@ Regal.
 - [CI/CD](https://www.openpolicyagent.org/projects/regal/cicd): Run Regal as part of your automated checks.
 - [Custom Rules](https://www.openpolicyagent.org/projects/regal/custom-rules): Learn how to write your own rules for Regal.
 - [Adopters](https://www.openpolicyagent.org/projects/regal/adopters): See who else is using Regal.
-
 
 <!-- If updating, please check resources-website.md too -->
 <!-- markdownlint-disable MD041 -->
@@ -274,14 +264,12 @@ contains information about how to hack on Regal itself.
 - [Regal を使って Rego を Lint する](https://tech.dentsusoken.com/entry/2024/12/05/Regal_%E3%82%92%E4%BD%BF%E3%81%A3%E3%81%A6_Rego_%E3%82%92_Lint_%E3%81%99%E3%82%8B)
   by Shibata Takao ([@shibata.takao](https://shodo.ink/@shibata.takao/))
 
-
 <!-- markdownlint-disable MD041 -->
 
 ## Status
 
 Regal is currently in beta. End-users should not expect any drastic changes, but any API may change without notice.
 If you want to embed Regal in another project or product, please reach out!
-
 
 <!-- markdownlint-disable MD041 -->
 
@@ -299,5 +287,3 @@ The current Roadmap items are all related to the preparation for
 - [ ] [lsp: Support a JetBrains LSP client (#1560)](https://github.com/open-policy-agent/regal/issues/1560)
 
 If there's something you'd like to have added to the roadmap, either open an issue, or reach out in the community Slack!
-
-

--- a/build/do.rq
+++ b/build/do.rq
@@ -25,8 +25,6 @@
 #     ref: https://git.sr.ht/~charles/rq
 package script
 
-import future.keywords
-
 # Path to Regal's project root. (./build/do.rq/../.. => ./)
 regal_root := rq.abs(rq.dir(rq.dir(rq.scriptpath())))
 
@@ -368,7 +366,7 @@ fetch_rq_caps if {
 		r := rq.template("https://git.sr.ht/~charles/rq/blob/{{.tag}}/capabilities.json", {"tag": t})
 	}
 
-print("fetching", count(missing_locally), "capabilities files missing locally")
+	print("fetching", count(missing_locally), "capabilities files missing locally")
 
 	new_caps := {
 	{"local": m.local, "content": c} |

--- a/docs/readme-sections/badges.md
+++ b/docs/readme-sections/badges.md
@@ -1,6 +1,5 @@
 <!-- markdownlint-disable MD041 -->
 
 [![Build Status](https://github.com/open-policy-agent/regal/workflows/Build/badge.svg)](https://github.com/open-policy-agent/regal/actions)
-![OPA v1.16.1](https://www.openpolicyagent.org/badge/v1.16.1)
-[![codecov](https://codecov.io/github/open-policy-agent/regal/graph/badge.svg?token=EQK01YF3X3)](https://codecov.io/github/StyraInc/regal)
+![OPA v1.16.2](https://www.openpolicyagent.org/badge/v1.16.2)
 [![Downloads](https://img.shields.io/github/downloads/open-policy-agent/regal/total.svg)](https://github.com/open-policy-agent/regal/releases)

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/jstemmer/go-junit-report/v2 v2.1.0
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/open-policy-agent/opa v1.16.1-0.20260506204008-1a4a71300669
+	github.com/open-policy-agent/opa v1.16.2
 	github.com/owenrumney/go-sarif/v2 v2.3.3
 	github.com/pdevine/go-asciisprite v0.1.6
 	github.com/pkg/profile v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
-github.com/open-policy-agent/opa v1.16.1-0.20260506204008-1a4a71300669 h1:A/F9EY1FQlZcC94Os/28Y05Sd6dPDPE+ulKzfh4qqDg=
-github.com/open-policy-agent/opa v1.16.1-0.20260506204008-1a4a71300669/go.mod h1:21uy+TcBM9muN9DvE9B6lcnovwTIBcE2Y9DRscar/uM=
+github.com/open-policy-agent/opa v1.16.2 h1:5gzbXeioG9TCguGOI9EKigeBP/1ZoD8VH/ca50ihGxI=
+github.com/open-policy-agent/opa v1.16.2/go.mod h1:21uy+TcBM9muN9DvE9B6lcnovwTIBcE2Y9DRscar/uM=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
 github.com/owenrumney/go-sarif/v2 v2.3.3 h1:ubWDJcF5i3L/EIOER+ZyQ03IfplbSU1BLOE26uKQIIU=

--- a/internal/lsp/rego/router.go
+++ b/internal/lsp/rego/router.go
@@ -30,7 +30,6 @@ var (
 			input:  ast.NewObjectWithCapacity(3),
 			params: ast.NewTerm(ast.NullValue),
 			regctx: ast.NewTerm(ast.NullValue),
-			buf:    new(bytes.Buffer),
 		}
 	}}
 	fileLines = Requirements{File: FileRequirements{Lines: true}}
@@ -40,7 +39,6 @@ type inputCacheItem struct {
 	input  ast.Value
 	params *ast.Term
 	regctx *ast.Term
-	buf    *bytes.Buffer
 }
 
 func init() {
@@ -313,13 +311,13 @@ func passthrough(ctx context.Context, rctx *RegalContext, req *jsonrpc2.Request)
 	if obj, ok := res.(ast.Object); ok {
 		rsp := obj.Get(ast.InternedTerm("response")).Value
 
-		cached.buf.Reset()
+		var buf bytes.Buffer
 
-		if err := encoding.OfValue().Encode(cached.buf, rsp); err != nil {
+		if err := encoding.OfValue().Encode(&buf, rsp); err != nil {
 			return nil, fmt.Errorf("failed to marshal response: %w", err)
 		}
 
-		raw := json.RawMessage(cached.buf.Bytes())
+		raw := json.RawMessage(buf.Bytes())
 
 		return &raw, nil
 	}


### PR DESCRIPTION
Also:
- Remove Codecov from CI as we haven't used it for a year or so and the less things we depend on the better
- Fix in Rego router to avoid potential reuse of a byte buffer that is still used elsewhere. Thanks @charlieegan3 for catching that!

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->