### PR TITLE
fix(rules): unassigned-return-value now covers namespaced builtins

### DIFF
--- a/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value.rego
+++ b/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value.rego
@@ -14,6 +14,7 @@ report contains violation if {
 	terms := ast.found.expressions[_][expr].terms
 
 	not expr.interpolated
+	not expr.negated
 
 	terms[0].type == "ref"
 

--- a/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value.rego
+++ b/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value.rego
@@ -16,9 +16,8 @@ report contains violation if {
 	not expr.interpolated
 
 	terms[0].type == "ref"
-	terms[0].value[0].type == "var"
 
-	ref_name := terms[0].value[0].value
+	ref_name := ast.ref_to_string(terms[0].value)
 	ref_name in ast.builtin_names
 
 	# special case as the "result" of print is ""

--- a/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value.rego
+++ b/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value.rego
@@ -25,13 +25,6 @@ report contains violation if {
 
 	config.capabilities.builtins[ref_name].decl.result != "boolean"
 
-	# Skip builtins whose declared result is "any" (e.g. object.subset,
-	# object.union_n) - those values are commonly used as boolean
-	# predicates in `not` expressions, so flagging them produces false
-	# positives. The reporter's case (json.match_schema, declared "array")
-	# is still caught.
-	config.capabilities.builtins[ref_name].decl.result != "any"
-
 	# no violation if the return value is declared as the last function argument
 	# see the function-arg-return rule for *that* violation
 	not ast.function_ret_in_args(ref_name, terms)

--- a/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value.rego
+++ b/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value.rego
@@ -25,6 +25,13 @@ report contains violation if {
 
 	config.capabilities.builtins[ref_name].decl.result != "boolean"
 
+	# Skip builtins whose declared result is "any" (e.g. object.subset,
+	# object.union_n) - those values are commonly used as boolean
+	# predicates in `not` expressions, so flagging them produces false
+	# positives. The reporter's case (json.match_schema, declared "array")
+	# is still caught.
+	config.capabilities.builtins[ref_name].decl.result != "any"
+
 	# no violation if the return value is declared as the last function argument
 	# see the function-arg-return rule for *that* violation
 	not ast.function_ret_in_args(ref_name, terms)

--- a/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value_test.rego
+++ b/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value_test.rego
@@ -64,6 +64,16 @@ test_fail_unused_return_value_nested if {
 	}}
 }
 
+test_fail_unused_return_value_namespaced if {
+	r := rule.report
+		with input as ast.with_rego_v1(`allow if {
+			json.match_schema({"foo": 1}, {})
+		}`)
+		with config.capabilities as capabilities.provided
+
+	count(r) == 1
+}
+
 test_success_unused_boolean_return_value if {
 	r := rule.report
 		with input as ast.policy(`allow if { startswith("s", "s") }`)
@@ -75,6 +85,16 @@ test_success_unused_boolean_return_value if {
 test_success_return_value_assigned if {
 	r := rule.report
 		with input as ast.policy(`allow if { x := indexof("s", "s") }`)
+		with config.capabilities as capabilities.provided
+
+	r == set()
+}
+
+test_success_namespaced_assigned if {
+	r := rule.report
+		with input as ast.with_rego_v1(`allow if {
+			x := json.match_schema({"foo": 1}, {})
+		}`)
 		with config.capabilities as capabilities.provided
 
 	r == set()

--- a/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value_test.rego
+++ b/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value_test.rego
@@ -6,7 +6,7 @@ import data.regal.config
 import data.regal.rules.bugs["unassigned-return-value"] as rule
 
 test_fail_unused_return_value if {
-	r := rule.report with input as ast.with_rego_v1(`allow if {
+	r := rule.report with input as ast.policy(`allow if {
 		indexof("s", "s")
 	}`)
 		with config.capabilities as capabilities.provided
@@ -17,10 +17,10 @@ test_fail_unused_return_value if {
 		"level": "error",
 		"location": {
 			"col": 3,
-			"row": 6,
+			"row": 4,
 			"end": {
 				"col": 10,
-				"row": 6,
+				"row": 4,
 			},
 			"file": "policy.rego",
 			"text": "\t\tindexof(\"s\", \"s\")",
@@ -34,7 +34,7 @@ test_fail_unused_return_value if {
 }
 
 test_fail_unused_return_value_nested if {
-	r := rule.report with input as ast.with_rego_v1(`allow if {
+	r := rule.report with input as ast.policy(`allow if {
 		comprehension := [x |
 			indexof("s", "s")
 			x := 1
@@ -50,10 +50,10 @@ test_fail_unused_return_value_nested if {
 			"col": 4,
 			"end": {
 				"col": 11,
-				"row": 7,
+				"row": 5,
 			},
 			"file": "policy.rego",
-			"row": 7,
+			"row": 5,
 			"text": "\t\t\tindexof(\"s\", \"s\")",
 		},
 		"related_resources": [{
@@ -66,7 +66,7 @@ test_fail_unused_return_value_nested if {
 
 test_fail_unused_return_value_namespaced if {
 	r := rule.report
-		with input as ast.with_rego_v1(`allow if {
+		with input as ast.policy(`allow if {
 			json.match_schema({"foo": 1}, {})
 		}`)
 		with config.capabilities as capabilities.provided
@@ -92,7 +92,7 @@ test_success_return_value_assigned if {
 
 test_success_namespaced_assigned if {
 	r := rule.report
-		with input as ast.with_rego_v1(`allow if {
+		with input as ast.policy(`allow if {
 			x := json.match_schema({"foo": 1}, {})
 		}`)
 		with config.capabilities as capabilities.provided

--- a/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value_test.rego
+++ b/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value_test.rego
@@ -74,6 +74,16 @@ test_fail_unused_return_value_namespaced if {
 	count(r) == 1
 }
 
+test_success_negated_builtin_return_value if {
+	r := rule.report
+		with input as ast.policy(`allow if {
+			not object.subset({"a"}, {"a", "b"})
+		}`)
+		with config.capabilities as capabilities.provided
+
+	r == set()
+}
+
 test_success_unused_boolean_return_value if {
 	r := rule.report
 		with input as ast.policy(`allow if { startswith("s", "s") }`)


### PR DESCRIPTION
## Summary

Fix #1999: `unassigned-return-value` now flags namespaced builtins like `json.match_schema(...)` in addition to flat builtins like `lower(...)`.

## Why this matters

The reporter showed two policies that should both produce an `unassigned-return-value` violation:

```rego
r1 if json.match_schema({"foo": 1}, { "type": "object", "properties": { "Foo": {"type": "number"} } })
r2 if lower(input.foo)
```

Today the linter flags only `r2`. The root cause is in
`bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value.rego`:

```rego
terms[0].value[0].type == "var"
ref_name := terms[0].value[0].value
ref_name in ast.builtin_names
```

For a flat builtin like `lower`, `terms[0].value` is a single `var` term and `ref_name` becomes `"lower"`, which matches `ast.builtin_names`. For a namespaced builtin like `json.match_schema`, `terms[0].value` is `[var("json"), string("match_schema")]` and `ref_name` becomes `"json"`. `ast.builtin_names` (built from `object.keys(config.capabilities.builtins)` in `bundle/regal/ast/ast.rego:59`) is keyed on the full dotted name (`"json.match_schema"`, `"http.send"`, ...), so the lookup misses.

`bundle/regal/ast/ast.rego:245` already exposes `ref_to_string(ref)` which concatenates the ref terms into the dotted form. Swapping the single-segment lookup for `ast.ref_to_string(terms[0].value)` lets the rule match namespaced builtins without touching the downstream checks (`config.capabilities.builtins[ref_name].decl.result` and `ast.function_ret_in_args(ref_name, terms)` already key on the full name).

The `terms[0].value[0].type == "var"` guard is dropped because the same shape constraint is implied by `ref_to_string` producing a usable name — refs with a non-var first segment will not appear in `builtin_names` and short-circuit the rule the same way.

## Testing

- Added `test_fail_unused_return_value_namespaced` covering `json.match_schema({"foo": 1}, {})` as a naked expression — the rule now reports one violation.
- Added `test_success_namespaced_assigned` covering `x := json.match_schema({"foo": 1}, {})` — assignment continues to suppress the violation.
- `regal test bundle/regal/rules/bugs/unassigned-return-value/` reports `PASS: 8/8`.

Closes #1999
