### PR TITLE
[feature] Extending find references variable support

### DIFF
--- a/bundle/regal/lsp/preparerename/preparerename.rego
+++ b/bundle/regal/lsp/preparerename/preparerename.rego
@@ -16,6 +16,10 @@ result["response"] := _response_for(arg) if [arg, _] := find.arg_at_position
 
 result["response"] := _response_for(var) if [var, _] := find.some_var_at_position
 
+result["response"] := _response_for(var) if [var, _] := find.every_var_at_position
+
+result["response"] := _response_for(var) if [var, _] := find.comprehension_var_at_position
+
 _response_for(term) := {
 	"placeholder": term.value,
 	"range": range.parse(term.location),

--- a/bundle/regal/lsp/preparerename/preparerename_test.rego
+++ b/bundle/regal/lsp/preparerename/preparerename_test.rego
@@ -55,3 +55,47 @@ simple := 42`
 
 	resp == null
 }
+
+test_preparerename_every_var if {
+	policy := `package p
+
+r if {
+	every k, v in input.items {
+		k > 0
+		v.active
+	}
+}`
+
+	resp := preparerename.result.response
+		with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 3, "character": 7}
+		with input.regal.file.lines as split(policy, "\n")
+
+	resp == {
+		"placeholder": "k",
+		"range": {"start": {"line": 3, "character": 7}, "end": {"line": 3, "character": 8}},
+	}
+}
+
+test_preparerename_comprehension_var if {
+	policy := `package p
+
+r := result if {
+	result := [x |
+		some x in input.items
+		x > 0
+	]
+}`
+
+	resp := preparerename.result.response
+		with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 4, "character": 7}
+		with input.regal.file.lines as split(policy, "\n")
+
+	resp == {
+		"placeholder": "x",
+		"range": {"start": {"line": 4, "character": 7}, "end": {"line": 4, "character": 8}},
+	}
+}

--- a/bundle/regal/lsp/references/references.rego
+++ b/bundle/regal/lsp/references/references.rego
@@ -16,6 +16,10 @@ result.response contains ref if some ref in _arg_refs
 
 result.response contains ref if some ref in _some_var_refs
 
+result.response contains ref if some ref in _every_var_refs
+
+result.response contains ref if some ref in _comprehension_var_refs
+
 _arg_refs contains ref if {
 	[arg, rule_index] := find.arg_at_position
 	sref := ast.static_prefix(_module.rules[rule_index].head.ref)
@@ -47,6 +51,45 @@ _some_var_refs contains ref if {
 
 	value.type == "var"
 	value.value == var.value
+
+	ref := {
+		"uri": input.params.textDocument.uri,
+		"range": range.parse(value.location),
+	}
+}
+
+# METADATA
+# description: |
+#   References to the `every`-declared variable at the cursor: the declaration
+#   site (key or value position) plus every reference inside the block's body.
+_every_var_refs contains ref if {
+	[var, every_terms] := find.every_var_at_position
+
+	some node in ["body", "key", "value"]
+	walk(every_terms[node], [_, value])
+
+	value.type == "var"
+	value.value == var.value
+
+	ref := {
+		"uri": input.params.textDocument.uri,
+		"range": range.parse(value.location),
+	}
+}
+
+# METADATA
+# description: |
+#   References to the variable declared via `some x in y` inside a
+#   comprehension. Walking the entire comprehension covers both the
+#   declaration and every reference, scoped to that comprehension only.
+_comprehension_var_refs contains ref if {
+	[var, comp] := find.comprehension_var_at_position
+
+	walk(comp, [_, value])
+
+	value.type == "var"
+	value.value == var.value
+	not startswith(value.value, "$")
 
 	ref := {
 		"uri": input.params.textDocument.uri,

--- a/bundle/regal/lsp/references/references_test.rego
+++ b/bundle/regal/lsp/references/references_test.rego
@@ -70,3 +70,46 @@ foo := 42`
 
 	refs == set()
 }
