### PR TITLE
Use common aggregate data in circular-import

### DIFF
--- a/bundle/regal/rules/imports/circular-import/circular_import.rego
+++ b/bundle/regal/rules/imports/circular-import/circular_import.rego
@@ -11,25 +11,9 @@ import data.regal.ast
 import data.regal.result
 import data.regal.util
 
-_refs[str] contains ref.location if {
-	some ref
-	ast.found.refs[_][ref].value[0].value == "data"
-	ast.static_ref(ref)
-
-	str := concat(".", [term.value | some term in ref.value])
-}
-
-_refs[ref] contains imported.path.location if {
-	some imported in ast.imports
-
-	imported.path.value[0].value == "data"
-
-	ref := concat(".", [term.value | some term in imported.path.value])
-}
-
 # METADATA
 # description: collects refs from module, if any
-aggregate contains {"package_name": ast.package_name_full, "refs": _refs} if _refs != {}
+aggregate contains {"refs": _refs} if _refs != {}
 
 # METADATA
 # schemas:
@@ -77,19 +61,41 @@ aggregate_report contains violation if {
 	})
 }
 
+_refs[str] contains ref.location if {
+	some ref
+	ast.found.refs[_][ref].value[0].value == "data"
+	ast.static_ref(ref)
+
+	str := concat(".", [term.value | some term in ref.value])
+}
+
+_refs[ref] contains imported.path.location if {
+	some imported in ast.imports
+
+	imported.path.value[0].value == "data"
+
+	ref := concat(".", [term.value | some term in imported.path.value])
+}
+
 # METADATA
 # schemas:
 #   - input: schema.regal.aggregate
