### PR TITLE
Unify common aggregation and aggregated data

### DIFF
--- a/bundle/regal/aggregated/aggregated.rego
+++ b/bundle/regal/aggregated/aggregated.rego
@@ -1,0 +1,58 @@
+# METADATA
+# description: |
+#   common collections of *aggregated* data, for use in aggregate_report rules
+# schemas:
+#   - input: schema.regal.aggregate
+package regal.aggregated
+
+import data.regal.util
+
+# METADATA
+# description: |
+#   a tree representing all rules in the linted files, e.g.:
+#   {
+#     "data": {
+#       "package1": {
+#         "rule1": {},
+#         "nested": {
+#           "rule2": {},
+#         },
+#       },
+#       "package2": {
+#         "rule3": {},
+#       },
+#     }
+#   }
+rule_tree := object.union_n([m | m := _aggregates[_][_].rule_tree])
+
+# METADATA
+# description: |
+#   a set containing all package paths from the linted files
+all_package_paths := {path | path := _aggregates[_][_].package_path}
+
+# METADATA
+# description: |
+#   like util.to_location_object, but with text and file passed in
+#   as we don't have access to the usual input.regal.file attributes
+#   in the context of reporting aggregated data
+location_object(loc, file) := {"location": {
+	"file": file,
+	"row": row,
+	"col": col,
+	"text": text,
+	"end": {
+		"row": row,
+		"col": col + count(ref_text),
+	},
+}} if {
+	pos := split(loc, ":")
+	row := to_number(pos[0])
+	col := to_number(pos[1])
+
+	text := util.any_set_item(input.aggregates_internal[file].common).lines[row - 1]
+
+	from_col := substring(text, col - 1, -1)
+	ref_text := substring(from_col, 0, indexof(from_col, " "))
+}
+
+_aggregates[file] := input.aggregates_internal[file].common if some file

--- a/bundle/regal/aggregators/aggregators.rego
+++ b/bundle/regal/aggregators/aggregators.rego
@@ -1,0 +1,63 @@
+package regal.aggregators
+
+import future.keywords.not
+
+import data.regal.ast
+import data.regal.util
+
+# METADATA
+# description: aggregates a rule tree for the given input module
+rule_tree := tree if {
+	pkg_name := replace(replace(ast.package_name_full, `["`, "."), `"]`, "")
+	pkg_path := split(pkg_name, ".")
+
+	pkg_obj := json.patch({}, [patch |
+		some i in numbers.range(1, count(pkg_path))
+
+		patch := {
+			"op": "add",
+			"path": $"/{concat("/", array.slice(pkg_path, 0, i))}",
+			"value": {},
+		}
+	])
+
+	tree := json.patch(pkg_obj, [patch |
+		some rule_path in _rule_paths
+
+		patch := {
+			"op": "add",
+			"path": $"/{concat("/", array.concat(pkg_path, rule_path))}",
+			"value": {},
+		}
+	])
+}
+
+# METADATA
+# description: |
+#   aggregates all input refs and their locations for the given input module§
+imports := [imp |
+	some _import in input.imports
+
+	_import.path.value[0].value == "data"
+	len := count(_import.path.value)
+	len > 1
+
+	# Special case for custom rules, where we don't want to flag e.g. `import data.regal.ast`
+	# as unknown, even though it's not a package included in evaluation.
+	not {
+		_import.path.value[1].value == "regal"
+		ast.package_path[0] == "custom"
+		ast.package_path[1] == "regal"
+	}
+
+	path := [term.value | some term in array.slice(_import.path.value, 1, len)]
+	imp := [path, _import.location]
+]
+
+_rule_paths contains path if {
+	pkg_name := replace(replace(ast.package_name_full, `["`, "."), `"]`, "")
+	pkg_pref := $"{pkg_name}."
+
+	some name, _ in ast.rule_head_locations
+	some path in util.all_paths(split(trim_prefix(name, pkg_pref), "."))
+}

--- a/bundle/regal/aggregators/aggregators_test.rego
+++ b/bundle/regal/aggregators/aggregators_test.rego
@@ -1,0 +1,28 @@
+package regal.aggregators_test
+
+import data.regal.aggregators
+
+test_aggregate_collects_imports_with_location if {
+	r := aggregators.imports with input as regal.parse_module("p.rego", `
+	package a
+
+	import data.b
+	import data.c.d`)
+
+	r == [
+		[["b"], "4:2:4:8"],
+		[["c", "d"], "5:2:5:8"],
+	]
+}
+
+test_aggregate_ignores_imports_of_regal_in_custom_rule if {
+	r := aggregators.imports with input as regal.parse_module("p.rego", `
+	package custom.regal.rules.foo.bar
+
+	import data.regal.ast
+
+	import data.a.b.c
+	`)
+
+	r == [[["a", "b", "c"], "6:2:6:8"]]
+}

--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -416,6 +416,6 @@ assignment_terms(terms) := [terms[1], terms[2]] if is_assignment(terms[0])
 rule_head_locations[name] contains {"row": loc.row, "col": loc.col} if {
 	some i, rule in input.rules
 
-	name := $"data.{package_name}.{rule_names_ordered[i]}"
+	name := $"{package_name_full}.{rule_names_ordered[i]}"
 	loc := util.to_location_object(rule.head.location)
 }

--- a/bundle/regal/main/main.rego
+++ b/bundle/regal/main/main.rego
@@ -8,6 +8,7 @@
 #   scope of a single file
 package regal.main
 
