### PR TITLE
Add import future.keywords completion provider

### DIFF
--- a/bundle/regal/lsp/completion/providers/future/future.rego
+++ b/bundle/regal/lsp/completion/providers/future/future.rego
@@ -1,0 +1,41 @@
+# METADATA
+# description: |
+#   the `future` provider provides completion suggestions for
+#   future keywords following an `import` declaration, provided
+#   that any are found in the determined capabilities
+package regal.lsp.completion.providers.future
+
+import data.regal.lsp.completion.kind
+import data.regal.lsp.location
+
+# METADATA
+# description: completion suggestion for future import
+items contains item if {
+	keywords := data.workspace.config.capabilities.future_keywords
+	keywords != []
+
+	line := input.regal.file.lines[input.params.position.line]
+	startswith(line, "import ")
+
+	word := location.ref_at(line, input.params.position.character + 1)
+
+	some keyword in keywords
+
+	ref := $"future.keywords.{keyword}"
+	startswith(ref, word.text)
+
+	item := _item(keyword, ref, word, input.params.position)
+}
+
+_item(keyword, ref, word, position) := {
+	"label": ref,
+	"labelDetails": {
+		"description": "reference",
+	},
+	"kind": kind.reference,
+	"detail": $"import future `{keyword}` keyword",
+	"textEdit": {
+		"range": location.word_range(word, position),
+		"newText": ref,
+	},
+}

--- a/bundle/regal/lsp/completion/providers/future/future_test.rego
+++ b/bundle/regal/lsp/completion/providers/future/future_test.rego
@@ -1,0 +1,43 @@
+package regal.lsp.completion.providers.future_test
+
+import data.regal.lsp.completion.providers.future as provider
+import data.regal.lsp.completion.providers.test_utils as util
+
+test_with_future_keyword if {
+	policy := "package policy\n\n"
+	module := regal.parse_module("p.rego", policy)
+	items := provider.items
+		with input as util.input_module_with_location(module, $`{policy}import f`, {"row": 3, "col": 9})
+		with data.workspace.config.capabilities.future_keywords as ["not"]
+
+	items == {{
+		"detail": "import future `not` keyword",
+		"kind": 18,
+		"label": "future.keywords.not",
+		"labelDetails": {
+			"description": "reference",
+		},
+		"textEdit": {
+			"newText": "future.keywords.not",
+			"range": {
+				"end": {
+					"character": 8,
+					"line": 2,
+				},
+				"start": {
+					"character": 7,
+					"line": 2,
+				},
+			},
+		},
+	}}
+}
+
+test_no_future_keywords if {
+	policy := "package policy\n\n"
+	module := regal.parse_module("p.rego", policy)
+	items := provider.items
+		with input as util.input_module_with_location(module, $`{policy}import f`, {"row": 3, "col": 9})
+
+	items == set()
+}


### PR DESCRIPTION
Little thing to help encourage this..

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->