-_package_locations[referenced_pkg][pkg.package_name] := [file, util.any_set_item(referenced_locations)] if {
+_package_locations[referenced_pkg][package_name] := [file, util.any_set_item(referenced_locations)] if {
 	some file, pkg in _aggregated
+
+	package_name := _common[file].package_name_full
+
 	some referenced_pkg, referenced_locations in pkg.refs
 }
 
 # METADATA
 # schemas:
 #   - input: schema.regal.aggregate
-_import_graph[pkg.package_name] contains str if {
-	some pkg in _aggregated
+_import_graph[package_name] contains str if {
+	some file, pkg in _aggregated
+
+	package_name := _common[file].package_name_full
+
 	some str, _ in pkg.refs
 }
 
@@ -118,4 +124,9 @@ _aggregated[file] := agg if {
 	# so we can simplify things some for our callers
 	some file
 	agg := input.aggregates_internal[file]["imports/circular-import"][_]
+}
+
+_common[file] := agg if {
+	some file
+	agg := input.aggregates_internal[file].common[_]
 }

--- a/bundle/regal/rules/imports/circular-import/circular_import_test.rego
+++ b/bundle/regal/rules/imports/circular-import/circular_import_test.rego
@@ -21,7 +21,7 @@ test_aggregate_rule_contains_single_self_ref if {
 		with input as ast.policy("import data.example")
 		with ast.package_name_full as "data.policy"
 
-	aggregate == {{"refs": {"data.example": {"3:8:3:20"}}, "package_name": "data.policy"}}
+	aggregate == {{"refs": {"data.example": {"3:8:3:20"}}}}
 }
 
 test_aggregate_rule_surfaces_refs if {
@@ -42,40 +42,37 @@ test_aggregate_rule_surfaces_refs if {
     }
     `)
 
-	aggregate == {{
-		"refs": {
-			"data.config.deny.enabled": {"11:7:11:31"},
-			"data.foo.bar": {"6:12:6:24"},
-			"data.baz.qux": {"8:14:8:26"},
-		},
-		"package_name": "data.policy.foo",
-	}}
+	aggregate == {{"refs": {
+		"data.config.deny.enabled": {"11:7:11:31"},
+		"data.foo.bar": {"6:12:6:24"},
+		"data.baz.qux": {"8:14:8:26"},
+	}}}
 }
 
 test_import_graph if {
 	r := rule._import_graph with input.aggregates_internal as {
-		"a.rego": {"imports/circular-import": {{
-			"refs": {"data.policy.b": {"3:12:3:12"}},
-			"package_name": "data.policy.a",
-		}}},
-		"b.rego": {"imports/circular-import": {{
-			"refs": {"data.policy.c": {"3:12:3:12"}},
-			"package_name": "data.policy.b",
-		}}},
-		"c.rego": {"imports/circular-import": {{
-			"refs": {"data.policy.a": {"3:12:3:12"}},
-			"package_name": "data.policy.c",
-		}}},
+		"a.rego": {
+			"common": {{"package_name_full": "data.policy.a"}},
+			"imports/circular-import": {{"refs": {"data.policy.b": {"3:12:3:12"}}}},
+		},
+		"b.rego": {
+			"common": {{"package_name_full": "data.policy.b"}},
+			"imports/circular-import": {{"refs": {"data.policy.c": {"3:12:3:12"}}}},
+		},
+		"c.rego": {
+			"common": {{"package_name_full": "data.policy.c"}},
+			"imports/circular-import": {{"refs": {"data.policy.a": {"3:12:3:12"}}}},
+		},
 	}
 
 	r == {"data.policy.a": {"data.policy.b"}, "data.policy.b": {"data.policy.c"}, "data.policy.c": {"data.policy.a"}}
 }
 
 test_import_graph_self_import if {
-	r := rule._import_graph with input.aggregates_internal as {"example.rego": {"imports/circular-import": {{
-		"refs": {"data.example": {"4:12:4:12"}},
-		"package_name": "data.example",
-	}}}}
+	r := rule._import_graph with input.aggregates_internal as {"example.rego": {
+		"common": {{"package_name_full": "data.example"}},
+		"imports/circular-import": {{"refs": {"data.example": {"4:12:4:12"}}}},
+	}}
 
 	r == {"data.example": {"data.example"}}
 }
@@ -106,18 +103,18 @@ test_groups_empty_graph if {
 
 test_package_locations if {
 	r := rule._package_locations with input.aggregates_internal as {
-		"a.rego": {"imports/circular-import": {{
-			"refs": {"data.policy.b": {"3:12:3:12"}},
-			"package_name": "data.policy.a",
-		}}},
-		"b.rego": {"imports/circular-import": {{
-			"refs": {"data.policy.c": {"3:12:3:12"}},
-			"package_name": "data.policy.b",
-		}}},
-		"c.rego": {"imports/circular-import": {{
-			"refs": {"data.policy.a": {"3:12:3:12"}},
-			"package_name": "data.policy.c",
-		}}},
+		"a.rego": {
+			"common": {{"package_name_full": "data.policy.a"}},
+			"imports/circular-import": {{"refs": {"data.policy.b": {"3:12:3:12"}}}},
+		},
+		"b.rego": {
+			"common": {{"package_name_full": "data.policy.b"}},
+			"imports/circular-import": {{"refs": {"data.policy.c": {"3:12:3:12"}}}},
+		},
+		"c.rego": {
+			"common": {{"package_name_full": "data.policy.c"}},
+			"imports/circular-import": {{"refs": {"data.policy.a": {"3:12:3:12"}}}},
+		},
 	}
 
 	r == {
@@ -129,14 +126,14 @@ test_package_locations if {
 
 test_aggregate_report_fails_when_cycle_present if {
 	r := rule.aggregate_report with input.aggregates_internal as {
-		"a.rego": {"imports/circular-import": {{
-			"refs": {"data.policy.b": {"3:12:3:12"}},
-			"package_name": "data.policy.a",
-		}}},
-		"b.rego": {"imports/circular-import": {{
-			"refs": {"data.policy.a": {"2:0:2:0"}},
-			"package_name": "data.policy.b",
-		}}},
+		"a.rego": {
+			"common": {{"package_name_full": "data.policy.a"}},
+			"imports/circular-import": {{"refs": {"data.policy.b": {"3:12:3:12"}}}},
+		},
+		"b.rego": {
+			"common": {{"package_name_full": "data.policy.b"}},
+			"imports/circular-import": {{"refs": {"data.policy.a": {"2:0:2:0"}}}},
+		},
 	}
 
 	r == {{
@@ -161,10 +158,10 @@ test_aggregate_report_fails_when_cycle_present if {
 }
 
 test_aggregate_report_fails_when_cycle_present_in_1_package if {
-	r := rule.aggregate_report with input.aggregates_internal as {"a.rego": {"imports/circular-import": {{
-		"refs": {"data.policy.a": {"3:12:3:12"}},
-		"package_name": "data.policy.a",
-	}}}}
+	r := rule.aggregate_report with input.aggregates_internal as {"a.rego": {
+		"common": {{"package_name_full": "data.policy.a"}},
+		"imports/circular-import": {{"refs": {"data.policy.a": {"3:12:3:12"}}}},
+	}}
 
 	r == {{
 		"category": "imports",
@@ -188,18 +185,18 @@ test_aggregate_report_fails_when_cycle_present_in_1_package if {
 
 test_aggregate_report_fails_when_cycle_present_in_n_packages if {
 	r := rule.aggregate_report with input.aggregates_internal as {
-		"a.rego": {"imports/circular-import": {{
-			"refs": {"data.policy.b": {"3:12:3:12"}},
-			"package_name": "data.policy.a",
-		}}},
-		"b.rego": {"imports/circular-import": {{
-			"refs": {"data.policy.c": {"3:12:3:12"}},
-			"package_name": "data.policy.b",
-		}}},
-		"c.rego": {"imports/circular-import": {{
-			"refs": {"data.policy.a": {"3:12:3:12"}},
-			"package_name": "data.policy.c",
-		}}},
+		"a.rego": {
+			"common": {{"package_name_full": "data.policy.a"}},
+			"imports/circular-import": {{"refs": {"data.policy.b": {"3:12:3:12"}}}},
+		},
+		"b.rego": {
+			"common": {{"package_name_full": "data.policy.b"}},
+			"imports/circular-import": {{"refs": {"data.policy.c": {"3:12:3:12"}}}},
+		},
+		"c.rego": {
+			"common": {{"package_name_full": "data.policy.c"}},
+			"imports/circular-import": {{"refs": {"data.policy.a": {"3:12:3:12"}}}},
+		},
 	}
 
 	r == {{


### PR DESCRIPTION
Just a tiny follow-up on the last change.

This does not block next release in any way.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->