### PR TITLE
Various completion provider improvements

### DIFF
--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -146,12 +146,12 @@ identifiers := rule_and_function_names | imported_identifiers
 rule_names contains name if {
 	some i, name in rule_names_ordered
 
-	not input.rules[i].head.args
+	not _rules[i].head.args
 }
 
 # METADATA
 # description: all rule and function names in the input AST indexed by position
-rule_names_ordered := [ref_static_to_string(rule.head.ref) | some rule in input.rules]
+rule_names_ordered := [ref_static_to_string(rule.head.ref) | some rule in _rules]
 
 # METADATA
 # description: |
@@ -324,10 +324,12 @@ function_decls[name] := info if {
 
 	some name, head in heads
 
-	info := {"decl": {
-		"args": [{"type": _custom_arg_type(arg.type), "name": arg.value} | some arg in head.args],
-		"result": {"type": "any"},
-	}}
+	info := {
+		"decl": {
+			"args": [{"type": _custom_arg_type(arg.type), "name": arg.value} | some arg in head.args],
+			"result": {"type": "any"},
+		},
+	}
 }
 
 _custom_arg_type(type) := type if type != "var"
@@ -427,7 +429,7 @@ assignment_terms(terms) := [terms[1], terms[2]] if is_assignment(terms[0])
 #   For a given rule head name, this rule contains a list of locations where
 #   there is a rule head with that name.
 rule_head_locations[name] contains {"row": loc.row, "col": loc.col} if {
-	some i, rule in input.rules
+	some i, rule in _rules
 
 	name := $"{package_name_full}.{rule_names_ordered[i]}"
 	loc := util.to_location_object(rule.head.location)

--- a/bundle/regal/lsp/client/client.rego
+++ b/bundle/regal/lsp/client/client.rego
@@ -54,3 +54,10 @@ identifiers["zed"] := 3
 # related_resources:
 #   - https://neovim.io/
 identifiers["neovim"] := 4
+
+# METADATA
+# description: True if client supports setting a default edit range for completion items, otherwise false
+# scope: document
+default supports["edit_range_defaults"] := false
+
+supports["edit_range_defaults"] if "editRange" in capabilities.textDocument.completion.completionList.itemDefaults

--- a/bundle/regal/lsp/completion/main.rego
+++ b/bundle/regal/lsp/completion/main.rego
@@ -25,7 +25,7 @@ result["response"] := {
 	"isIncomplete": true,
 } if {
 	input.method == "textDocument/completion"
-	not _default_edit_range_supported
+	not client.supports.edit_range_defaults
 }
 
 # METADATA
@@ -40,12 +40,10 @@ result["response"] := {
 	"itemDefaults": {"editRange": range},
 } if {
 	input.method == "textDocument/completion"
-	_default_edit_range_supported
+	client.supports.edit_range_defaults
 
 	line := input.regal.file.lines[input.params.position.line]
 	line != ""
-
-	location.in_rule_body(line)
 
 	ref := location.ref_at(line, input.params.position.character + 1)
 	range := location.word_range(ref, input.params.position)
@@ -87,8 +85,4 @@ inside_comment if {
 
 	startswith(comment.location, line)
 	util.to_location_no_text(comment.location).col <= input.params.position.character + 1
-}
-
-_default_edit_range_supported if {
-	"editRange" in client.capabilities.textDocument.completion.completionList.itemDefaults
 }

--- a/bundle/regal/lsp/completion/main_test.rego
+++ b/bundle/regal/lsp/completion/main_test.rego
@@ -1,5 +1,8 @@
 package regal.lsp.completion_test
 
+import data.regal.ast
+import data.regal.util
+
 import data.regal.lsp.completion
 
 test_completion_entrypoint if {
@@ -27,3 +30,25 @@ test_not_inside_comment if not completion.inside_comment
 		{"location": "2:1:2:10"},
 		{"location": "4:8:4:10"},
 	]}}
