### PR TITLE
WIP: Prep for OPA 1.19

### DIFF
--- a/internal/roast/encoding/testdata/annotations_all.json
+++ b/internal/roast/encoding/testdata/annotations_all.json
@@ -26,19 +26,16 @@
     {
       "path": [
         {
-          "location": "1:1:1:6",
           "type": "var",
           "value": "input"
         }
       ],
       "schema": [
         {
-          "location": "1:1:1:7",
           "type": "var",
           "value": "schema"
         },
         {
-          "location": "1:8:1:13",
           "type": "string",
           "value": "input"
         }
@@ -47,34 +44,28 @@
     {
       "path": [
         {
-          "location": "1:1:1:5",
           "type": "var",
           "value": "data"
         },
         {
-          "location": "1:6:1:9",
           "type": "string",
           "value": "foo"
         },
         {
-          "location": "1:10:1:13",
           "type": "string",
           "value": "bar"
         }
       ],
       "schema": [
         {
-          "location": "1:1:1:7",
           "type": "var",
           "value": "schema"
         },
         {
-          "location": "1:8:1:11",
           "type": "string",
           "value": "foo"
         },
         {
-          "location": "1:12:1:15",
           "type": "string",
           "value": "bar"
         }
@@ -83,17 +74,14 @@
     {
       "path": [
         {
-          "location": "1:1:1:5",
           "type": "var",
           "value": "data"
         },
         {
-          "location": "1:6:1:9",
           "type": "string",
           "value": "foo"
         },
         {
-          "location": "1:10:1:13",
           "type": "string",
           "value": "baz"
         }


### PR DESCRIPTION
TODO update OPA when https://github.com/open-policy-agent/opa/pull/8947/changes/6cf1d33d38256e9111985c6ba4e161402c7ebc63 is on main

This was spotted by running the tests in Regal and seeing TestAnnotationsEncoding fail for OPA main ahead of 1.19 release.

The fix is this, following OPA PR #7281 to address the inconsistency and have location removed where it's not accurate for schemas AND here on the Regal side to remove test data that expected this to be set.


https://github.com/open-policy-agent/opa/pull/8947/commits/6cf1d33d38256e9111985c6ba4e161402c7ebc63