### PR TITLE
Use logger in Rego router

### DIFF
--- a/internal/lsp/config/watcher_test.go
+++ b/internal/lsp/config/watcher_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/open-policy-agent/regal/internal/lsp/log"
+	"github.com/open-policy-agent/regal/internal/lsp/test"
 	"github.com/open-policy-agent/regal/internal/test/must"
 	"github.com/open-policy-agent/regal/internal/testutil"
 )
@@ -17,7 +17,7 @@ func TestWatcher(t *testing.T) {
 	t.Parallel()
 
 	tempDir := testutil.TempDirectoryOf(t, map[string]string{"config.yaml": "---\nfoo: bar\n"})
-	watcher := NewWatcher(&WatcherOpts{Logger: log.NewLogger(log.LevelDebug, t.Output())})
+	watcher := NewWatcher(&WatcherOpts{Logger: test.DebugLogger(t)})
 	configFilePath := filepath.Join(tempDir, "config.yaml")
 
 	ctx, cancel := context.WithCancel(t.Context())

--- a/internal/lsp/eval_test.go
+++ b/internal/lsp/eval_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/ast"
 
 	"github.com/open-policy-agent/regal/internal/lsp/client"
-	"github.com/open-policy-agent/regal/internal/lsp/log"
+	"github.com/open-policy-agent/regal/internal/lsp/test"
 	"github.com/open-policy-agent/regal/internal/lsp/workspace"
 	rparse "github.com/open-policy-agent/regal/internal/parse"
 	"github.com/open-policy-agent/regal/internal/test/assert"
@@ -22,7 +22,7 @@ func TestEvalWorkspacePath(t *testing.T) {
 
 	workspace := workspace.New("file:///workspace").WithClient(client.NewGeneric())
 
-	ls := NewLanguageServer(t.Context(), &LanguageServerOptions{Logger: log.NewLogger(log.LevelDebug, t.Output())})
+	ls := NewLanguageServer(t.Context(), &LanguageServerOptions{Logger: test.DebugLogger(t)})
 	ls.workspace = workspace
 
 	policy1 := `package policy1
@@ -67,7 +67,7 @@ func TestEvalWorkspacePath(t *testing.T) {
 func TestEvalWorkspacePathInternalData(t *testing.T) {
 	t.Parallel()
 
-	ls := NewLanguageServer(t.Context(), &LanguageServerOptions{Logger: log.NewLogger(log.LevelDebug, t.Output())})
+	ls := NewLanguageServer(t.Context(), &LanguageServerOptions{Logger: test.DebugLogger(t)})
 
 	res := must.Return(ls.EvalInWorkspace(t.Context(), "object.keys(data.internal)", ast.InternedEmptyObjectValue))(t)
 	val := must.Be[[]any](t, res.Value)

--- a/internal/lsp/input/input.go
+++ b/internal/lsp/input/input.go
@@ -67,7 +67,7 @@ func (m *Manager) LoadFromWorkspace(ctx context.Context, workspace workspace.Wor
 	err := files.DefaultWalker(".").
 		WithFilters(filter.Not(filter.Suffixes("input.json", "input.yaml"))).
 		WalkFS(workspace.FS(), func(path string) error {
-			m.log.Message("using input file: %s", path)
+			m.log.Debug("using input file: %s", path)
 
 			return m.Update(ctx, path, nil)
 		})

--- a/internal/lsp/input/input_test.go
+++ b/internal/lsp/input/input_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
 
 	"github.com/open-policy-agent/regal/internal/lsp/input"
-	"github.com/open-policy-agent/regal/internal/lsp/log"
+	"github.com/open-policy-agent/regal/internal/lsp/test"
 	"github.com/open-policy-agent/regal/internal/lsp/workspace"
 )
 
@@ -15,7 +15,7 @@ func TestFindForPath(t *testing.T) {
 	t.Parallel()
 
 	st := inmem.NewFromObject(map[string]any{"workspace": map[string]any{"inputs": map[string]any{}}})
-	im := input.NewManager(st, log.NewLogger(log.LevelDebug, t.Output()))
+	im := input.NewManager(st, test.DebugLogger(t))
 
 	inputJSON, inputYAML := []byte(`{"foo": "bar"}`), []byte(`foo: bar`)
 

--- a/internal/lsp/rego/router.go
+++ b/internal/lsp/rego/router.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/storage"
 
 	"github.com/open-policy-agent/regal/internal/lsp/client"
+	"github.com/open-policy-agent/regal/internal/lsp/log"
 	"github.com/open-policy-agent/regal/internal/lsp/rego/query"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	ruri "github.com/open-policy-agent/regal/internal/lsp/uri"
@@ -73,10 +75,11 @@ type (
 		InputPathProvider            func(path string) string
 	}
 
-	RegoRouter struct {
+	Router struct {
 		routes         map[string]Route
 		resultHandlers map[string]ResultHandler
 		providers      Providers
+		log            *log.Logger
 		qc             *query.Cache
 	}
 
@@ -110,8 +113,8 @@ type (
 	}
 )
 
-func NewRegoRouter(ctx context.Context, store storage.Store, qc *query.Cache, prvs Providers) *RegoRouter {
-	if _, err := qc.GetOrSet(ctx, store, query.MainEval); err != nil {
+func NewRouter(ctx context.Context, s storage.Store, qc *query.Cache, prvs Providers, log *log.Logger) *Router {
+	if _, err := qc.GetOrSet(ctx, s, query.MainEval); err != nil {
 		panic(err) // can't recover here
 	}
 
@@ -138,10 +141,10 @@ func NewRegoRouter(ctx context.Context, store storage.Store, qc *query.Cache, pr
 		"initialized": {}, // special case
 	}
 
-	return &RegoRouter{routes: routes, providers: prvs, qc: qc}
+	return &Router{routes: routes, providers: prvs, qc: qc, log: log}
 }
 
-func (m *RegoRouter) RegisterResultHandler(method string, handler ResultHandler) {
+func (m *Router) RegisterResultHandler(method string, handler ResultHandler) {
 	if m.resultHandlers == nil {
 		m.resultHandlers = make(map[string]ResultHandler)
 	}
@@ -153,7 +156,7 @@ func (m *RegoRouter) RegisterResultHandler(method string, handler ResultHandler)
 	m.resultHandlers[method] = handler
 }
 
-func (m *RegoRouter) Handle(ctx context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
+func (m *Router) Handle(ctx context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
 	pq := m.qc.Get(query.MainEval)
 	if pq == nil {
 		return nil, fmt.Errorf("no prepared query for %s", query.MainEval)
@@ -175,7 +178,7 @@ func (m *RegoRouter) Handle(ctx context.Context, _ *jsonrpc2.Conn, req *jsonrpc2
 
 	if route, ok := m.routes[req.Method]; ok {
 		if strings.HasPrefix(req.Method, "textDocument/") {
-			result, err = textDocumentPassthroughHandlerFor(route)(ctx, pq, m.providers, req)
+			result, err = m.textDocumentPassthroughHandlerFor(route)(ctx, pq, m.providers, req)
 		} else {
 			rctx := m.providers.ContextProvider("", route.requires) // No requirements for resolvers yet
 			rctx.Query = pq
@@ -195,9 +198,22 @@ func (m *RegoRouter) Handle(ctx context.Context, _ *jsonrpc2.Conn, req *jsonrpc2
 	return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeMethodNotFound, Message: "method not supported: " + req.Method}
 }
 
+// handleError logs the given message and returns nil, unless REGAL_DEBUG
+// is set, in which case msg is returned as an error. This makes issues
+// more visible during development, while not annoying actual users.
+func (m *Router) handleError(msg string) error {
+	if os.Getenv("REGAL_DEBUG") != "" {
+		return errors.New(msg)
+	}
+
+	m.log.Message(msg)
+
+	return nil
+}
+
 // textDocumentPassthroughHandlerFor wraps a regoHandler which first verifies that the text document URI isn't
 // ignored, and ensures that any custom requirements the handler may have are met.
-func textDocumentPassthroughHandlerFor(route Route) regoHandler {
+func (m *Router) textDocumentPassthroughHandlerFor(route Route) regoHandler {
 	return func(ctx context.Context, query *query.Prepared, prvs Providers, req *jsonrpc2.Request) (any, error) {
 		maybeURI := jsoniter.Get(*req.Params, "textDocument", "uri")
 		if maybeURI.LastError() != nil {
@@ -212,7 +228,7 @@ func textDocumentPassthroughHandlerFor(route Route) regoHandler {
 
 		rctx, err := regalContextForRequirements(prvs, docURI, route.requires)
 		if err != nil {
-			return nil, fmt.Errorf("error handling route %s: %w", req.Method, err)
+			return nil, m.handleError(fmt.Sprintf("error handling route %s: %v", req.Method, err))
 		} else if rctx == nil {
 			return nil, nil // e.g. file has always been unparsable
 		}

--- a/internal/lsp/rego/router_bench_test.go
+++ b/internal/lsp/rego/router_bench_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-policy-agent/regal/internal/lsp/rego"
 	"github.com/open-policy-agent/regal/internal/lsp/rego/query"
 	"github.com/open-policy-agent/regal/internal/lsp/semantictokens"
+	"github.com/open-policy-agent/regal/internal/lsp/test"
 	"github.com/open-policy-agent/regal/internal/test/must"
 	"github.com/open-policy-agent/regal/internal/testutil"
 )
@@ -20,10 +21,12 @@ import (
 // Therefore make sure all tests in TestRegoHandlers pass before running these benchmarks!
 // See testdata/bench_results.txt for the current results, and update it on changes.
 func BenchmarkRegoHandlers(b *testing.B) {
+	logger := test.DebugLogger(b)
+
 	for name, test := range handlerTests(b) { //nolint:gocritic // "each iteration copies 184 bytes"
 		b.Run(name, func(b *testing.B) {
 			stg := storeForDocument(b, test.policy, test.data.content)
-			mgr := rego.NewRegoRouter(b.Context(), stg, query.NewCache(), providersForTest(b, test))
+			mgr := rego.NewRouter(b.Context(), stg, query.NewCache(), providersForTest(b, test), logger)
 			mgr.RegisterResultHandler("textDocument/semanticTokens/full", semantictokens.ResultHandler)
 
 			runBenchmark(b, mgr, request(test.method, new(json.RawMessage(test.input.content))))
@@ -54,14 +57,14 @@ func BenchmarkFoldingRangeHandlerLineFoldingOnlyVsFull(b *testing.B) {
 					"parsed": map[string]any{doc.uri: doc.parsed},
 				},
 			}, inmem.OptReturnASTValuesOnRead(true))
-			router := rego.NewRegoRouter(b.Context(), store, query.NewCache(), contextForDoc(doc))
+			router := rego.NewRouter(b.Context(), store, query.NewCache(), contextForDoc(doc), test.DebugLogger(b))
 
 			runBenchmark(b, router, req)
 		})
 	}
 }
 
-func runBenchmark(b *testing.B, mgr *rego.RegoRouter, req *jsonrpc2.Request) {
+func runBenchmark(b *testing.B, mgr *rego.Router, req *jsonrpc2.Request) {
 	b.Helper()
 
 	for b.Loop() {

--- a/internal/lsp/rego/router_test.go
+++ b/internal/lsp/rego/router_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/open-policy-agent/regal/internal/lsp/rego/query"
 	"github.com/open-policy-agent/regal/internal/lsp/semantictokens"
 	"github.com/open-policy-agent/regal/internal/lsp/store"
+	"github.com/open-policy-agent/regal/internal/lsp/test"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/parse"
 	"github.com/open-policy-agent/regal/internal/roast/transforms/module"
@@ -55,6 +56,7 @@ func TestRegoHandlers(t *testing.T) {
 	t.Parallel()
 
 	testsExecuted := 0
+	logger := test.DebugLogger(t)
 
 	for name, test := range handlerTests(t) {
 		t.Run(name, func(t *testing.T) {
@@ -63,7 +65,7 @@ func TestRegoHandlers(t *testing.T) {
 			// map implementation... to be fixed later, but only a problem in tests, as the
 			// language server doesn't launch more than one Rego router.
 			stg := storeForDocument(t, test.policy, test.data.content)
-			mgr := rego.NewRegoRouter(t.Context(), stg, query.NewCache(), providersForTest(t, test))
+			mgr := rego.NewRouter(t.Context(), stg, query.NewCache(), providersForTest(t, test), logger)
 			mgr.RegisterResultHandler("textDocument/semanticTokens/full", semantictokens.ResultHandler)
 
 			req := request(test.method, new(json.RawMessage(test.input.content)))
@@ -224,9 +226,9 @@ func TestRouteIgnoredDocument(t *testing.T) {
 	t.Parallel()
 
 	uri := "file:///workspace/ignored.rego"
-	mgr := rego.NewRegoRouter(t.Context(), nil, query.NewCache(), rego.Providers{IgnoredProvider: func(string) bool {
+	mgr := rego.NewRouter(t.Context(), nil, query.NewCache(), rego.Providers{IgnoredProvider: func(string) bool {
 		return true
-	}})
+	}}, test.DebugLogger(t))
 	req := request("textDocument/signatureHelp", docPositionParams(t, uri, types.Position{Line: 0, Character: 0}))
 	rsp, err := mgr.Handle(t.Context(), nil, req)
 
@@ -240,7 +242,7 @@ func TestRouteInitialize(t *testing.T) {
 	data := map[string]any{"server": map[string]any{"version": "0.2.0"}}
 	store := inmem.NewFromObjectWithOpts(data, inmem.OptReturnASTValuesOnRead(true))
 
-	mgr := rego.NewRegoRouter(t.Context(), store, query.NewCache(), rego.Providers{})
+	mgr := rego.NewRouter(t.Context(), store, query.NewCache(), rego.Providers{}, test.DebugLogger(t))
 	mgr.RegisterResultHandler("initialize", func(_ context.Context, result any) (any, error) {
 		rsp, ok := result.(rego.InitializeResponse)
 

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -151,7 +151,7 @@ type LanguageServer struct {
 	bundleCache *bundles.Cache
 	queryCache  *query.Cache
 
-	regoRouter *rego.RegoRouter
+	regoRouter *rego.Router
 
 	// initializationGate blocks workers until the initialized notification is received
 	initializationGate     chan struct{}
@@ -226,14 +226,14 @@ func NewLanguageServerMinimal(ctx context.Context, opts *LanguageServerOptions, 
 		loadedConfigAllRegoVersions: concurrent.MapOf(make(map[string]ast.RegoVersion)),
 	}
 
-	ls.regoRouter = rego.NewRegoRouter(ctx, rstore, qc, rego.Providers{
+	ls.regoRouter = rego.NewRouter(ctx, rstore, qc, rego.Providers{
 		ContextProvider:              ls.regalContext,
 		IgnoredProvider:              ls.ignoreURI,
 		ContentProvider:              ls.cache.GetFileContents,
 		ParseErrorsProvider:          ls.cache.GetParseErrors,
 		SuccessfulParseCountProvider: ls.cache.GetSuccessfulParseLineCount,
 		InputPathProvider:            ls.input.FindForPath,
-	})
+	}, opts.Logger)
 
 	ls.regoRouter.RegisterResultHandler("initialize", ls.initializeResultHandler)
 	ls.regoRouter.RegisterResultHandler("initialized", ls.initializedResultHandler)

--- a/internal/lsp/server_aggregates_test.go
+++ b/internal/lsp/server_aggregates_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/open-policy-agent/regal/internal/lsp/log"
+	"github.com/open-policy-agent/regal/internal/lsp/test"
 	"github.com/open-policy-agent/regal/internal/testutil"
 )
 
@@ -32,8 +32,7 @@ package bar
 	}
 
 	receivedMessages := createMessageChannels(files)
-	logger := log.NewLogger(log.LevelDebug, t.Output())
-	clientHandler := createPublishDiagnosticsHandler(t, logger, receivedMessages)
+	clientHandler := createPublishDiagnosticsHandler(t, test.DebugLogger(t), receivedMessages)
 
 	tempDir := testutil.TempDirectoryOf(t, files)
 
@@ -91,10 +90,9 @@ import rego.v1
 		".regal/config.yaml": ``,
 	}
 
-	logger := log.NewLogger(log.LevelDebug, t.Output())
 	tempDir := testutil.TempDirectoryOf(t, files)
 	receivedMessages := createMessageChannels(files)
-	clientHandler := createPublishDiagnosticsHandler(t, logger, receivedMessages)
+	clientHandler := createPublishDiagnosticsHandler(t, test.DebugLogger(t), receivedMessages)
 
 	ls, connClient, ctx := createAndInitServer(t, tempDir, clientHandler)
 

--- a/internal/lsp/server_config_test.go
+++ b/internal/lsp/server_config_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/open-policy-agent/regal/internal/lsp/log"
+	"github.com/open-policy-agent/regal/internal/lsp/test"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	"github.com/open-policy-agent/regal/internal/test/must"
 	"github.com/open-policy-agent/regal/internal/testutil"
@@ -41,7 +41,7 @@ allow := true
 	tempDir := testutil.TempDirectoryOf(t, files)
 
 	receivedMessages := createMessageChannels(files)
-	clientHandler := createPublishDiagnosticsHandler(t, log.NewLogger(log.LevelDebug, t.Output()), receivedMessages)
+	clientHandler := createPublishDiagnosticsHandler(t, test.DebugLogger(t), receivedMessages)
 
 	ls, _, ctx := createAndInitServer(t, tempDir, clientHandler)
 

--- a/internal/lsp/server_custom_rules_test.go
+++ b/internal/lsp/server_custom_rules_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/open-policy-agent/regal/internal/lsp/clients"
-	"github.com/open-policy-agent/regal/internal/lsp/log"
+	"github.com/open-policy-agent/regal/internal/lsp/test"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	"github.com/open-policy-agent/regal/internal/testutil"
@@ -48,10 +48,8 @@ allow if {
 	}
 
 	tempDir := testutil.TempDirectoryOf(t, files)
-
-	logger := log.NewLogger(log.LevelDebug, t.Output())
 	receivedMessages := createMessageChannels(files)
-	clientHandler := createPublishDiagnosticsHandler(t, logger, receivedMessages)
+	clientHandler := createPublishDiagnosticsHandler(t, test.DebugLogger(t), receivedMessages)
 
 	_, connClient, ctx := createAndInitServer(t, tempDir, clientHandler)
 

--- a/internal/lsp/server_formatting_test.go
+++ b/internal/lsp/server_formatting_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/open-policy-agent/regal/internal/lsp/clients"
-	"github.com/open-policy-agent/regal/internal/lsp/log"
+	"github.com/open-policy-agent/regal/internal/lsp/test"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	"github.com/open-policy-agent/regal/internal/test/must"
@@ -20,9 +20,8 @@ func TestFormatting(t *testing.T) {
 		"main/main.rego": "package main\n\n",
 	}
 
-	logger := log.NewLogger(log.LevelDebug, t.Output())
 	receivedMessages := createMessageChannels(files)
-	clientHandler := createPublishDiagnosticsHandler(t, logger, receivedMessages)
+	clientHandler := createPublishDiagnosticsHandler(t, test.DebugLogger(t), receivedMessages)
 	tempDir := testutil.TempDirectoryOf(t, files)
 	ls, connClient, ctx := createAndInitServer(t, tempDir, clientHandler)
 

--- a/internal/lsp/server_load_workspace_test.go
+++ b/internal/lsp/server_load_workspace_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/regal/internal/lsp/client"
-	"github.com/open-policy-agent/regal/internal/lsp/log"
+	"github.com/open-policy-agent/regal/internal/lsp/test"
 	"github.com/open-policy-agent/regal/internal/lsp/workspace"
 	"github.com/open-policy-agent/regal/internal/test/assert"
 	"github.com/open-policy-agent/regal/internal/test/must"
@@ -135,9 +135,7 @@ func TestLoadWorkspaceContents(t *testing.T) {
 				must.Equal(t, nil, os.Chmod(unreadableFile, 0o000), "make file %s unreadable %v", fileName)
 			}
 
-			opts := &LanguageServerOptions{Logger: log.NewLogger(log.LevelDebug, t.Output())}
-
-			server := NewLanguageServer(t.Context(), opts)
+			server := NewLanguageServer(t.Context(), &LanguageServerOptions{Logger: test.DebugLogger(t)})
 			server.workspace = workspace
 			server.loadedConfig = &config.Config{}
 

--- a/internal/lsp/server_multi_file_test.go
+++ b/internal/lsp/server_multi_file_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/open-policy-agent/regal/internal/lsp/clients"
-	"github.com/open-policy-agent/regal/internal/lsp/log"
+	"github.com/open-policy-agent/regal/internal/lsp/test"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	"github.com/open-policy-agent/regal/internal/testutil"
@@ -54,7 +54,7 @@ ignore:
 	// set up the workspace content with some example rego and regal config
 	tempDir := testutil.TempDirectoryOf(t, files)
 	receivedMessages := createMessageChannels(files)
-	clientHandler := createPublishDiagnosticsHandler(t, log.NewLogger(log.LevelDebug, t.Output()), receivedMessages)
+	clientHandler := createPublishDiagnosticsHandler(t, test.DebugLogger(t), receivedMessages)
 
 	ls, connClient, ctx := createAndInitServer(t, tempDir, clientHandler)
 

--- a/internal/lsp/server_no_workspace_test.go
+++ b/internal/lsp/server_no_workspace_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/open-policy-agent/regal/internal/lsp/clients"
-	"github.com/open-policy-agent/regal/internal/lsp/log"
+	"github.com/open-policy-agent/regal/internal/lsp/test"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	"github.com/open-policy-agent/regal/internal/testutil"
@@ -39,9 +39,8 @@ rules:
 	// set up the workspace content with some example rego and regal config
 	tempDir := testutil.TempDirectoryOf(t, files)
 	mainRegoURI := uri.FromPath(clients.IdentifierGeneric, filepath.Join(tempDir, filepath.FromSlash(mainRegoFileName)))
-
 	receivedMessages := receivedMessagesMap{"main.rego": make(chan []string, 10)}
-	clientHandler := createPublishDiagnosticsHandler(t, log.NewLogger(log.LevelDebug, t.Output()), receivedMessages)
+	clientHandler := createPublishDiagnosticsHandler(t, test.DebugLogger(t), receivedMessages)
 
 	// note using a blank tempDir here so we can simulate the single file mode
 	_, connClient, ctx := createAndInitServer(t, "", clientHandler)

--- a/internal/lsp/server_rename_test.go
+++ b/internal/lsp/server_rename_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/open-policy-agent/regal/internal/lsp/client"
 	"github.com/open-policy-agent/regal/internal/lsp/clients"
-	"github.com/open-policy-agent/regal/internal/lsp/log"
+	"github.com/open-policy-agent/regal/internal/lsp/test"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	"github.com/open-policy-agent/regal/internal/lsp/workspace"
@@ -24,7 +24,7 @@ func TestLanguageServerFixRenameParams(t *testing.T) {
 	wsRootURI := uri.FromPath(clients.IdentifierGeneric, filepath.Join(tmpDir, "workspace"))
 	workspace := workspace.New(wsRootURI).WithClient(client.NewGeneric())
 
-	ls := NewLanguageServer(t.Context(), &LanguageServerOptions{Logger: log.NewLogger(log.LevelDebug, t.Output())})
+	ls := NewLanguageServer(t.Context(), &LanguageServerOptions{Logger: test.DebugLogger(t)})
 	ls.workspace = workspace
 	ls.loadedConfig = &config.Config{
 		Rules: map[string]config.Category{"idiomatic": {
@@ -57,7 +57,7 @@ func TestLanguageServerFixRenameParamsWithConflict(t *testing.T) {
 	wsRootURI := uri.FromPath(clients.IdentifierGeneric, filepath.Join(tmpDir, "workspace"))
 	workspace := workspace.New(wsRootURI).WithClient(client.NewGeneric())
 
-	ls := NewLanguageServer(t.Context(), &LanguageServerOptions{Logger: log.NewLogger(log.LevelDebug, t.Output())})
+	ls := NewLanguageServer(t.Context(), &LanguageServerOptions{Logger: test.DebugLogger(t)})
 	ls.workspace = workspace
 	ls.loadedConfig = &config.Config{
 		Rules: map[string]config.Category{"idiomatic": {
@@ -111,7 +111,7 @@ func TestLanguageServerFixRenameParamsWhenTargetOutsideRoot(t *testing.T) {
 	wsRootURI := client.URIFromPath(filepath.Join(tmpDir, "workspace"))
 	workspace := workspace.New(wsRootURI).WithClient(client)
 
-	ls := NewLanguageServer(t.Context(), &LanguageServerOptions{Logger: log.NewLogger(log.LevelDebug, t.Output())})
+	ls := NewLanguageServer(t.Context(), &LanguageServerOptions{Logger: test.DebugLogger(t)})
 	must.Equal(t, nil, ls.loadWorkspace(t.Context(), wsRootURI, client))
 
 	// the root where the client stated the workspace is

--- a/internal/lsp/server_single_file_test.go
+++ b/internal/lsp/server_single_file_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/open-policy-agent/regal/internal/lsp/clients"
-	"github.com/open-policy-agent/regal/internal/lsp/log"
+	"github.com/open-policy-agent/regal/internal/lsp/test"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	"github.com/open-policy-agent/regal/internal/test/must"
 	"github.com/open-policy-agent/regal/internal/testutil"
@@ -43,7 +43,7 @@ rules:
 	mainRegoURI := uri.FromPath(clients.IdentifierGeneric, filepath.Join(tempDir, filepath.FromSlash(mainRegoFileName)))
 
 	receivedMessages := createMessageChannels(files)
-	clientHandler := createPublishDiagnosticsHandler(t, log.NewLogger(log.LevelDebug, t.Output()), receivedMessages)
+	clientHandler := createPublishDiagnosticsHandler(t, test.DebugLogger(t), receivedMessages)
 
 	ls, connClient, ctx := createAndInitServer(t, tempDir, clientHandler)
 

--- a/internal/lsp/server_template_test.go
+++ b/internal/lsp/server_template_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/ast"
 
 	"github.com/open-policy-agent/regal/internal/lsp/clients"
-	"github.com/open-policy-agent/regal/internal/lsp/log"
+	"github.com/open-policy-agent/regal/internal/lsp/test"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	"github.com/open-policy-agent/regal/internal/lsp/workspace"
@@ -113,9 +113,8 @@ func TestTemplateContentsForFile(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			lg := log.NewLogger(log.LevelDebug, t.Output())
 			td := testutil.TempDirectoryOf(t, tc.DiskContents)
-			ls := NewLanguageServer(t.Context(), &LanguageServerOptions{Logger: lg})
+			ls := NewLanguageServer(t.Context(), &LanguageServerOptions{Logger: test.DebugLogger(t)})
 
 			wsRootURI := uri.FromPath(clients.IdentifierGeneric, td)
 			ls.workspace = workspace.New(wsRootURI)
@@ -143,7 +142,7 @@ func TestTemplateContentsForFileInWorkspaceRoot(t *testing.T) {
 	t.Parallel()
 
 	td := testutil.TempDirectoryOf(t, map[string]string{".regal/config.yaml": ""})
-	ls := NewLanguageServer(t.Context(), &LanguageServerOptions{Logger: log.NewLogger(log.LevelDebug, t.Output())})
+	ls := NewLanguageServer(t.Context(), &LanguageServerOptions{Logger: test.DebugLogger(t)})
 
 	workspaceRootURI := uri.FromPath(clients.IdentifierGeneric, td)
 	ls.workspace = workspace.New(workspaceRootURI)
@@ -161,7 +160,7 @@ func TestTemplateContentsForFileWithUnknownRoot(t *testing.T) {
 	t.Parallel()
 
 	td := t.TempDir()
-	ls := NewLanguageServer(t.Context(), &LanguageServerOptions{Logger: log.NewLogger(log.LevelDebug, t.Output())})
+	ls := NewLanguageServer(t.Context(), &LanguageServerOptions{Logger: test.DebugLogger(t)})
 	fileURI := uri.FromPath(clients.IdentifierGeneric, filepath.Join(td, "foo", "bar.rego"))
 
 	ls.workspace = workspace.New(uri.FromPath(clients.IdentifierGeneric, td))
@@ -337,7 +336,7 @@ func TestTemplateWorkerSkipsDidOpenWhenTemplating(t *testing.T) {
 
 	receivedMessages := receivedMessagesMap{"policy.rego": make(chan []string, 10)}
 	tempDir := testutil.TempDirectoryOf(t, map[string]string{".regal/config.yaml": `{}`})
-	clientHandler := createPublishDiagnosticsHandler(t, log.NewLogger(log.LevelDebug, t.Output()), receivedMessages)
+	clientHandler := createPublishDiagnosticsHandler(t, test.DebugLogger(t), receivedMessages)
 	ls, connClient, ctx := createAndInitServer(t, tempDir, clientHandler)
 
 	// note that the template worker is not started, we simulate it's running

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/open-policy-agent/regal/internal/lsp/clients"
 	"github.com/open-policy-agent/regal/internal/lsp/connection"
 	"github.com/open-policy-agent/regal/internal/lsp/handler"
-	"github.com/open-policy-agent/regal/internal/lsp/log"
+	"github.com/open-policy-agent/regal/internal/lsp/test"
 	"github.com/open-policy-agent/regal/internal/lsp/types"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	"github.com/open-policy-agent/regal/internal/testutil"
@@ -97,11 +97,9 @@ func createAndInitServerWithClientName(
 		pollingInterval = 10 * time.Second
 	}
 
-	logger := log.NewLogger(log.LevelDebug, t.Output())
-
 	// set up the server and client connections
 	ls := NewLanguageServer(ctx, &LanguageServerOptions{
-		Logger:                   logger,
+		Logger:                   test.DebugLogger(t),
 		WorkspaceDiagnosticsPoll: pollingInterval,
 	})
 

--- a/internal/lsp/test/test.go
+++ b/internal/lsp/test/test.go
@@ -2,11 +2,13 @@ package test
 
 import (
 	"context"
+	"testing"
 
 	"github.com/sourcegraph/jsonrpc2"
 
 	"github.com/open-policy-agent/regal/internal/lsp/connection"
 	"github.com/open-policy-agent/regal/internal/lsp/handler"
+	"github.com/open-policy-agent/regal/internal/lsp/log"
 )
 
 func HandlerFor[T any](method string, h handler.Func[T]) connection.HandlerFunc {
@@ -26,4 +28,10 @@ func SendsToChannel[T any](c chan T) func(T) (any, error) {
 
 		return struct{}{}, nil
 	}
+}
+
+func DebugLogger(tb testing.TB) *log.Logger {
+	tb.Helper()
+
+	return log.NewLogger(log.LevelDebug, tb.Output())
 }

--- a/internal/lsp/testgen/testgen_test.go
+++ b/internal/lsp/testgen/testgen_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/open-policy-agent/regal/internal/lsp/clients"
 	"github.com/open-policy-agent/regal/internal/lsp/input"
-	"github.com/open-policy-agent/regal/internal/lsp/log"
 	"github.com/open-policy-agent/regal/internal/lsp/store"
+	"github.com/open-policy-agent/regal/internal/lsp/test"
 	"github.com/open-policy-agent/regal/internal/lsp/testgen"
 	"github.com/open-policy-agent/regal/internal/lsp/uri"
 	"github.com/open-policy-agent/regal/internal/lsp/workspace"
@@ -114,7 +114,7 @@ deny if {
 				t.Fatalf("failed to parse policy: %v", err)
 			}
 
-			im := input.NewManager(store.NewRegalStore(), log.NewLogger(log.LevelDebug, t.Output()))
+			im := input.NewManager(store.NewRegalStore(), test.DebugLogger(t))
 			im.LoadFromWorkspace(t.Context(), workspace)
 
 			result, err := testgen.CreateTestModule(t.Context(), testgen.TestModuleOptions{


### PR DESCRIPTION
And log most errors rather than have them presented to the user.

Also added a helper for logging in tests.