+
+# Ensure that completions are provided both when itemDefaults are supported
+# by the client and when they are not. We use the boolean completion provider
+# below for it's simplicity only — it's the main logic that's being tested
+# here and nothing else
+test_edit_range_support_result[supported] if {
+	module := ast.policy("r := f")
+
+	some item_defaults in [[], ["editRange"]]
+
+	supported := count(item_defaults) == 1
+
+	result := completion.items
+		with data.client.capabilities.textDocument.completion.completionList.itemDefaults as item_defaults
+		with data.workspace["file:///p.rego"] as module
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position.line as 2
+		with input.params.position.character as count("r := f")
+		with input.regal as module.regal
+
+	util.single_set_item(result).label == "false"
+}

--- a/bundle/regal/lsp/completion/providers/booleans/booleans.rego
+++ b/bundle/regal/lsp/completion/providers/booleans/booleans.rego
@@ -2,35 +2,53 @@
 # description: the boolean provider suggests `true`/`false` values where appropriate
 package regal.lsp.completion.providers.booleans
 
+import data.regal.lsp.client
 import data.regal.lsp.completion.kind
 import data.regal.lsp.location
 
 # METADATA
-# description: completion suggestions for true/false
+# description: completion suggestions for true/false boolean values
 items contains item if {
 	line := input.regal.file.lines[input.params.position.line]
 	line != ""
 
-	words := regex.split(`\s+`, line)
-
-	words_on_line := count(words)
-	previous_word := words[words_on_line - 2]
-
-	previous_word in {"==", ":="}
-
 	word := location.word_at(line, input.params.position.character + 1)
+	word.text != ""
 
-	some str in ["true", "false"]
+	item := _bool_suggestion(_matched(word), word, client.supports.edit_range_defaults)
+}
 
-	startswith(str, word.text)
+_bool_str(s) := "true" if startswith("true", s)
+_bool_str(s) := "false" if startswith("false", s)
 
-	item := {
-		"label": str,
-		"kind": kind.constant,
-		"detail": "boolean value",
-		"textEdit": {
-			"range": location.word_range(word, input.params.position),
-			"newText": str,
-		},
-	}
+_matched(word) := _bool_str(word.text) if regex.match(`^\s+$`, word.text_before)
+_matched(word) := _bool_str(word.text) if strings.any_suffix_match(trim_space(word.text_before), [
+	"if",
+	",",
+	":",
+	"(",
+	"[",
+	"=", # covers =, ==, !=, :=
+])
+
+_bool_suggestion(bool, _, true) := {
+	"label": bool,
+	"labelDetails": {
+		"description": "value",
+	},
+	"kind": kind.value,
+	"detail": "boolean value",
+}
+
+_bool_suggestion(bool, word, false) := {
+	"label": bool,
+	"labelDetails": {
+		"description": "value",
+	},
+	"kind": kind.value,
+	"detail": "boolean value",
+	"textEdit": {
+		"range": location.word_range(word, input.params.position),
+		"newText": bool,
+	},
 }

--- a/bundle/regal/lsp/completion/providers/booleans/booleans_test.rego
+++ b/bundle/regal/lsp/completion/providers/booleans/booleans_test.rego
@@ -1,102 +1,45 @@
 package regal.lsp.completion.providers.booleans_test
 
+import data.regal.ast
+import data.regal.util
+
 import data.regal.lsp.completion.providers.booleans as provider
-import data.regal.lsp.completion.providers.test_utils as utils
 
