### PR TITLE
perf: remove a million allocations with this one simple trick

### DIFF
--- a/bundle/regal/ast/search.rego
+++ b/bundle/regal/ast/search.rego
@@ -137,7 +137,7 @@ found.vars[rule_index].term contains var if {
 	fn_name := ref_static_to_string(call[0].value)
 	undeclared_start := count(all_functions[fn_name].decl.args) + 1
 
-	call[undeclared_start]
+	_ = call[undeclared_start]
 	fn_name != "print"
 
 	some var in find_term_vars(array.slice(call, undeclared_start, 100))
@@ -236,7 +236,7 @@ found.expressions[rule_index] contains value if {
 
 	walk(rule[node], [_, value])
 
-	value.terms
+	_ = value.terms
 }
 
 # METADATA
@@ -258,8 +258,7 @@ is_in_local_scope(rule, location, value) if {
 #   assignments / unification, but it's likely good enough since other rules
 #   recommend against those
 find_vars_in_local_scope(rule, location) := [var |
-	some var
-	found.vars[_rule_index(rule)][_][var]
+	var := found.vars[_rule_index(rule)][_][_]
 
 	not startswith(var.value, "$")
 	_before_location(rule.head, var, util.to_location_object(location))

--- a/bundle/regal/rules/bugs/impossible-not/impossible_not.rego
+++ b/bundle/regal/rules/bugs/impossible-not/impossible_not.rego
@@ -15,7 +15,7 @@ _package_path := [term.value | some term in input.package.path]
 _multivalue_rules contains path if {
 	some rule in ast.rules
 
-	rule.head.key
+	_ = rule.head.key
 	not rule.head.value
 
 	# ignore general ref head rules for now

--- a/bundle/regal/rules/bugs/not-equals-in-loop/not_equals_in_loop.rego
+++ b/bundle/regal/rules/bugs/not-equals-in-loop/not_equals_in_loop.rego
@@ -12,10 +12,7 @@ report contains violation if {
 	some rule_index, i
 	ast.found.expressions[rule_index][i].terms[0].type == "ref"
 
-	expr := ast.found.expressions[rule_index][i]
-	not expr.interpolated
-
-	terms := expr.terms
+	terms := ast.found.expressions[rule_index][i].terms
 
 	terms[0].type == "ref"
 	terms[0].value[0].type == "var"
@@ -23,6 +20,8 @@ report contains violation if {
 
 	some neq_term in array.slice(terms, 1, 100)
 	neq_term.type == "ref"
+
+	not ast.found.expressions[rule_index][i].interpolated
 
 	some value in neq_term.value
 	ast.is_wildcard(value)

--- a/bundle/regal/rules/imports/unresolved-reference/unresolved_reference.rego
+++ b/bundle/regal/rules/imports/unresolved-reference/unresolved_reference.rego
@@ -50,13 +50,13 @@ _excepted_export_patterns := config.rules.imports["unresolved-reference"].except
 # an import is shadowed if it shares name with a rule
 _shadowed_imports contains rule_name if {
 	some rule_name in ast.rule_names
-	ast.resolved_imports[rule_name]
+	_ = ast.resolved_imports[rule_name]
 }
 
 # an import is shadowed if it shares name with a variable (or function argument)
 _shadowed_imports contains var_name if {
 	var_name := ast.found.vars[_][_][_].value
-	ast.resolved_imports[var_name]
+	_ = ast.resolved_imports[var_name]
 }
 
 _refs[name] contains terms[0].location if {

--- a/bundle/regal/rules/performance/non-loop-expression/non_loop_expression.rego
+++ b/bundle/regal/rules/performance/non-loop-expression/non_loop_expression.rego
@@ -81,7 +81,7 @@ _assign_vars(body) := {expr.terms[1].value |
 }
 
 _expr_vars(expr) := _term_vars(expr.terms) if not expr.with
-_expr_vars(expr) := array.flatten([_term_vars(expr.terms), _vars_no_builtins(expr.with)]) if expr.with
+_expr_vars(expr) := array.flatten([_term_vars(expr.terms), _vars_no_builtins(expr.with)]) if _ = expr.with
 
 _term_vars(terms) := _vars_no_builtins(terms[2]) if {
 	terms[0].type == "ref"

--- a/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator.rego
+++ b/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator.rego
@@ -16,7 +16,7 @@ report contains violation if {
 	# default foo(_) = "bar"
 	some rule in input.rules
 
-	rule.head.value.location
+	_ = rule.head.value.location
 	not rule.head.assign
 	not rule.head.key
 	not ast.is_chained_rule_body(rule, input.regal.file.lines)

--- a/internal/lsp/store/store.go
+++ b/internal/lsp/store/store.go
@@ -84,17 +84,6 @@ func Put[T any](ctx context.Context, store storage.Store, path storage.Path, val
 	})
 }
 
-func Get(ctx context.Context, store storage.Store, path storage.Path) (val ast.Value, err error) {
-	var res any
-	if res, err = storage.ReadOne(ctx, store, path); err == nil {
-		if v, ok := res.(ast.Value); ok {
-			val = v
-		}
-	}
-
-	return val, err
-}
-
 func Remove(ctx context.Context, store storage.Store, path storage.Path) error {
 	return storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
 		return remove(ctx, store, txn, path)

--- a/internal/test/must/must.go
+++ b/internal/test/must/must.go
@@ -68,15 +68,6 @@ func Write(tb testing.TB, w io.Writer, contents string) {
 	}
 }
 
-func ReadDir(tb testing.TB, path string) []os.DirEntry {
-	tb.Helper()
-
-	entries, err := os.ReadDir(path)
-	Equal(tb, nil, err, "failed to read directory %s", path)
-
-	return entries
-}
-
 func ReadFile(tb testing.TB, path string) string {
 	tb.Helper()
 
@@ -91,14 +82,6 @@ func WriteFile(tb testing.TB, path string, contents []byte) {
 
 	if err := os.WriteFile(path, contents, 0o600); err != nil {
 		tb.Fatalf("failed to write file %s: %v", path, err)
-	}
-}
-
-func Remove(tb testing.TB, path string) {
-	tb.Helper()
-
-	if err := os.Remove(path); err != nil {
-		tb.Fatalf("failed to remove file %s: %v", path, err)
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -29,16 +29,6 @@ func NewServer(logger *log.Logger) *Server {
 	return &Server{log: logger}
 }
 
-func (s *Server) GetBaseURL() string {
-	return s.baseURL
-}
-
-// SetBaseURL sets the base URL for the server
-// NOTE: This is normally set by the server itself, and this method is provided only for testing purposes.
-func (s *Server) SetBaseURL(baseURL string) {
-	s.baseURL = baseURL
-}
-
 func (s *Server) Start(context.Context) {
 	mux := http.NewServeMux()
 	if err := statsviz.Register(mux); err != nil {

--- a/pkg/linter/linter_bench_test.go
+++ b/pkg/linter/linter_bench_test.go
@@ -37,6 +37,7 @@ func BenchmarkRegalLintingItself(b *testing.B) {
 // 371014222 ns/op	1246251634 B/op	35248709 allocs/op // Lots of new Rego code (to lint) added
 // 370440556 ns/op	1247207368 B/op	35345393 allocs/op // ... some time later ...
 // 367091361 ns/op	1236597106 B/op	34901438 allocs/op // Unified aggregates
+// 364328681 ns/op	1212708122 B/op	33820873 allocs/op // Ridiculous _ = value.terms hack
 func BenchmarkRegalLintingItselfPrepareOnce(b *testing.B) {
 	benchmarkLint(b, bundleLinter(b, true).MustPrepare(b.Context()))
 }

--- a/pkg/roast/transform/transform.go
+++ b/pkg/roast/transform/transform.go
@@ -4,15 +4,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
-
-	jsoniter "github.com/json-iterator/go"
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
 	"github.com/open-policy-agent/regal/internal/roast/transforms"
 	"github.com/open-policy-agent/regal/internal/roast/transforms/module"
-	"github.com/open-policy-agent/regal/pkg/roast/encoding"
 	"github.com/open-policy-agent/regal/pkg/roast/rast"
 
 	_ "github.com/open-policy-agent/regal/internal/roast/encoding"
@@ -37,21 +33,6 @@ var (
 // unmarshaled from RoAST JSON. Don't use it for anything else.
 func AnyToValue(x any) (ast.Value, error) {
 	return transforms.AnyToValue(x)
-}
-
-// ToOPAInputValue converts provided x to an ast.Value suitable for use as
-// parsed input to OPA (`rego.EvalParsedInput`). This will have the value
-// pass through the same kind of roundtrip as OPA would otherwise have to
-// do when provided unparsed input, but much more efficiently as both JSON
-// marshalling and the custom InterfaceToValue function provided here are
-// optimized for performance.
-func ToOPAInputValue(x any) (ast.Value, error) {
-	ptr := reference(x)
-	if err := anyPtrRoundTrip(ptr); err != nil {
-		return nil, err
-	}
-
-	return AnyToValue(*ptr)
 }
 
 // ToAST converts a Rego module to an ast.Value suitable for use as input in Regal.
@@ -113,41 +94,4 @@ func RegalContextWithOperations(name, content, regoVersion string, collect bool)
 	context.Insert(operations[0], operations[1])
 
 	return context
-}
-
-// From OPA's util package
-//
-// Reference returns a pointer to its argument unless the argument already is
-// a pointer. If the argument is **t, or ***t, etc, it will return *t.
-//
-// Used for preparing Go types (including pointers to structs) into values to be
-// put through util.RoundTrip().
-func reference(x any) *any {
-	var y any
-
-	rv := reflect.ValueOf(x)
-	if rv.Kind() == reflect.Pointer {
-		return reference(rv.Elem().Interface())
-	}
-
-	if rv.Kind() != reflect.Invalid {
-		y = rv.Interface()
-
-		return &y
-	}
-
-	return &x
-}
-
-func anyPtrRoundTrip(x *any) error {
-	bs, err := jsoniter.ConfigFastest.Marshal(x)
-	if err != nil {
-		return err
-	}
-
-	if err = jsoniter.ConfigFastest.Unmarshal(bs, x); err != nil {
-		return encoding.SafeNumberConfig.Unmarshal(bs, x)
-	}
-
-	return nil
 }


### PR DESCRIPTION
The OPA maintainer's hate him for it!

(there are _many_ more locations where we can do this, but I'd rather not have to clutter the code with voodoo, so this covers only the most costly allocs, of which ast.found.expressions is the worst by far)

Also getting rid of some dead Go code.