+import data.regal.aggregators
 import data.regal.ast
 import data.regal.config
 import data.regal.notices
@@ -136,7 +137,10 @@ report contains violation if {
 aggregate[input.regal.file.name].common contains {
 	"package_name": ast.package_name,
 	"package_name_full": ast.package_name_full,
+	"package_path": ast.package_path,
 	"lines": input.regal.file.lines,
+	"rule_tree": aggregators.rule_tree,
+	"imports": aggregators.imports,
 }
 
 # METADATA

--- a/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports.rego
+++ b/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports.rego
@@ -7,76 +7,30 @@ package regal.rules.imports["prefer-package-imports"]
 
 import future.keywords.not
 
-import data.regal.ast
+import data.regal.aggregated
 import data.regal.config
 import data.regal.result
-import data.regal.util
-
-# METADATA
-# description: collects imports and package paths from each module
-aggregate contains entry if {
-	imports_with_location := [imp |
-		some _import in input.imports
-
-		_import.path.value[0].value == "data"
-		len := count(_import.path.value)
-		len > 1
-
-		# Special case for custom rules, where we don't want to flag e.g. `import data.regal.ast`
-		# as unknown, even though it's not a package included in evaluation.
-		not {
-			_import.path.value[1].value == "regal"
-			ast.package_path[0] == "custom"
-			ast.package_path[1] == "regal"
-		}
-
-		path := [term.value | some term in array.slice(_import.path.value, 1, len)]
-		imp := [path, _import.location]
-	]
-
-	entry := {
-		"imports": imports_with_location,
-		"package_path": ast.package_path,
-	}
-}
 
 # METADATA
 # schemas:
 #   - input: schema.regal.aggregate
 aggregate_report contains violation if {
-	all_package_paths := {path | path := _aggregates[_].package_path}
-
 	some file
-
-	# regal ignore:prefer-some-in-iteration
-	entry := _aggregates[file]
+	entry := input.aggregates_internal[file].common[_]
 
 	some [path, location] in entry.imports
 
-	not path in all_package_paths
+	not path in aggregated.all_package_paths
 	not path in _ignored_import_paths
 
 	[path |
-		some pkg_path in all_package_paths
+		some pkg_path in aggregated.all_package_paths
 		pkg_path == array.slice(path, 0, count(pkg_path))
 	] != []
 
-	violation := result.fail(rego.metadata.chain(), {"location": object.union(util.to_location_no_text(location), {
-		"file": file,
-		"text": $"import data.{concat(".", path)}",
-	})})
+	violation := result.fail(rego.metadata.chain(), aggregated.location_object(location, file))
 }
 
 _ignored_import_paths contains split(trim_prefix(item, "data."), ".") if {
 	some item in config.rules.imports["prefer-package-imports"]["ignore-import-paths"]
-}
-
-# METADATA
-# schemas:
-#   - input: schema.regal.aggregate
-_aggregates[file] := agg if {
-	# we know that there is only one aggregate of this type per file,
-	# so we can simplify things some for our callers
-	some file
-	agg := input.aggregates_internal[file]["imports/prefer-package-imports"][_]
 }

--- a/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports_test.rego
+++ b/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports_test.rego
@@ -4,37 +4,34 @@ import data.regal.config
 
 import data.regal.rules.imports["prefer-package-imports"] as rule
 
-test_aggregate_collects_imports_with_location if {
-	r := rule.aggregate with input as regal.parse_module("p.rego", `
-	package a
-
-	import data.b
-	import data.c.d
-	`)
-
-	r == {{
-		"imports": [
-			[["b"], "4:2:4:8"],
-			[["c", "d"], "5:2:5:8"],
-		],
-		"package_path": ["a"],
-	}}
-}
-
 test_fail_aggregate_report_on_imported_rule if {
 	r := rule.aggregate_report with input.aggregates_internal as {
-		"policy1.rego": {"imports/prefer-package-imports": {{
-			"package_path": ["a"],
-			"imports": [
-				[["b", "c"], "3:1:3:8"], # likely import of rule — should fail
-				[["b"], "4:1:4:8"], # import of package, should not fail
-				[["c"], "5:1:5:8"], # unresolved import, should not fail
-			],
-		}}},
-		"policy2.rego": {"imports/prefer-package-imports": {{
-			"package_path": ["b"],
-			"imports": [],
-		}}},
+		"policy1.rego": {
+			"common": {{
+				"package_path": ["a"],
+				"lines": [
+					"package a",
+					"",
+					"import data.b.c",
+					"import data.b",
+					"import data.c",
+				],
+				"imports": [
+					[["b", "c"], "3:1:3:8"], # likely import of rule — should fail
+					[["b"], "4:1:4:8"], # import of package, should not fail
+					[["c"], "5:1:5:8"], # unresolved import, should not fail
+				],
+			}},
+		},
+		"policy2.rego": {
+			"common": {{
+				"package_path": ["b"],
+				"lines": [
+					"package b",
+				],
+				"imports": [],
+			}},
+		},
 	}
 
 	r == {{
@@ -46,7 +43,7 @@ test_fail_aggregate_report_on_imported_rule if {
 			"col": 1,
 			"row": 3,
 			"end": {
-				"col": 8,
+				"col": 7,
 				"row": 3,
 			},
 			"text": "import data.b.c",
@@ -59,69 +56,97 @@ test_fail_aggregate_report_on_imported_rule if {
 	}}
 }
 
-test_success_aggregate_report_on_import_with_matching_package if {
-	r := rule.aggregate_report with input.aggregate as {
-		{"aggregate_data": {
+test_fail_import_of_rule if {
+	r := rule.aggregate_report with input.aggregates_internal as {
+		"a.rego": {"common": {{
 			"package_path": ["a"],
-			"imports": [[["b"], "3:1:3:8"]],
-		}},
-		{"aggregate_data": {
+			"lines": [
+				"package a",
+				"",
+				"import data.b.c",
+			],
+			"imports": [[["b", "c"], "3:1:3:8"]],
+		}}},
+		"b.rego": {"common": {{
 			"package_path": ["b"],
+			"lines": [
+				"package b",
+				"",
+				"c := 1",
+			],
 			"imports": [],
-		}},
+		}}},
 	}
+
+	r != set()
+}
+
+test_success_import_with_matching_package if {
+	r := rule.aggregate_report with input.aggregates_internal as {{
+		"a.rego": {"common": {{
+			"package_path": ["a"],
+			"lines": [
+				"package a",
+				"",
+				"import data.b",
+			],
+			"imports": [[["b"], "3:1:3:8"]],
+		}}},
+		"b.rego": {"common": {{
+			"package_path": ["b"],
+			"lines": ["package b"],
+			"imports": [],
+		}}},
+	}}
 
 	r == set()
 }
 
 test_success_aggregate_report_on_import_with_unresolved_path if {
-	r := rule.aggregate_report with input.aggregate as {
-		{"aggregate_data": {
+	r := rule.aggregate_report with input.aggregates_internal as {{
+		"a.rego": {"common": {{
 			"package_path": ["a"],
+			"lines": [
+				"package a",
+				"",
+				"import data.b",
+			],
 			"imports": [[["b"], "3:1:3:8"]],
-		}},
-		{"aggregate_data": {
+		}}},
+		"b.rego": {"common": {{
 			"package_path": ["bar"],
+			"lines": ["package bar"],
 			"imports": [],
-		}},
-	}
+		}}},
+	}}
 
 	r == set()
 }
 
 test_success_aggregate_report_ignored_import_path if {
-	aggregate := {
-		{"aggregate_data": {
+	aggregates_internal := {
+		"a.rego": {"common": {{
 			"package_path": ["a"],
+			"lines": [
+				"package a",
+				"",
+				"import data.b.c",
+			],
 			"imports": [[["b", "c"], "3:1:3:8"]],
-		}},
-		{"aggregate_data": {
+		}}},
+		"b.rego": {"common": {{
 			"package_path": ["b"],
+			"lines": ["package b"],
 			"imports": [],
-		}},
+		}}},
 	}
 
 	r := rule.aggregate_report
-		with input.aggregate as aggregate
+		with input.aggregates_internal as aggregates_internal
 		with config.rules as {"imports": {"prefer-package-imports": {
 			"level": "error",
 			"ignore-import-paths": ["data.b.c"],
 		}}}
 
 	r == set()
-}
-
-test_aggregate_ignores_imports_of_regal_in_custom_rule if {
-	r := rule.aggregate with input as regal.parse_module("p.rego", `
-	package custom.regal.rules.foo.bar
-
-	import data.regal.ast
-
-	import data.a.b.c
-	`)
-
-	r == {{
-		"imports": [[["a", "b", "c"], "6:2:6:8"]],
-		"package_path": ["custom", "regal", "rules", "foo", "bar"],
-	}}
 }

--- a/bundle/regal/rules/imports/unresolved-import/unresolved_import.rego
+++ b/bundle/regal/rules/imports/unresolved-import/unresolved_import.rego
@@ -5,70 +5,30 @@
 #     ref: https://www.openpolicyagent.org/projects/regal/rules/imports/unresolved-import
 package regal.rules.imports["unresolved-import"]
 
-import future.keywords.not
-
-import data.regal.ast
+import data.regal.aggregated
 import data.regal.config
 import data.regal.result
 import data.regal.util
 
 # METADATA
-# description: collects imports and exported refs from each module
-aggregate contains entry if {
-	imports_with_location := [imp |
-		some _import in input.imports
-
-		_import.path.value[0].value == "data"
-		len := count(_import.path.value)
-		len > 1
-
-		# Special case for custom rules, where we don't want to flag e.g. `import data.regal.ast`
-		# as unknown, even though it's not a package included in evaluation.
-		not {
-			_import.path.value[1].value == "regal"
-			ast.package_path[0] == "custom"
-			ast.package_path[1] == "regal"
-		}
-
-		path := [term.value | some term in array.slice(_import.path.value, 1, len)]
-		imp := [path, _import.location]
-	]
-
-	exported_refs := {ast.package_path} | {ref |
-		some rule in input.rules
-
-		# locations will only contribute to each item in the set being unique,
-		# which we don't want here — we only care for distinct ref paths
-		some ref in _to_paths(ast.package_path, rule.head.ref)
-	}
-
-	entry := {
-		"imports": imports_with_location,
-		"exported_refs": exported_refs,
-	}
-}
-
-# METADATA
 # schemas:
 #   - input: schema.regal.aggregate
 aggregate_report contains violation if {
-	all_known_refs := {path | path := input.aggregates_internal[_]["imports/unresolved-import"][_].exported_refs[_]}
+	rule_tree := aggregated.rule_tree
 
-	some file
-	entry := input.aggregates_internal[file]["imports/unresolved-import"][_]
-
+	some file, entries in _aggregates
+	some entry in entries
 	some [path, location] in entry.imports
+
 	not path in _except_imports
-	not path in all_known_refs
+	object.get(rule_tree.data, path, false) == false
 
 	# cheap operation failed — need to check wildcards here to account
 	# for map generating / general ref head rules
-	not _wildcard_match(path, (all_known_refs | _except_imports))
+	not _wildcard_match(path, _except_imports)
+	not _is_resolved_ref(path, rule_tree.data)
 
-	violation := result.fail(rego.metadata.chain(), {"location": object.union(util.to_location_no_text(location), {
-		"file": file,
-		"text": $"import data.{concat(".", path)}",
-	})})
+	violation := result.fail(rego.metadata.chain(), aggregated.location_object(location, file))
 }
 
 # the package part will always be included exported refs
@@ -84,12 +44,18 @@ _to_path(pkg_path, terms) := array.flatten([pkg_path, terms[0].value, [_to_strin
 _to_string(term) := term.value if term.type == "string"
 _to_string(term) := "**" if term.type == "var"
 
+_is_resolved_ref(ref_path, rule_tree) if {
+	some i in numbers.range(1, count(ref_path))
+
+	object.get(rule_tree, array.slice(ref_path, 0, i), false) == {} # regal ignore:superfluous-object-get
+}
+
 _except_imports contains split(trim_prefix(str, "data."), ".") if {
 	some str in config.rules.imports["unresolved-import"]["except-imports"]
 }
 
-_wildcard_match(imp_path, refs_and_except_imports) if {
-	some except in refs_and_except_imports
+_wildcard_match(imp_path, except_imports) if {
+	some except in except_imports
 	path := concat(".", except)
 	contains(path, "*")
 
@@ -105,9 +71,4 @@ _wildcard_match(imp_path, refs_and_except_imports) if {
 # METADATA
 # schemas:
 #   - input: schema.regal.aggregate
-_aggregates[file] := agg if {
-	# we know that there is only one aggregate of this type per file,
-	# so we can simplify things some for our callers
-	some file
-	agg := input.aggregates_internal[file]["imports/unresolved-import"][_]
-}
+_aggregates[file] := input.aggregates_internal[file].common if some file

--- a/bundle/regal/rules/imports/unresolved-import/unresolved_import_test.rego
+++ b/bundle/regal/rules/imports/unresolved-import/unresolved_import_test.rego
@@ -1,29 +1,28 @@
 package regal.rules.imports["unresolved-import_test"]
 
+import data.regal.aggregators
 import data.regal.config
-import data.regal.util
 
 import data.regal.rules.imports["unresolved-import"] as rule
 
 test_fail_identifies_unresolved_imports if {
-	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
+	p1 := `package foo
 	import data.bar
 	import data.bar.x
 	import data.bar.nope
 	import data.nope
 
 	x := 1
-	`)
-	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", `package bar
+	`
+	p2 := `package bar
 	import data.foo
 	import data.foo.x
 
 	x := 1
-	`)
-
-	r := rule.aggregate_report with input.aggregates_internal as util.with_source_files(
-		"imports/unresolved-import",
-		[agg1, agg2],
+	`
+	r := rule.aggregate_report with input.aggregates_internal as object.union(
+		_imports_agg("p1.rego", p1),
+		_imports_agg("p2.rego", p2),
 	)
 
 	r == {
@@ -35,7 +34,7 @@ test_fail_identifies_unresolved_imports if {
 				"col": 8,
 				"row": 5,
 			},
-			"text": "import data.nope",
+			"text": "\timport data.nope",
 		}),
 		with_location({
 			"file": "p1.rego",
@@ -45,129 +44,145 @@ test_fail_identifies_unresolved_imports if {
 				"col": 8,
 				"row": 4,
 			},
-			"text": "import data.bar.nope",
+			"text": "\timport data.bar.nope",
 		}),
 	}
 }
 
 test_success_no_unresolved_imports if {
-	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
+	p1 := `package foo
 	import data.bar.x
 
 	x := 1
-	`)
-	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", `package bar
+	`
+	p2 := `package bar
 	import data.foo.x
 
 	x := 1
-	`)
-	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
+	`
+	r := rule.aggregate_report with input.aggregates_internal as object.union(
+		_imports_agg("p1.rego", p1),
+		_imports_agg("p2.rego", p2),
+	)
 
 	r == set()
 }
 
 test_success_unresolved_imports_are_excepted if {
-	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
+	p1 := `package foo
 	import data.bar.x
 	import data.bar.excepted
 
 	x := 1
-	`)
-	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", `package bar
+	`
+	p2 := `package bar
 
 	x := 1
-	`)
-	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
+	`
+	r := rule.aggregate_report
+		with input.aggregates_internal as object.union(
+			_imports_agg("p1.rego", p1),
+			_imports_agg("p2.rego", p2),
+		)
 		with config.rules as {"imports": {"unresolved-import": {"except-imports": ["data.bar.excepted"]}}}
 
 	r == set()
 }
 
 test_success_unresolved_imports_with_wildcards_are_excepted if {
-	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
+	p1 := `package foo
 	import data.bar.x
 	import data.bar.excepted
 
 	x := 1
-	`)
+	`
 	r := rule.aggregate_report
-		with input as {"aggregate": agg1}
+		with input.aggregates_internal as _imports_agg("p1.rego", p1)
 		with config.rules as {"imports": {"unresolved-import": {"except-imports": ["data.bar.*"]}}}
 
 	r == set()
 }
 
 test_success_resolved_import_in_middle_of_explicit_paths if {
-	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
+	p1 := `package foo
 	import data.bar.x.y
-	`)
-	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", `package bar
+	`
+	p2 := `package bar
 
 	x.y.z := 1
-	`)
-	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
+	`
+	r := rule.aggregate_report with input.aggregates_internal as object.union(
+		_imports_agg("p1.rego", p1),
+		_imports_agg("p2.rego", p2),
+	)
 
 	r == set()
 }
 
 test_success_map_rule_resolves if {
-	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
+	p1 := `package foo
 	import data.bar.x
-	`)
-
-	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", `package bar
+	`
+	p2 := `package bar
 
 	x[y] := z if {
 		some y in input.ys
 		z := {"foo": y + 1}
 	}
-	`)
-	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
+	`
+	r := rule.aggregate_report with input.aggregates_internal as object.union(
+		_imports_agg("p1.rego", p1),
+		_imports_agg("p2.rego", p2),
+	)
 
 	r == set()
 }
 
 test_success_map_rule_may_resolve_so_allow if {
-	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
+	p1 := `package foo
 	import data.bar.x.y
-	`)
-
-	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", `package bar
+	`
+	p2 := `package bar
 
 	x[y] := z if {
 		some y in input.ys
 		z := {"foo": y + 1}
 	}
-	`)
-	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
+	`
+	r := rule.aggregate_report with input.aggregates_internal as object.union(
+		_imports_agg("p1.rego", p1),
+		_imports_agg("p2.rego", p2),
+	)
 
 	r == set()
 }
 
 test_success_general_ref_head_rule_may_resolve_so_allow if {
-	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
+	p1 := `package foo
 	import data.bar.x.foo.z.bar
-	`)
-
-	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", `package bar
+	`
+	p2 := `package bar
 
 	x[y].z[foo] := z if {
 		some y in input.ys
 		z := {"foo": y + 1}
 	}
-	`)
-	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
+	`
+	r := rule.aggregate_report with input.aggregates_internal as object.union(
+		_imports_agg("p1.rego", p1),
+		_imports_agg("p2.rego", p2),
+	)
 
 	r == set()
 }
 
 test_success_custom_rule_not_flagging_regal_import if {
-	agg := rule.aggregate with input as regal.parse_module("p2.rego", `package custom.regal.bar
+	p1 := `package custom.regal.bar
 	import data.regal.ast
 
 	x := 1
-	`)
-	r := rule.aggregate_report with input as {"aggregate": agg}
+	`
+	r := rule.aggregate_report with input.aggregates_internal as _imports_agg("p1.rego", p1)
 
 	r == set()
 }
@@ -182,4 +197,16 @@ with_location(location) := {
 		"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/unresolved-import",
 	}],
 	"title": "unresolved-import",
+}
+
+_lines(policy) := split(policy, "\n")
+
+_imports_agg(name, policy) := agg if {
+	# regal ignore: with-outside-test-context
+	aggregated := aggregators with input as regal.parse_module(name, policy)
+	agg := {name: {"common": {{
+		"imports": aggregated.imports,
+		"lines": split(policy, "\n"),
+		"rule_tree": aggregated.rule_tree,
+	}}}}
 }

--- a/bundle/regal/rules/imports/unresolved-reference/unresolved_reference.rego
+++ b/bundle/regal/rules/imports/unresolved-reference/unresolved_reference.rego
@@ -5,41 +5,47 @@
 #     ref: https://www.openpolicyagent.org/projects/regal/rules/imports/unresolved-reference
 package regal.rules.imports["unresolved-reference"]
 
+import future.keywords.not
+
+import data.regal.aggregated
 import data.regal.ast
 import data.regal.config
 import data.regal.result
 
 # METADATA
 # description: collects exported and full of used refs from each module
-aggregate contains entry if {
-	exported := {rule |
-		some rule, _ in ast.rule_head_locations
-		not rule in unexported_rules
+aggregate contains {"expanded_refs": _all_full_path_refs}
+
+# METADATA
+# schemas:
+#   - input: schema.regal.aggregate
+aggregate_report contains violation if {
+	rule_tree := aggregated.rule_tree
+
+	some name, files in _aggregated_refs
+
+	# ignore everything from the first "[" in the ref name. E.g. foo.bar[0].baz becomes foo.bar
+	ref_name := regex.replace(name, `^([^\[]+)\[.*`, "$1")
+	ref_path := split(ref_name, ".")
+
+	# a reference is considered resolved with respect to a rule if
+	# it indexes into a rule, or is the prefix of a rule, or the
+	# reference is ignored in the config
+	not _is_resolved_ref(ref_path, rule_tree)
+	not {
+		some exception in config.rules.imports["unresolved-reference"]["except-paths"]
+		glob.match(exception, [], ref_name)
 	}
 
-	entry := {
-		"exported_rules": exported,
-		"expanded_refs": _all_full_path_refs,
-		"prefix_set": {["data"]} | {prefix_path |
-			some rule_name in exported
-			rule_path := split(rule_name, ".")
-			some i in numbers.range(2, count(rule_path))
-			prefix_path := array.slice(rule_path, 0, i)
-		},
-	}
+	some file, locations in files
+	some location in locations
+
+	violation := result.fail(rego.metadata.chain(), aggregated.location_object(location, file))
 }
 
 default _excepted_export_patterns := {"**.test_*"}
 
 _excepted_export_patterns := config.rules.imports["unresolved-reference"].excepted_export_patterns
-
-# METADATA
-# description: removes rules that are ignored in the config file
-unexported_rules contains rule_name if {
-	some rule_name, _ in ast.rule_head_locations
-	some exception in _excepted_export_patterns
-	glob.match(exception, [], rule_name)
-}
 
 # an import is shadowed if it shares name with a rule
 _shadowed_imports contains rule_name if {
@@ -53,101 +59,50 @@ _shadowed_imports contains var_name if {
 	ast.resolved_imports[var_name]
 }
 
-_refs contains ref if {
-	terms := ast.found.refs[_][_].value
-	terms[0].value != "input"
+_refs[name] contains terms[0].location if {
+	some rule_index
+	terms := ast.found.refs[rule_index][_].value
+	head := terms[0].value
+	head != "input"
 
 	name := ast.ref_static_to_string(terms)
 
 	not name in ast.builtin_names
 	not name in ast.rule_and_function_names
-	not name in unexported_rules
-
-	not terms[0].value in _shadowed_imports
-
-	row := to_number(regex.replace(terms[0].location, `^(\d+):.*`, "$1"))
-	ref := {
-		"name": name,
-		"text": input.regal.file.lines[row - 1],
-		"location": terms[0].location,
-	}
+	not head in _shadowed_imports
 }
 
-_all_full_path_refs[ref.name] contains [ref.location, ref.text] if {
-	some ref in _refs
-	startswith(ref.name, "data.")
+_all_full_path_refs[name] contains location if {
+	some name, locations in _refs
+
+	startswith(name, "data.")
+
+	some location in locations
 }
 
-_all_full_path_refs[expanded] contains [ref.location, ref.text] if {
-	some ref in _refs
+_all_full_path_refs[expanded] contains location if {
+	some name, locations in _refs
 
-	ref_root := regex.replace(ref.name, `^([^\.]+)\..*`, "$1") # anything before the first ".", like "bar" in "foo.bar"
+	ref_root := regex.replace(name, `^([^\.]+)\..*`, "$1") # anything before the first ".", like "bar" in "foo.bar"
 	resolved := concat(".", ast.resolved_imports[ref_root]) #    resolve that root, e.g. "data.regal.foo"
-	expanded := regex.replace(ref.name, `^([^\.]+)`, resolved) # add back the suffix, e.g. "data.regal.foo.bar"
+	expanded := regex.replace(name, `^([^\.]+)`, resolved) # add back the suffix, e.g. "data.regal.foo.bar"
+
+	some location in locations
 }
 
-# METADATA
-# schemas:
-#   - input: schema.regal.aggregate
-aggregate_report contains violation if {
-	all_exports := {export | export := _aggregates[_][_].exported_rules[_]}
-	prefix_set := {prefix | prefix := _aggregates[_][_].prefix_set[_]}
-
+_aggregated_refs[name][file] := locations if {
 	some file
 	entry := _aggregates[file][_]
-	some name, refs in entry.expanded_refs
 
-	# ignore everything from the first "[" in the ref name. E.g. foo.bar[0].baz becomes foo.bar
-	ref_name := regex.replace(name, `^([^\[]+)\[.*`, "$1")
-	ref_path := split(ref_name, ".")
-
-	# a reference is considered resolved with respect to a rule if
-	# 1: it is the prefix of a rule
-	# 2: it indexes into a rule - we do not consider the possible data
-	# 3: the reference is ignored in the config
-	not ref_path in prefix_set
-	not _is_resolved_ref(ref_path, all_exports)
-	not _is_excepted(ref_name)
-
-	some ref in refs
-
-	violation := result.fail(rego.metadata.chain(), _to_location_object(ref[0], ref[1], file))
+	some name, locations in entry.expanded_refs
 }
 
-_is_excepted(ref_full_name) if {
-	some exception in config.rules.imports["unresolved-reference"]["except-paths"]
-	glob.match(exception, [], ref_full_name)
-}
+_is_resolved_ref(ref_path, rule_tree) if is_object(object.get(rule_tree, ref_path, false))
 
-_is_resolved_ref(ref_full_path, all_exports) if {
-	some i in numbers.range(1, count(ref_full_path))
-	path_prefix := concat(".", array.slice(ref_full_path, 0, i))
+_is_resolved_ref(ref_path, rule_tree) if {
+	some i in numbers.range(1, count(ref_path))
 
-	path_prefix in all_exports
-}
-
-# like util.to_location_object, but with text and file passed in
-# as we don't have access to the usual input.regal.file attributes
-# in the context of reporting aggregated data
-_to_location_object(loc, text, file) := {"location": {
-	"file": file,
-	"row": row,
-	"col": col,
-	"text": text,
-	"end": {
-		"row": row,
-		"col": end_col,
-	},
-}} if {
-	vals := split(loc, ":")
-
-	row := to_number(vals[0])
-	col := to_number(vals[1])
-
-	from_col := substring(text, col - 1, -1)
-	ref_text := substring(from_col, 0, indexof(from_col, " "))
-
-	end_col := col + count(ref_text)
+	object.get(rule_tree, array.slice(ref_path, 0, i), false) == {} # regal ignore:superfluous-object-get
 }
 
 # METADATA

--- a/bundle/regal/rules/imports/unresolved-reference/unresolved_reference_test.rego
+++ b/bundle/regal/rules/imports/unresolved-reference/unresolved_reference_test.rego
@@ -6,30 +6,26 @@ import data.regal.util
 import data.regal.rules.imports["unresolved-reference"] as rule
 
 test_fail_identifies_unresolved_reference if {
-	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
-	import data.bar
+	p1 := "package foo\n\nimport data.bar\nx := bar.baz\n"
+	p2 := "package bar\n\nx := 1\n"
 
-	x := bar.baz
-	`)
-	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", `package bar
+	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", p1)
+	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", p2)
 
-	x := 1
-	`)
-
-	r := rule.aggregate_report with input.aggregates_internal as util.with_source_files(
-		"imports/unresolved-reference",
-		[agg1, agg2],
-	)
+	r := rule.aggregate_report
+		with input.aggregates_internal as util.with_source_files("imports/unresolved-reference", [agg1, agg2])
+		with input.aggregates_internal["p1.rego"].common as _lines(p1)
+		with input.aggregates_internal["p2.rego"].common as _lines(p2)
 
 	r == {with_location({
 		"file": "p1.rego",
 		"row": 4,
-		"col": 7,
+		"col": 6,
 		"end": {
 			"row": 4,
-			"col": 14,
+			"col": 13,
 		},
-		"text": "\tx := bar.baz",
+		"text": "x := bar.baz",
 	})}
 }
 
@@ -48,30 +44,26 @@ test_success_no_unresolved_reference if {
 }
 
 test_fail_identifies_unresolved_reference_with_alias if {
-	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
-	import data.bar as baz
+	p1 := "package foo\n\nimport data.bar as baz\nx := baz.qux\n"
+	p2 := "package bar\n\nx := 1\n"
 
-	x := baz.qux
-	`)
-	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", `package bar
+	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", p1)
+	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", p2)
 
-	x := 1
-	`)
-
-	r := rule.aggregate_report with input.aggregates_internal as util.with_source_files(
-		"imports/unresolved-reference",
-		[agg1, agg2],
-	)
+	r := rule.aggregate_report
+		with input.aggregates_internal as util.with_source_files("imports/unresolved-reference", [agg1, agg2])
+		with input.aggregates_internal["p1.rego"].common as _lines(p1)
+		with input.aggregates_internal["p2.rego"].common as _lines(p2)
 
 	r == {with_location({
 		"file": "p1.rego",
 		"row": 4,
-		"col": 7,
+		"col": 6,
 		"end": {
 			"row": 4,
-			"col": 14,
+			"col": 13,
 		},
-		"text": "\tx := baz.qux",
+		"text": "x := baz.qux",
 	})}
 }
 
@@ -91,29 +83,26 @@ test_success_identifies_reference_with_alias if {
 }
 
 test_fail_identifies_unresolved_full_path if {
-	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
+	p1 := "package foo\n\nx := data.bar.baz\n"
+	p2 := "package bar\n\nx := 1\n"
 
-	x := data.bar.baz
-	`)
-	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", `package bar
+	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", p1)
+	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", p2)
 
-	x := 1
-	`)
-
-	r := rule.aggregate_report with input.aggregates_internal as util.with_source_files(
-		"imports/unresolved-reference",
-		[agg1, agg2],
-	)
+	r := rule.aggregate_report
+		with input.aggregates_internal as util.with_source_files("imports/unresolved-reference", [agg1, agg2])
+		with input.aggregates_internal["p1.rego"].common as _lines(p1)
+		with input.aggregates_internal["p2.rego"].common as _lines(p2)
 
 	r == {with_location({
 		"file": "p1.rego",
 		"row": 3,
-		"col": 7,
+		"col": 6,
 		"end": {
 			"row": 3,
-			"col": 19,
+			"col": 18,
 		},
-		"text": "\tx := data.bar.baz",
+		"text": "x := data.bar.baz",
 	})}
 }
 
@@ -132,31 +121,28 @@ test_success_identifies_full_path if {
 }
 
 test_fail_everything_all_at_once if {
-	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
+	p1 := `package foo
 	import data.bar
 	import data.baz as qux
 
 	x := bar.unknown
 	y := qux.unknown
-	z := data.qux.unknown
-	`)
-	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", `package bar
+	z := data.qux.unknown`
+	p2 := "package bar\n\nknown := 1\n"
+	p3 := "package baz\n\nknown := 1\n"
+	p4 := "package qux\n\nknown := 1\n"
 
-	known := 1
-	`)
-	agg3 := rule.aggregate with input as regal.parse_module("p3.rego", `package baz
+	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", p1)
+	agg2 := rule.aggregate with input as regal.parse_module("p2.rego", p2)
+	agg3 := rule.aggregate with input as regal.parse_module("p3.rego", p3)
+	agg4 := rule.aggregate with input as regal.parse_module("p4.rego", p4)
 
-	known := 1
-	`)
-	agg4 := rule.aggregate with input as regal.parse_module("p4.rego", `package qux
-
-	known := 1
-	`)
-
-	r := rule.aggregate_report with input.aggregates_internal as util.with_source_files(
-		"imports/unresolved-reference",
-		[agg1, agg2, agg3, agg4],
-	)
+	r := rule.aggregate_report
+		with input.aggregates_internal as util.with_source_files(
+			"imports/unresolved-reference",
+			[agg1, agg2, agg3, agg4],
+		)
+		with input.aggregates_internal["p1.rego"].common as _lines(p1)
 
 	r == {
 		with_location({
@@ -264,30 +250,27 @@ test_success_builtin_names_are_ignored if {
 }
 
 test_fail_builtin_namespaces_are_not_ignored if {
-	agg := rule.aggregate with input as regal.parse_module("p1.rego", `package bar
-	import data.time
+	p1 := "package bar\nimport data.time\n\nfun(foo) := time.now_nss\n"
 
-	fun(foo) := time.now_nss
-	`)
+	agg := rule.aggregate
+		with input as regal.parse_module("p1.rego", p1)
 		with data.regal.ast.builtin_names as {"time.now_ns"}
 		with data.regal.ast.builtin_namespaces as {"time"}
 
-	r := rule.aggregate_report with input.aggregates_internal as util.with_source_files(
-		"imports/unresolved-reference",
-		[agg],
-	)
+	r := rule.aggregate_report
+		with input.aggregates_internal as util.with_source_files("imports/unresolved-reference", [agg])
+		with input.aggregates_internal["p1.rego"].common as _lines(p1)
 
-	expected := {with_location({
+	r == {with_location({
 		"file": "p1.rego",
 		"row": 4,
-		"col": 14,
+		"col": 13,
 		"end": {
 			"row": 4,
-			"col": 26,
+			"col": 25,
 		},
-		"text": "\tfun(foo) := time.now_nss",
+		"text": "fun(foo) := time.now_nss",
 	})}
-	r == expected
 }
 
 test_success_ignored_paths_are_ignored if {
@@ -307,10 +290,11 @@ with_location(location) := {
 	"description": "Unresolved Reference",
 	"level": "error",
 	"location": location,
-	# "location": location,
 	"related_resources": [{
 		"description": "documentation",
 		"ref": "https://www.openpolicyagent.org/projects/regal/rules/imports/unresolved-reference",
 	}],
 	"title": "unresolved-reference",
 }
+
+_lines(policy) := {{"lines": split(policy, "\n")}}

--- a/internal/lsp/server_multi_file_test.go
+++ b/internal/lsp/server_multi_file_test.go
@@ -22,24 +22,14 @@ func TestLanguageServerMultipleFiles(t *testing.T) {
 	files := map[string]string{
 		"authz.rego": `package authz
 
-import rego.v1
-
 import data.admins.users
 
 default allow := false
 
 allow if input.user in users
 `,
-		"admins.rego": `package admins
-
-import rego.v1
-
-users = {"alice", "bob"}
-`,
-		"ignored/foo.rego": `package ignored
-
-foo = 1
-`,
+		"admins.rego":      "package admins\n\nusers = {\"alice\", \"bob\"}\n",
+		"ignored/foo.rego": "package ignored\n\nfoo = 1\n",
 		".regal/config.yaml": `
 rules:
   idiomatic:

--- a/pkg/linter/linter_bench_test.go
+++ b/pkg/linter/linter_bench_test.go
@@ -35,6 +35,8 @@ func BenchmarkRegalLintingItself(b *testing.B) {
 // 403083139 ns/op	1520423272 B/op	36511766 allocs/op // 3 new rules added
 // 350271889 ns/op	1180526954 B/op	33308189 allocs/op // 2 new rules added
 // 371014222 ns/op	1246251634 B/op	35248709 allocs/op // Lots of new Rego code (to lint) added
+// 370440556 ns/op	1247207368 B/op	35345393 allocs/op // ... some time later ...
+// 367091361 ns/op	1236597106 B/op	34901438 allocs/op // Unified aggregates
 func BenchmarkRegalLintingItselfPrepareOnce(b *testing.B) {
 	benchmarkLint(b, bundleLinter(b, true).MustPrepare(b.Context()))
 }

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -369,7 +369,7 @@ func TestLintWithCollectQuery(t *testing.T) {
 
 	must.Equal(t, 1, result.Aggregates.Len(), "aggregates count")
 
-	_, err := result.Aggregates.Find(util.Map([]string{"p.rego", "imports/unresolved-import"}, ast.InternedTerm))
+	_, err := result.Aggregates.Find(util.Map([]string{"p.rego", "common"}, ast.InternedTerm))
 
-	assert.Equal(t, nil, err, "expected aggregates to contain 'p.rego/imports/unresolved-import'")
+	assert.Equal(t, nil, err, "expected aggregates to contain 'p.rego/common'")
 }


### PR DESCRIPTION
This PR unifies aggregation of data and some aggregated reports in a centralized manner, allowing multiple aggregate rules to share data and reported aggregates between them.

Included here is also a new aggregate that collects a rule tree from each linted package, similarly to how the OPA compiler does it. Having a rule tree aggregated from all modules means that we now also easily can extract e.g. all the tests from the module, greatly simplifying how these are collected. Or implement the references feature from the language server spec. And so on! Querying the rule tree for a particular node is as easy as calling `object.get`, and for more advanced queries we can `walk`.

We'll also need to aggregate location data for more advanced things, but since we're preparing for a release, I'll leave it here until v0.41.0 is out!

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->