-test_suggested_in_head if {
-	workspace := {"file:///p.rego": `package policy
+test_boolean_suggested_where_expected[$"{name}-{count(item_defaults)}"] if {
+	# assert that boolean suggestions are provided at all appropriate locations,
+	# and that the format of the suggestion is correct both with and without the
+	# `editRange` item default in the client's capability list. The latter property
+	# must be reflected in each test's name or else both cases will be counted as
+	# one (as the test name is the key in the result set).
+	some item_defaults in [[], ["editRange"]]
+	some [name, edit] in [
+		["head key literal", "rule[t█] if foo"],
+		["head value assign", "rule := t█"],
+		["body expression start", "rule if t█"],
+		["body expression compare", "rule if x == t█"],
+		["function argument first", "f(t█)"],
+		["function argument next", "f(foo, t█)"],
+		["object literal", "o := {\"key\": t█}"],
+		["array item first", "a := [t█]"],
+		["array item next", "a := [foo, t█]"],
+	]
 
-allow := f`}
+	module := ast.policy(replace(edit, "█", ""))
+	result := provider.items
+		with data.client.capabilities.textDocument.completion.completionList.itemDefaults as item_defaults
+		with data.workspace["file:///p.rego"] as module
+		with input.params.textDocument.uri as "file:///p.rego"
+		with input.params.position.line as 2
+		with input.params.position.character as indexof(edit, "█")
+		with input.regal as module.regal
 
-	regal_module := {
-		"params": {
-			"textDocument": {"uri": "file:///p.rego"},
-			"position": {"line": 2, "character": 9},
-		},
-		"regal": {"file": {"lines": split(workspace["file:///p.rego"], "\n")}},
-	}
-
-	items := provider.items
-		with input as regal_module
-		with data.workspace.parsed as utils.parsed_modules(workspace)
-
-	count(items) == 1
-
-	some item in items
-
-	item.label == "false"
-}
-
-test_suggested_in_body if {
-	workspace := {"file:///p.rego": `package policy
-
-allow if {
-  foo := t
-}`}
-
-	regal_module := {
-		"params": {
-			"textDocument": {"uri": "file:///p.rego"},
-			"position": {"line": 3, "character": 9},
-		},
-		"regal": {"file": {"lines": split(workspace["file:///p.rego"], "\n")}},
-	}
-
-	items := provider.items
-		with input as regal_module
-		with data.workspace.parsed as utils.parsed_modules(workspace)
-
-	count(items) == 1
-
-	some item in items
+	item := util.single_set_item(result)
 
 	item.label == "true"
-}
+	item.labelDetails.description == "value"
+	item.detail == "boolean value"
+	item.kind == 12
 
-test_suggested_after_equals if {
-	workspace := {"file:///p.rego": `package policy
-
-allow if {
-  foo == t
-}`}
-
-	regal_module := {
-		"params": {
-			"textDocument": {"uri": "file:///p.rego"},
-			"position": {"line": 3, "character": 9},
-		},
-		"regal": {"file": {"lines": split(workspace["file:///p.rego"], "\n")}},
-	}
-
-	items := provider.items
-		with input as regal_module
-		with data.workspace.parsed as utils.parsed_modules(workspace)
-
-	count(items) == 1
-
-	some item in items
-
-	item.label == "true"
-}
-
-test_not_suggested_at_start if {
-	workspace := {"file:///p.rego": `package policy
-
-allow if {
-  t
-}`}
-
-	regal_module := {
-		"params": {
-			"textDocument": {"uri": "file:///p.rego"},
-			"position": {"line": 3, "character": 2},
-		},
-		"regal": {"file": {"lines": split(workspace["file:///p.rego"], "\n")}},
-	}
-
-	items := provider.items
-		with input as regal_module
-		with data.workspace.parsed as utils.parsed_modules(workspace)
-
-	count(items) == 0
+	has_text_edit := object.get(item, "textEdit", count(item_defaults) == 1)
+	has_text_edit != false
 }

--- a/bundle/regal/lsp/completion/providers/builtins/builtins.rego
+++ b/bundle/regal/lsp/completion/providers/builtins/builtins.rego
@@ -13,7 +13,7 @@ import data.regal.lsp.location
 # METADATA
 # description: without editRange item defaults (large amount of duplicated data)
 items contains item if {
-	not _default_edit_range_supported
+	not client.supports.edit_range_defaults
 
 	line := input.regal.file.lines[input.params.position.line]
 
@@ -35,7 +35,10 @@ items contains item if {
 		"label": builtin.name,
 		"kind": kind.function,
 		"detail": "built-in function",
-		"textEdit": {"range": location.word_range(ref, input.params.position), "newText": builtin.name},
+		"textEdit": {
+			"range": location.word_range(ref, input.params.position),
+			"newText": builtin.name,
+		},
 		"data": "builtins",
 	}
 }
