### PR TITLE
build: Add capabilities verification to build check

### DIFF
--- a/build/do.rq
+++ b/build/do.rq
@@ -64,7 +64,7 @@ main contains null if {
 # title: pull_request
 # description: Run all task to verify a pull request
 do contains "pull_request" if {
-	some x in ["test", "lint", "e2e", "check_readme"]
+	some x in ["test", "lint", "e2e", "check_readme", "check_capabilities"]
 	github("::group::", x)
 	job[x]
 	github("::endgroup::", x)
@@ -94,6 +94,7 @@ job contains "pr" if {
 	# format
 	fmt_all
 	write_readme
+	write_capabilities
 	golangcilintfix
 
 	# verify
@@ -148,6 +149,14 @@ build(false) if {
 job contains "check_readme" if {
 	build(true)
 	check_readme
+}
+
+# METADATA
+# title: check_capabilities
+# description: Verify that build/capabilities.json is up-to-date
+job contains "check_capabilities" if {
+	build(true)
+	check_capabilities
 }
 
 # any binary is good enough when calling `build(false)`, it doesn't need to be
@@ -393,6 +402,14 @@ check_readme if {
 
 write_readme if {
 	run("./build/update-readme.sh write")
+}
+
+check_capabilities if {
+	run("./build/update-capabilities.sh check")
+}
+
+write_capabilities if {
+	run("./build/update-capabilities.sh write")
 }
 
 fmt_all if {

--- a/build/update-capabilities.sh
+++ b/build/update-capabilities.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+CAPABILITIES_PATH="./build/capabilities.json"
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 {check|write}"
+  exit 1
+fi
+
+MODE="$1"
+
+tmpfile=$(mktemp)
+
+if ! ./regal capabilities > "$tmpfile"; then
+  echo "Error: failed to generate capabilities JSON" >&2
+  rm "$tmpfile"
+  exit 1
+fi
+
+if [[ "$MODE" == "check" ]]; then
+  if ! cmp -s "$tmpfile" "$CAPABILITIES_PATH"; then
+    echo "build/capabilities.json is out of date. Please run '$0 write' to update it."
+    rm "$tmpfile"
+    exit 1
+  else
+    echo "build/capabilities.json is up to date."
+    rm "$tmpfile"
+  fi
+elif [[ "$MODE" == "write" ]]; then
+  mv "$tmpfile" "$CAPABILITIES_PATH"
+  echo "build/capabilities.json has been updated."
+else
+  echo "Unknown mode: $MODE"
+  echo "Usage: $0 {check|write}"
+  rm "$tmpfile"
+  exit 1
+fi


### PR DESCRIPTION
Add check_capabilities job to pull_request workflow to verify build/capabilities.json is up-to-date.

Checks similar to what we do for readme.