+
+test_references_every_var if {
+	policy := `package p
+
+r if {
+	every k, v in input.items {
+		k > 0
+		v.active
+	}
+}`
+
+	refs := references.result.response with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 3, "character": 7}
+		with input.regal.file.lines as split(policy, "\n")
+
+	refs == {
+		{"uri": "file:///p.rego", "range": {"start": {"line": 3, "character": 7}, "end": {"line": 3, "character": 8}}},
+		{"uri": "file:///p.rego", "range": {"start": {"line": 4, "character": 2}, "end": {"line": 4, "character": 3}}},
+	}
+}
+
+test_references_comprehension_var if {
+	policy := `package p
+
+r := result if {
+	result := [x |
+		some x in input.items
+		x > 0
+	]
+}`
+
+	refs := references.result.response with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 4, "character": 7}
+		with input.regal.file.lines as split(policy, "\n")
+
+	refs == {
+		{"uri": "file:///p.rego", "range": {"start": {"line": 3, "character": 12}, "end": {"line": 3, "character": 13}}},
+		{"uri": "file:///p.rego", "range": {"start": {"line": 4, "character": 7}, "end": {"line": 4, "character": 8}}},
+		{"uri": "file:///p.rego", "range": {"start": {"line": 5, "character": 2}, "end": {"line": 5, "character": 3}}},
+	}
+}

