### PR TITLE
Fix wrong end location reported by rule-shadows-builtin

### DIFF
--- a/bundle/regal/rules/bugs/rule-shadows-builtin/rule_shadows_builtin.rego
+++ b/bundle/regal/rules/bugs/rule-shadows-builtin/rule_shadows_builtin.rego
@@ -13,5 +13,5 @@ report contains violation if {
 
 	ast.ref_to_string(head.ref) in ast.builtin_namespaces
 
-	violation := result.fail(rego.metadata.chain(), result.location(head))
+	violation := result.fail(rego.metadata.chain(), result.location(head.ref))
 }

--- a/bundle/regal/rules/bugs/rule-shadows-builtin/rule_shadows_builtin_test.rego
+++ b/bundle/regal/rules/bugs/rule-shadows-builtin/rule_shadows_builtin_test.rego
@@ -23,7 +23,7 @@ test_fail_rule_name_shadows_builtin if {
 			"file": "policy.rego",
 			"row": 3,
 			"end": {
-				"col": 8,
+				"col": 3,
 				"row": 3,
 			},
 			"text": "or := 1",
@@ -50,7 +50,7 @@ test_fail_rule_name_shadows_builtin_namespace if {
 			"file": "policy.rego",
 			"row": 3,
 			"end": {
-				"col": 14,
+				"col": 5,
 				"row": 3,
 			},
 			"text": "http := \"yes\"",


### PR DESCRIPTION
Use only the rule head ref location, not the whole head.

Fixes #2046

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->