### PR TITLE
[lsp] Update find references and rename request to support "some" variables

### DIFF
--- a/bundle/regal/lsp/preparerename/preparerename.rego
+++ b/bundle/regal/lsp/preparerename/preparerename.rego
@@ -8,15 +8,15 @@ package regal.lsp.preparerename
 import data.regal.lsp.util.find
 import data.regal.lsp.util.range
 
-default result["response"] := null
-
 # METADATA
 # entrypoint: true
-result["response"] := response if {
-	[arg, _] := find.arg_at_position
+default result["response"] := null
 
-	response := {
-		"placeholder": arg.value,
-		"range": range.parse(arg.location),
-	}
+result["response"] := _response_for(arg) if [arg, _] := find.arg_at_position
+
+result["response"] := _response_for(var) if [var, _] := find.some_var_at_position
+
+_response_for(term) := {
+	"placeholder": term.value,
+	"range": range.parse(term.location),
 }

--- a/bundle/regal/lsp/preparerename/preparerename_test.rego
+++ b/bundle/regal/lsp/preparerename/preparerename_test.rego
@@ -1,0 +1,57 @@
+package regal.lsp.preparerename_test
+
+import data.regal.lsp.preparerename
+
+test_preparerename_arg if {
+	policy := `package p
+
+greet(name) := msg if {
+	msg := sprintf("hello, %s", [name])
+}`
+
+	resp := preparerename.result.response
+		with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 2, "character": 6}
+		with input.regal.file.lines as split(policy, "\n")
+
+	resp == {
+		"placeholder": "name",
+		"range": {"start": {"line": 2, "character": 6}, "end": {"line": 2, "character": 10}},
+	}
+}
+
+test_preparerename_some_var if {
+	policy := `package p
+
+list_admins contains admin if {
+	some user in input.users
+	user.role == "admin"
+	admin := user.name
+}`
+
+	resp := preparerename.result.response
+		with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 3, "character": 6}
+		with input.regal.file.lines as split(policy, "\n")
+
+	resp == {
+		"placeholder": "user",
+		"range": {"start": {"line": 3, "character": 6}, "end": {"line": 3, "character": 10}},
+	}
+}
+
+test_preparerename_no_match if {
+	policy := `package p
+
+simple := 42`
+
+	resp := preparerename.result.response
+		with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 2, "character": 11}
+		with input.regal.file.lines as split(policy, "\n")
+
+	resp == null
+}

