### PR TITLE
Raise test timeout threshold to 3 seconds

### DIFF
--- a/build/do.rq
+++ b/build/do.rq
@@ -169,7 +169,7 @@ binary_present if {
 
 test if {
 	run("go test ./...")
-	run("go run main.go test --timeout 1s bundle")
+	run("go run main.go test --timeout 3s bundle")
 }
 
 e2e if {


### PR DESCRIPTION
This was meant to catch outlier tests at an early stage. It seems like we're past 1 second in CI running tests naturally now though, so raising this to 3 seconds.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/open-policy-agent/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#opa-regal` channel in the [OPA Community Slack](https://slack.openpolicyagent.org/).
-->