@@ -43,11 +46,12 @@ items contains item if {
 # METADATA
 # description: with editRange item defaults (range defined in main, label used as textEdit.newText))
 items contains item if {
-	_default_edit_range_supported
+	client.supports.edit_range_defaults
 
 	line := input.regal.file.lines[input.params.position.line]
 
 	not startswith(line, "default ")
+	location.in_rule_body(line)
 
 	ref := location.ref_at(line, input.params.position.character + 1)
 
@@ -61,12 +65,11 @@ items contains item if {
 
 	item := {
 		"label": builtin.name,
+		"labelDetails": {
+			"description": "built-in function",
+		},
 		"kind": kind.function,
 		"detail": "built-in function",
 		"data": "builtins",
 	}
-}
-
-_default_edit_range_supported if {
-	"editRange" in client.capabilities.textDocument.completion.completionList.itemDefaults
 }

--- a/bundle/regal/lsp/completion/providers/commonrule/commonrule.rego
+++ b/bundle/regal/lsp/completion/providers/commonrule/commonrule.rego
@@ -16,6 +16,7 @@ _suggested_names := {
 # description: all completion suggestions for common rule names
 items contains item if {
 	line := input.regal.file.lines[input.params.position.line]
+	not startswith(line, "default")
 
 	some label in _suggested_names
 
@@ -24,7 +25,7 @@ items contains item if {
 	item := {
 		"label": label,
 		"kind": kind.snippet,
-		"detail": "common name",
+		"detail": "common rule name",
 		"documentation": {
 			"kind": "markdown",
 			"value": $`"{label}" is a common rule name`,
@@ -32,6 +33,33 @@ items contains item if {
 		"textEdit": {
 			"range": location.from_start_of_line_to_position(input.params.position),
 			"newText": $"{label} ",
+		},
+	}
+}
+
+# METADATA
+# description: all completion suggestions for common rule names
+items contains item if {
+	line := input.regal.file.lines[input.params.position.line]
+	startswith(line, "default ")
+
+	word := location.word_at(line, input.params.position.character + 1)
+
+	some label in _suggested_names
+
+	startswith(label, word.text)
+
+	item := {
+		"label": label,
+		"kind": kind.snippet,
+		"detail": "common rule name",
+		"documentation": {
+			"kind": "markdown",
+			"value": $`"{label}" is a common rule name`,
+		},
+		"textEdit": {
+			"range": location.word_range(word, input.params.position),
+			"newText": label,
 		},
 	}
 }

--- a/bundle/regal/lsp/completion/providers/commonrule/commonrule_test.rego
+++ b/bundle/regal/lsp/completion/providers/commonrule/commonrule_test.rego
@@ -31,10 +31,42 @@ import rego.v1
 	expected_item(items, "deny")
 }
 
+test_common_name_completion_on_typed_default_rule if {
+	policy := "package policy\n\n"
+	module := regal.parse_module("p.rego", policy)
+	items := provider.items with input as util.input_module_with_location(
+		module,
+		$`{policy}default d`, {"row": 3, "col": 10},
+	)
+
+	items == {{
+		"detail": "common rule name",
+		"documentation": {
+			"kind": "markdown",
+			"value": "\"deny\" is a common rule name",
+		},
+		"kind": 15,
+		"label": "deny",
+		"textEdit": {
+			"newText": "deny",
+			"range": {
+				"end": {
+					"character": 9,
+					"line": 2,
+				},
+				"start": {
+					"character": 8,
+					"line": 2,
+				},
+			},
+		},
+	}}
+}
+
 expected_item(items, label) if {
 	item := {
 		"label": label,
-		"detail": "common name",
+		"detail": "common rule name",
 		"documentation": {
 			"kind": "markdown",
 			"value": $`"{label}" is a common rule name`,

--- a/bundle/regal/lsp/completion/providers/import/import.rego
+++ b/bundle/regal/lsp/completion/providers/import/import.rego
@@ -18,9 +18,31 @@ items contains item if {
 		"label": "import",
 		"kind": kind.keyword,
 		"detail": "import <path>",
+		"documentation": {
+			"kind": "markdown",
+			"value": doc,
+		},
 		"textEdit": {
 			"range": location.word_range(word, input.params.position),
 			"newText": "import ",
 		},
 	}
 }
+
+# METADATA
+# description: documentation for import suggestion
+## exported for test
+doc := $`### import
+
+Add import to package. Examples:
+
+{_code}
+`
+
+_code := concat("\n", [
+	"```rego",
+	"import data.users",
+	"import input.environment as env",
+	"import future.keywords.not",
+	"```",
+])

--- a/bundle/regal/lsp/completion/providers/import/import_test.rego
+++ b/bundle/regal/lsp/completion/providers/import/import_test.rego
@@ -14,6 +14,10 @@ import rego.v1
 		"label": "import",
 		"detail": "import <path>",
 		"kind": 14,
+		"documentation": {
+			"kind": "markdown",
+			"value": provider.doc,
+		},
 		"textEdit": {
 			"newText": "import ",
 			"range": {
@@ -37,6 +41,10 @@ imp`
 		"label": "import",
 		"detail": "import <path>",
 		"kind": 14,
+		"documentation": {
+			"kind": "markdown",
+			"value": provider.doc,
+		},
 		"textEdit": {
 			"newText": "import ",
 			"range": {

--- a/bundle/regal/lsp/completion/providers/inputdotjson/inputdotjson.rego
+++ b/bundle/regal/lsp/completion/providers/inputdotjson/inputdotjson.rego
@@ -16,13 +16,44 @@ import data.regal.lsp.completion.kind
 import data.regal.lsp.location
 
 # METADATA
-# description: items contains found suggestions from `input.json`
+# description: items contains suggestions from `input.json` in expressions
+# scope: rule
 items contains item if {
 	input.regal.environment.input_path != ""
 
 	line := input.regal.file.lines[input.params.position.line]
 	line != ""
 	location.in_rule_body(line)
+
+	word := location.ref_at(line, input.params.position.character + 1)
+	startswith(word.text, "i")
+
+	edit := location.word_range(word, input.params.position)
+
+	some [suggestion, type] in _input_paths
+
+	startswith(suggestion, word.text)
+
+	item := {
+		"label": suggestion,
+		"kind": kind.variable,
+		"detail": type,
+		"documentation": _documentation,
+		"textEdit": {
+			"range": edit,
+			"newText": suggestion,
+		},
+	}
+}
+
+# METADATA
+# description: items contains suggestions from `input.json` in imports
+# scope: rule
+items contains item if {
+	input.regal.environment.input_path != ""
+
+	line := input.regal.file.lines[input.params.position.line]
+	startswith(line, "import ")
 
 	word := location.ref_at(line, input.params.position.character + 1)
 	startswith(word.text, "i")

--- a/bundle/regal/lsp/completion/providers/inputdotjson/inputdotjson_test.rego
+++ b/bundle/regal/lsp/completion/providers/inputdotjson/inputdotjson_test.rego
@@ -59,11 +59,48 @@ test_matching_input_suggestions if {
 	}
 }
 
+test_provides_input_suggestions_in_import_position if {
+	items := provider.items
+		with input as {
+			"params": {
+				"textDocument": {
+					"uri": "file:///example.rego",
+				},
+				"position": {
+					"line": 2,
+					"character": 8,
+				},
+			},
+			"regal": {
+				"environment": {
+					"input_path": "foo/bar/input.json",
+				},
+				"file": {
+					"lines": [
+						"package p", "", "import i",
+					],
+				},
+			},
+		}
+		with data.workspace.inputs as {
+			"foo/bar/input.json": {
+				"request": {
+					"method": "GET",
+					"url": "https://example.com",
+				},
+			},
+		}
+
+	[item.label | some item in items] == ["input.request", "input.request.method", "input.request.url"]
+}
+
 test_not_matching_input_suggestions if {
-	input_obj_new_loc := object.union(input_obj, {"params": {
-		"textDocument": {"uri": "file:///example.rego"},
-		"position": {"line": 0, "character": 0},
-	}})
+	input_obj_new_loc := object.union(input_obj, {
+		"params": {
+			"textDocument": {"uri": "file:///example.rego"},
+			"position": {"line": 0, "character": 0},
+		},
+	})
 	items := provider.items
 		with input as input_obj_new_loc
 		with data.workspace as workspace_obj
@@ -73,34 +110,50 @@ test_not_matching_input_suggestions if {
 
 input_obj := {
 	"params": {
-		"textDocument": {"uri": "file:///example.rego"},
-		"position": {"line": 5, "character": 11},
+		"textDocument": {
+			"uri": "file:///example.rego",
+		},
+		"position": {
+			"line": 5,
+			"character": 11,
+		},
 	},
 	"regal": {
-		"environment": {"input_path": "foo/bar/input.json"},
-		"file": {"lines": [
-			"package p",
-			"",
-			"import rego.v1",
-			"",
-			"allow if {",
-			"    f(input.r",
-			"}",
-		]},
+		"environment": {
+			"input_path": "foo/bar/input.json",
+		},
+		"file": {
+			"lines": [
+				"package p",
+				"",
+				"import rego.v1",
+				"",
+				"allow if {",
+				"    f(input.r",
+				"}",
+			],
+		},
 	},
 }
 
-workspace_obj := {"inputs": {"foo/bar/input.json": {
-	"user": {
-		"name": {
-			"first": "John",
-			"last": "Doe",
+workspace_obj := {
+	"inputs": {
+		"foo/bar/input.json": {
+			"user": {
+				"name": {
+					"first": "John",
+					"last": "Doe",
+				},
+				"email": "john@doe.com",
+				"roles": [
+					{"name": "admin"},
+					{"name": "user"},
+				],
+			},
+			"request": {
+				"method": "GET",
+				"url": "https://example.com",
+			},
 		},
-		"email": "john@doe.com",
-		"roles": [{"name": "admin"}, {"name": "user"}],
 	},
-	"request": {
-		"method": "GET",
-		"url": "https://example.com",
-	},
-}}}
+}

--- a/bundle/regal/lsp/completion/providers/package/package.rego
+++ b/bundle/regal/lsp/completion/providers/package/package.rego
@@ -8,9 +8,9 @@ import data.regal.lsp.location
 # METADATA
 # description: completion suggestions for package keyword
 items contains item if {
-	not strings.any_prefix_match(input.regal.file.lines, "package ")
-
 	startswith("package", input.regal.file.lines[input.params.position.line])
+
+	not strings.any_prefix_match(input.regal.file.lines, "package ")
 
 	item := {
 		"label": "package",

--- a/bundle/regal/lsp/completion/providers/regov1/regov1.rego
+++ b/bundle/regal/lsp/completion/providers/regov1/regov1.rego
@@ -1,6 +1,6 @@
 # METADATA
 # description: |
-#   the `regov1`` provider provides completion suggestions for
+#   the `regov1` provider provides completion suggestions for
 #   `rego.v1` following an `import` declaration
 package regal.lsp.completion.providers.regov1
 

--- a/bundle/regal/lsp/completion/providers/ruleheadkeyword/ruleheadkeyword.rego
+++ b/bundle/regal/lsp/completion/providers/ruleheadkeyword/ruleheadkeyword.rego
@@ -24,6 +24,8 @@ items contains item if {
 
 	word := location.word_at(line, input.params.position.character + 1)
 
+	not endswith(word.text_after, " ")
+
 	_word_matches(word.text)
 
 	some obj in _suggestions(word.text, _words_no_space(word.text_before))

--- a/bundle/regal/lsp/completion/resolvers/input/input.rego
+++ b/bundle/regal/lsp/completion/resolvers/input/input.rego
@@ -4,9 +4,10 @@ package regal.lsp.completion.resolvers.input
 
 # METADATA
 # description: provides documentation for the `input` keyword completion item
-resolve := object.union(input.params, {"documentation": {
-	"kind": "markdown",
-	"value": `# input
+resolve := object.union(input.params, {
+	"documentation": {
+		"kind": "markdown",
+		"value": `### input
 
 'input' refers to the input document being evaluated.
 It is a special keyword that allows you to access the data sent to OPA at evaluation time.
@@ -16,4 +17,5 @@ To see more examples of how to use 'input', check out the
 
 You can also experiment with input in the [Rego Playground](https://play.openpolicyagent.org/).
 `,
-}})
+	},
+})

--- a/internal/lsp/rego/testdata/router/completionItem/resolve/input.md
+++ b/internal/lsp/rego/testdata/router/completionItem/resolve/input.md
@@ -56,7 +56,7 @@ The server resolves the completion item using the `data` field to provide markdo
   "detail": "input document",
   "documentation": {
     "kind": "markdown",
-    "value": "# input\n\n'input' refers to the input document being evaluated.\nIt is a special keyword that allows you to access the data sent to OPA at evaluation time.\n\nTo see more examples of how to use 'input', check out the\n[policy language documentation](https://www.openpolicyagent.org/docs/policy-language/).\n\nYou can also experiment with input in the [Rego Playground](https://play.openpolicyagent.org/).\n"
+    "value": "### input\n\n'input' refers to the input document being evaluated.\nIt is a special keyword that allows you to access the data sent to OPA at evaluation time.\n\nTo see more examples of how to use 'input', check out the\n[policy language documentation](https://www.openpolicyagent.org/docs/policy-language/).\n\nYou can also experiment with input in the [Rego Playground](https://play.openpolicyagent.org/).\n"
   },
   "kind": 14,
   "label": "input",

--- a/internal/lsp/rego/testdata/router/textDocument/completion/item_defaults.md
+++ b/internal/lsp/rego/testdata/router/textDocument/completion/item_defaults.md
@@ -77,163 +77,244 @@ only once, thus massively reducing the size of the completion response:
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "indexof"
+      "label": "indexof",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "indexof_n"
+      "label": "indexof_n",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "intersection"
+      "label": "intersection",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "io.jwt.decode"
+      "label": "io.jwt.decode",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "io.jwt.decode_verify"
+      "label": "io.jwt.decode_verify",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "io.jwt.encode_sign"
+      "label": "io.jwt.encode_sign",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "io.jwt.encode_sign_raw"
+      "label": "io.jwt.encode_sign_raw",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "io.jwt.verify_eddsa"
+      "label": "io.jwt.verify_eddsa",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "io.jwt.verify_es256"
+      "label": "io.jwt.verify_es256",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "io.jwt.verify_es384"
+      "label": "io.jwt.verify_es384",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "io.jwt.verify_es512"
+      "label": "io.jwt.verify_es512",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "io.jwt.verify_hs256"
+      "label": "io.jwt.verify_hs256",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "io.jwt.verify_hs384"
+      "label": "io.jwt.verify_hs384",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "io.jwt.verify_hs512"
+      "label": "io.jwt.verify_hs512",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "io.jwt.verify_ps256"
+      "label": "io.jwt.verify_ps256",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "io.jwt.verify_ps384"
+      "label": "io.jwt.verify_ps384",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "io.jwt.verify_ps512"
+      "label": "io.jwt.verify_ps512",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "io.jwt.verify_rs256"
+      "label": "io.jwt.verify_rs256",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "io.jwt.verify_rs384"
+      "label": "io.jwt.verify_rs384",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "io.jwt.verify_rs512"
+      "label": "io.jwt.verify_rs512",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "is_array"
+      "label": "is_array",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "is_boolean"
+      "label": "is_boolean",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "is_null"
+      "label": "is_null",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "is_number"
+      "label": "is_number",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "is_object"
+      "label": "is_object",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "is_set"
+      "label": "is_set",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "builtins",
       "detail": "built-in function",
       "kind": 3,
-      "label": "is_string"
+      "label": "is_string",
+      "labelDetails": {
+        "description": "built-in function"
+      }
     },
     {
       "data": "input",


### PR DESCRIPTION
Fixing some things I've noticed while working on policies recently.

- Have common rule name provider provide suggestions for default rules
- Have input.json completion provider provide suggestion for imports
- Have boolean value completion provider provide suggestions in many more locations
- Add inline docs to import provider
- Add label details to built-in function completion provider
- Move cheap check above expensive in package completion provider
- Use `_rules` in ast.rego to allow LSP callers with different input schema
- Some small doc fixes

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->