--- a/bundle/regal/lsp/references/references.rego
+++ b/bundle/regal/lsp/references/references.rego
@@ -42,7 +42,8 @@ _arg_refs contains ref if {
 _some_var_refs contains ref if {
 	[var, rule_index] := find.some_var_at_position
 
-	walk(_module.rules[rule_index].body, [_, value])
+	some node in ["head", "body"]
+	walk(_module.rules[rule_index][node], [_, value])
 
 	value.type == "var"
 	value.value == var.value

--- a/bundle/regal/lsp/references/references.rego
+++ b/bundle/regal/lsp/references/references.rego
@@ -12,18 +12,50 @@ import data.regal.lsp.util.range
 
 # METADATA
 # entrypoint: true
-result.response contains reference if {
-	[arg, i] := find.arg_at_position
+result.response contains ref if some ref in _arg_refs
 
-	some expr in ast.found.expressions[i]
+result.response contains ref if some ref in _some_var_refs
 
-	walk(expr, [_, value])
+_arg_refs contains ref if {
+	[arg, rule_index] := find.arg_at_position
+	sref := ast.static_prefix(_module.rules[rule_index].head.ref)
+
+	some url, parsed in data.workspace.parsed
+	ast.ref_value_equal(_module.package.path, parsed.package.path)
+
+	some rule in parsed.rules
+	_has_arg_named(rule.head.args, arg.value)
+	ast.ref_value_equal(sref, ast.static_prefix(rule.head.ref))
+
+	some node in ["head", "body", "else"]
+	walk(rule[node], [_, value])
 
 	value.type == "var"
 	value.value == arg.value
 
-	reference := {
+	ref := {
+		"uri": url,
+		"range": range.parse(value.location),
+	}
+}
+
+_some_var_refs contains ref if {
+	[var, rule_index] := find.some_var_at_position
+
+	walk(_module.rules[rule_index].body, [_, value])
+
+	value.type == "var"
+	value.value == var.value
+
+	ref := {
 		"uri": input.params.textDocument.uri,
 		"range": range.parse(value.location),
 	}
 }
+
+_has_arg_named(args, name) if {
+	some arg in args
+	arg.value == name
+}
+
+_module := data.workspace.parsed[input.params.textDocument.uri]

--- a/bundle/regal/lsp/references/references_test.rego
+++ b/bundle/regal/lsp/references/references_test.rego
@@ -1,0 +1,72 @@
+package regal.lsp.references_test
+
+import data.regal.lsp.references
+
+test_references_arg_cross_file if {
+	policy_a := `package shared
+
+greet(name) := msg if {
+	msg := sprintf("hello, %s", [name])
+}`
+	policy_b := `package shared
+
+greet(name) := msg if {
+	count(name) > 50
+	msg := sprintf("hi %s", [name])
+}`
+
+	refs := references.result.response with data.workspace.parsed as {
+		"file:///a.rego": regal.parse_module("a.rego", policy_a),
+		"file:///b.rego": regal.parse_module("b.rego", policy_b),
+	}
+		with input.params.textDocument.uri as "file:///a.rego"
+		with input.params.position as {"line": 2, "character": 6}
+		with input.regal.file.lines as split(policy_a, "\n")
+
+	refs == {
+		{"uri": "file:///a.rego", "range": {"start": {"line": 2, "character": 6}, "end": {"line": 2, "character": 10}}},
+		{"uri": "file:///a.rego", "range": {"start": {"line": 3, "character": 30}, "end": {"line": 3, "character": 34}}},
+		{"uri": "file:///b.rego", "range": {"start": {"line": 2, "character": 6}, "end": {"line": 2, "character": 10}}},
+		{"uri": "file:///b.rego", "range": {"start": {"line": 3, "character": 7}, "end": {"line": 3, "character": 11}}},
+		{"uri": "file:///b.rego", "range": {"start": {"line": 4, "character": 26}, "end": {"line": 4, "character": 30}}},
+	}
+}
+
+test_references_some_var_single_rule if {
+	policy := `package p
+
+list_admins contains admin if {
+	some user in input.users
+	user.role == "admin"
+	admin := user.name
+}
+
+other_rule contains x if {
+	some user in input.items
+	x := user.label
+}`
+
+	refs := references.result.response with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 3, "character": 6}
+		with input.regal.file.lines as split(policy, "\n")
+
+	refs == {
+		{"uri": "file:///p.rego", "range": {"start": {"line": 3, "character": 6}, "end": {"line": 3, "character": 10}}},
+		{"uri": "file:///p.rego", "range": {"start": {"line": 4, "character": 1}, "end": {"line": 4, "character": 5}}},
+		{"uri": "file:///p.rego", "range": {"start": {"line": 5, "character": 10}, "end": {"line": 5, "character": 14}}},
+	}
+}
+
+test_references_no_match if {
+	policy := `package p
+
+foo := 42`
+
+	refs := references.result.response with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 2, "character": 11}
+		with input.regal.file.lines as split(policy, "\n")
+
+	refs == set()
+}

--- a/bundle/regal/lsp/rename/rename.rego
+++ b/bundle/regal/lsp/rename/rename.rego
@@ -6,9 +6,7 @@
 #   - input.params.newName: {type: "string"}
 package regal.lsp.rename
 
-import data.regal.ast
-import data.regal.lsp.util.find
-import data.regal.lsp.util.range
+import data.regal.lsp.references
 
 # METADATA
 # entrypoint: true
@@ -16,36 +14,11 @@ default result.response := null
 
 result.response := {"changes": _changes} if _changes != {}
 
-_changes[url] contains change if {
-	[arg, rule_index] := find.arg_at_position
-	sref := ast.static_prefix(_module.rules[rule_index].head.ref)
-
-	some url
-	ref := data.workspace.parsed[url].package.path
-
-	ast.ref_value_equal(_module.package.path, ref)
-
-	some rule in data.workspace.parsed[url].rules
-
-	_has_arg_named(rule.head.args, arg.value)
-	ast.ref_value_equal(sref, ast.static_prefix(rule.head.ref))
-
-	some node in ["head", "body", "else"]
-
-	walk(rule[node], [_, value])
-
-	value.type == "var"
-	value.value == arg.value
+_changes[ref.uri] contains change if {
+	some ref in references.result.response
 
 	change := {
-		"range": range.parse(value.location),
+		"range": ref.range,
 		"newText": input.params.newName,
 	}
 }
-
-_has_arg_named(args, name) if {
-	some arg in args
-	arg.value == name
-}
-
-_module := data.workspace.parsed[input.params.textDocument.uri]

--- a/bundle/regal/lsp/rename/rename_test.rego
+++ b/bundle/regal/lsp/rename/rename_test.rego
@@ -1,0 +1,74 @@
+package regal.lsp.rename_test
+
+import data.regal.lsp.rename
+
+test_rename_arg_cross_file if {
+	policy_a := `package shared
+
+greet(name) := msg if {
+	msg := sprintf("hello, %s", [name])
+}`
+	policy_b := `package shared
+
+greet(name) := msg if {
+	count(name) > 50
+	msg := sprintf("hi %s", [name])
+}`
+
+	resp := rename.result.response with data.workspace.parsed as {
+		"file:///a.rego": regal.parse_module("a.rego", policy_a),
+		"file:///b.rego": regal.parse_module("b.rego", policy_b),
+	}
+		with input.params.textDocument.uri as "file:///a.rego"
+		with input.params.position as {"line": 2, "character": 6}
+		with input.params.newName as "user"
+		with input.regal.file.lines as split(policy_a, "\n")
+
+	resp == {"changes": {
+		"file:///a.rego": {
+			{"newText": "user", "range": {"start": {"line": 2, "character": 6}, "end": {"line": 2, "character": 10}}},
+			{"newText": "user", "range": {"start": {"line": 3, "character": 30}, "end": {"line": 3, "character": 34}}},
+		},
+		"file:///b.rego": {
+			{"newText": "user", "range": {"start": {"line": 2, "character": 6}, "end": {"line": 2, "character": 10}}},
+			{"newText": "user", "range": {"start": {"line": 3, "character": 7}, "end": {"line": 3, "character": 11}}},
+			{"newText": "user", "range": {"start": {"line": 4, "character": 26}, "end": {"line": 4, "character": 30}}},
+		},
+	}}
+}
+
+test_rename_some_var_single_file if {
+	policy := `package p
+
+list_admins contains admin if {
+	some user in input.users
+	user.role == "admin"
+	admin := user.name
+}`
+
+	resp := rename.result.response with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 3, "character": 6}
+		with input.params.newName as "u"
+		with input.regal.file.lines as split(policy, "\n")
+
+	resp == {"changes": {"file:///p.rego": {
+		{"newText": "u", "range": {"start": {"line": 3, "character": 6}, "end": {"line": 3, "character": 10}}},
+		{"newText": "u", "range": {"start": {"line": 4, "character": 1}, "end": {"line": 4, "character": 5}}},
+		{"newText": "u", "range": {"start": {"line": 5, "character": 10}, "end": {"line": 5, "character": 14}}},
+	}}}
+}
+
+test_rename_no_match if {
+	policy := `package p
+
+foo := 42`
+
+	resp := rename.result.response with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 2, "character": 11}
+		with input.params.newName as "x"
+		with input.regal.file.lines as split(policy, "\n")
+
+	resp == null
+}

--- a/bundle/regal/lsp/util/find/find.rego
+++ b/bundle/regal/lsp/util/find/find.rego
@@ -4,6 +4,7 @@
 #   - input: schema.regal.lsp.common
 package regal.lsp.util.find
 
+import data.regal.ast
 import data.regal.lsp.location
 import data.regal.lsp.util.range
 
@@ -13,7 +14,9 @@ import data.regal.lsp.util.range
 #   - input.params: schema.regal.lsp.textdocumentposition
 arg_at_position := [arg, rule_index] if {
 	text := input.regal.file.lines[input.params.position.line]
-	word := location.word_at(text, input.params.position.character)
+
+	# `+ 1` converts LSP 0-based char position to word_at's 1-based column
+	word := location.word_at(text, input.params.position.character + 1)
 
 	some rule_index
 	arg := data.workspace.parsed[input.params.textDocument.uri].rules[rule_index].head.args[_]
@@ -46,4 +49,27 @@ import_at_position := imp if {
 	some imp in data.workspace.parsed[input.params.textDocument.uri].imports
 
 	range.contains_position(range.parse(imp.path.location), input.params.position)
+}
+
+# METADATA
+# description: |
+#   find the `some`-declared variable at the given position, if any.
+# schemas:
+#   - input.params: schema.regal.lsp.textdocumentposition
+some_var_at_position := [var, rule_index] if {
+	text := input.regal.file.lines[input.params.position.line]
+
+	# `+ 1` converts LSP 0-based char position to word_at's 1-based column
+	word := location.word_at(text, input.params.position.character + 1)
+
+	some kind in ["some", "somein"]
+	some rule_index, vars in ast.found.vars
+	some var in vars[kind]
+
+	var.value == word.text
+
+	var_pos := range.parse(var.location)
+	input.params.position.line == var_pos.start.line
+	input.params.position.character >= var_pos.start.character
+	input.params.position.character <= var_pos.end.character
 }

--- a/bundle/regal/lsp/util/find/find_some_var_test.rego
+++ b/bundle/regal/lsp/util/find/find_some_var_test.rego
@@ -1,0 +1,54 @@
+package regal.lsp.util.find_test
+
+import data.regal.lsp.util.find
+
+test_some_var_at_position_idx if {
+	policy := `package p
+
+myrule := r if {
+	some idx, user in input.users
+	r := user.name
+}`
+
+	[var, rule_index] := find.some_var_at_position
+		with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 3, "character": 6}
+		with input.regal.file.lines as split(policy, "\n")
+
+	var.value == "idx"
+	rule_index == 0
+}
+
+test_some_var_at_position_user if {
+	policy := `package p
+
+myrule := r if {
+	some idx, user in input.users
+	r := user.name
+}`
+
+	[var, rule_index] := find.some_var_at_position
+		with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 3, "character": 11}
+		with input.regal.file.lines as split(policy, "\n")
+
+	var.value == "user"
+	rule_index == 0
+}
+
+test_some_var_at_position_no_match_on_keyword if {
+	policy := `package p
+
+myrule := r if {
+	some idx, user in input.users
+	r := user.name
+}`
+
+	not find.some_var_at_position
+		with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 3, "character": 1}
+		with input.regal.file.lines as split(policy, "\n")
+}


### PR DESCRIPTION
This PR makes some updates to the find references request implemented in #2029:

1. Move cross-module logic for finding references from rename.rego to references.rego, and used the result there to power the rename request
2. Add `some` vars as an additional result set returned in references.rego
3. Add tests for the new find references rules

More variable types are planned to be supported here shortly, as well as sharing this logic with our semantic token rules!

<img width="961" height="505" alt="image" src="https://github.com/user-attachments/assets/d7aa32e7-23fa-48a3-b199-3b194b6db398" />


<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->