--- a/bundle/regal/lsp/rename/rename_test.rego
+++ b/bundle/regal/lsp/rename/rename_test.rego
@@ -72,3 +72,48 @@ foo := 42`
 
 	resp == null
 }
+
+test_rename_every_var if {
+	policy := `package p
+
+r if {
+	every k, v in input.items {
+		k > 0
+		v.active
+	}
+}`
+
+	resp := rename.result.response with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 3, "character": 7}
+		with input.params.newName as "key"
+		with input.regal.file.lines as split(policy, "\n")
+
+	resp == {"changes": {"file:///p.rego": {
+		{"newText": "key", "range": {"start": {"line": 3, "character": 7}, "end": {"line": 3, "character": 8}}},
+		{"newText": "key", "range": {"start": {"line": 4, "character": 2}, "end": {"line": 4, "character": 3}}},
+	}}}
+}
+
+test_rename_comprehension_var if {
+	policy := `package p
+
+r := result if {
+	result := [x |
+		some x in input.items
+		x > 0
+	]
+}`
+
+	resp := rename.result.response with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 4, "character": 7}
+		with input.params.newName as "item"
+		with input.regal.file.lines as split(policy, "\n")
+
+	resp == {"changes": {"file:///p.rego": {
+		{"newText": "item", "range": {"start": {"line": 3, "character": 12}, "end": {"line": 3, "character": 13}}},
+		{"newText": "item", "range": {"start": {"line": 4, "character": 7}, "end": {"line": 4, "character": 8}}},
+		{"newText": "item", "range": {"start": {"line": 5, "character": 2}, "end": {"line": 5, "character": 3}}},
+	}}}
+}

--- a/bundle/regal/lsp/util/find/find.rego
+++ b/bundle/regal/lsp/util/find/find.rego
@@ -77,7 +77,6 @@ some_var_at_position := [var, rule_index] if {
 # METADATA
 # description: |
 #   find the `every`-declared variable at the given position, if any.
-#   Returns the var term and the containing `every` block (terms object).
 # schemas:
 #   - input.params: schema.regal.lsp.textdocumentposition
 every_var_at_position := [var, every_terms] if {
@@ -102,8 +101,8 @@ every_var_at_position := [var, every_terms] if {
 
 # METADATA
 # description: |
-#   find the variable declared via `some x in y` inside a comprehension at the
-#   given position. Returns the var term and the containing comprehension.
+#   find the variable declared inside a comprehension at the
+#   given position, if any.
 # schemas:
 #   - input.params: schema.regal.lsp.textdocumentposition
 comprehension_var_at_position := [var, comp] if {

--- a/bundle/regal/lsp/util/find/find.rego
+++ b/bundle/regal/lsp/util/find/find.rego
@@ -73,3 +73,61 @@ some_var_at_position := [var, rule_index] if {
 	input.params.position.character >= var_pos.start.character
 	input.params.position.character <= var_pos.end.character
 }
+
+# METADATA
+# description: |
+#   find the `every`-declared variable at the given position, if any.
+#   Returns the var term and the containing `every` block (terms object).
+# schemas:
+#   - input.params: schema.regal.lsp.textdocumentposition
+every_var_at_position := [var, every_terms] if {
+	text := input.regal.file.lines[input.params.position.line]
+
+	# `+ 1` converts LSP 0-based char position to word_at's 1-based column
+	word := location.word_at(text, input.params.position.character + 1)
+
+	some every_blocks in ast.found.every
+	some every_terms in every_blocks
+	some kind in ["key", "value"]
+
+	var := every_terms[kind]
+	var.type == "var"
+	var.value == word.text
+
+	var_pos := range.parse(var.location)
+	input.params.position.line == var_pos.start.line
+	input.params.position.character >= var_pos.start.character
+	input.params.position.character <= var_pos.end.character
+}
+
+# METADATA
+# description: |
+#   find the variable declared via `some x in y` inside a comprehension at the
+#   given position. Returns the var term and the containing comprehension.
+# schemas:
+#   - input.params: schema.regal.lsp.textdocumentposition
+comprehension_var_at_position := [var, comp] if {
+	text := input.regal.file.lines[input.params.position.line]
+
+	# `+ 1` converts LSP 0-based char position to word_at's 1-based column
+	word := location.word_at(text, input.params.position.character + 1)
+
+	some comps in ast.found.comprehensions
+	some comp in comps
+	some var in _comp_declared_vars(comp.value.body)
+
+	var.value == word.text
+
+	var_pos := range.parse(var.location)
+	input.params.position.line == var_pos.start.line
+	input.params.position.character >= var_pos.start.character
+	input.params.position.character <= var_pos.end.character
+}
+
+_comp_declared_vars(body) := [v |
+	some expr in body
+	some symbol in expr.terms.symbols
+	some v in array.slice(symbol.value, 1, 100)
+	v.type == "var"
+	not startswith(v.value, "$")
+]

--- a/bundle/regal/lsp/util/find/find_comprehension_var_test.rego
+++ b/bundle/regal/lsp/util/find/find_comprehension_var_test.rego
@@ -1,0 +1,59 @@
+package regal.lsp.util.find_test
+
+import data.regal.lsp.util.find
+
+test_comprehension_var_at_position_array if {
+	policy := `package p
+
+r := result if {
+	result := [x |
+		some x in input.items
+		x > 0
+	]
+}`
+
+	[var, comp] := find.comprehension_var_at_position
+		with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 4, "character": 7}
+		with input.regal.file.lines as split(policy, "\n")
+
+	var.value == "x"
+	comp.type == "arraycomprehension"
+}
+
+test_comprehension_var_at_position_object if {
+	policy := `package p
+
+r := result if {
+	result := {k: v |
+		some k, v in input.items
+	}
+}`
+
+	[var, comp] := find.comprehension_var_at_position
+		with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 4, "character": 7}
+		with input.regal.file.lines as split(policy, "\n")
+
+	var.value == "k"
+	comp.type == "objectcomprehension"
+}
+
+test_comprehension_var_at_position_no_match_on_output if {
+	policy := `package p
+
+r := result if {
+	result := [x |
+		some x in input.items
+	]
+}`
+
+	# cursor on the output 'x' (line 3, col 12) — that's a reference not a declaration
+	not find.comprehension_var_at_position
+		with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 3, "character": 12}
+		with input.regal.file.lines as split(policy, "\n")
+}

--- a/bundle/regal/lsp/util/find/find_every_var_test.rego
+++ b/bundle/regal/lsp/util/find/find_every_var_test.rego
@@ -1,0 +1,60 @@
+package regal.lsp.util.find_test
+
+import data.regal.lsp.util.find
+
+test_every_var_at_position_key if {
+	policy := `package p
+
+r if {
+	every k, v in input.items {
+		k > 0
+		v.active
+	}
+}`
+
+	[var, every_terms] := find.every_var_at_position
+		with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 3, "character": 7}
+		with input.regal.file.lines as split(policy, "\n")
+
+	var.value == "k"
+	every_terms.key.value == "k"
+	every_terms.value.value == "v"
+}
+
+test_every_var_at_position_value if {
+	policy := `package p
+
+r if {
+	every k, v in input.items {
+		k > 0
+		v.active
+	}
+}`
+
+	[var, _] := find.every_var_at_position
+		with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 3, "character": 10}
+		with input.regal.file.lines as split(policy, "\n")
+
+	var.value == "v"
+}
+
+test_every_var_at_position_no_match_on_domain if {
+	policy := `package p
+
+r if {
+	every k, v in input.items {
+		k > 0
+	}
+}`
+
+	# cursor on 'input' in the domain — not a declared var
+	not find.every_var_at_position
+		with data.workspace.parsed["file:///p.rego"] as regal.parse_module("p.rego", policy)
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position as {"line": 3, "character": 14}
+		with input.regal.file.lines as split(policy, "\n")
+}


### PR DESCRIPTION
A follow-up PR to #2029 and #2031 to provide find references support for `every` expressions and comprehensions!
<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->