### PR TITLE
fix: override object.subset return type to boolean

### DIFF
--- a/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value_test.rego
+++ b/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value_test.rego
@@ -84,6 +84,16 @@ test_success_negated_builtin_return_value if {
 	r == set()
 }
 
+test_success_object_subset_boolean_return if {
+	r := rule.report
+		with input as ast.policy(`allow if {
+			object.subset({"a"}, {"a", "b"})
+		}`)
+		with config.capabilities as capabilities.provided
+
+	r == set()
+}
+
 test_success_unused_boolean_return_value if {
 	r := rule.report
 		with input as ast.policy(`allow if { startswith("s", "s") }`)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -728,7 +728,21 @@ func fromOPABuiltin(builtin ast.Builtin) *Builtin {
 		rb.Decl.Result = builtin.Decl.Result().String()
 	}
 
+	if corrected, ok := builtinResultOverrides[builtin.Name]; ok {
+		rb.Decl.Result = corrected
+	}
+
 	return rb
+}
+
+// builtinResultOverrides corrects imprecise return types in OPA's builtin
+// metadata. object.subset returns a boolean, but is declared `any` in the
+// pinned OPA version, which causes false positives for the
+// unassigned-return-value rule. Fixed upstream in
+// https://github.com/open-policy-agent/opa/pull/8849; remove entries here once
+// the depended-upon OPA release ships the fix.
+var builtinResultOverrides = map[string]string{
+	"object.subset": "boolean",
 }
 
 func fromOPACapabilities(capabilities *ast.Capabilities) *Capabilities {


### PR DESCRIPTION
## Summary

Regal flags a bare `object.subset(...)` call used as a condition in a rule body
as an `unassigned-return-value` violation, even though `object.subset`
semantically returns a boolean.

The `unassigned-return-value` rule fires on any builtin call whose declared
result type is not `boolean`. The root cause is that OPA's builtin metadata in
the pinned OPA version declares `object.subset`'s return type as `any` rather
than `boolean`, so the rule treats its result as an unassigned non-boolean value.

This was fixed upstream in OPA (open-policy-agent/opa#8849), but that fix is not
yet in a released OPA version Regal depends on. Per @anderseknert's note on the
issue, a small local patch is the intended stop-gap until the OPA dependency is
bumped.

This change overrides the imprecise return type to `boolean` at the single Go
conversion point (`fromOPABuiltin` in `pkg/config/config.go`), so every consumer
of the capabilities (the `unassigned-return-value` rule, `boolean-assignment`,
and LSP hover/completion) sees the accurate type. The override table is
documented with a reference to the upstream OPA PR and a note to remove the entry
once the OPA dependency ships the fix.

## Why this matters

Without this, any policy that uses `object.subset(...)` as a plain condition
(a common pattern, e.g. checking required JWT claims) produces a spurious
`unassigned-return-value` error, forcing users to disable the rule or work around
a correct-and-idiomatic usage.

Verification:

- Added Rego regression test `test_success_object_subset_boolean_return` in
  `unassigned_return_value_test.rego`, asserting a bare `object.subset(...)`
  condition produces no violation. It fails without the override and passes with
  it.
- `go build ./...`, `go test ./pkg/config/...`, and `regal test bundle`
  (1047/1047) all pass.

Closes #2036
