### PR TITLE
docs: clarify rule configuration file locations

### DIFF
--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCreateBuiltinDocsIncludesConfigurationFileLocations(t *testing.T) {
+	t.Parallel()
+
+	output := t.TempDir()
+
+	err := createBuiltinDocs(newRuleCommandParams{
+		category: "naming",
+		name:     "foo-bar-baz",
+		output:   output,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(output, "docs", "rules", "naming", "foo-bar-baz.md")
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doc := string(content)
+	for _, expected := range []string{
+		"[configuration options](https://www.openpolicyagent.org/projects/regal/configuration)",
+		"```yaml title=\".regal/config.yaml or .regal.yaml\"",
+	} {
+		if !strings.Contains(doc, expected) {
+			t.Errorf("generated documentation does not contain %q", expected)
+		}
+	}
+}

--- a/docs/rules/bugs/annotation-without-metadata.md
+++ b/docs/rules/bugs/annotation-without-metadata.md
@@ -33,9 +33,9 @@ A comment that starts with `<annotation-attribute>:` but is not part of a metada
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     annotation-without-metadata:

--- a/docs/rules/bugs/argument-always-wildcard.md
+++ b/docs/rules/bugs/argument-always-wildcard.md
@@ -69,9 +69,9 @@ authorized(_, request) if {
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     argument-always-wildcard:

--- a/docs/rules/bugs/constant-condition.md
+++ b/docs/rules/bugs/constant-condition.md
@@ -33,9 +33,9 @@ since removing it would leave the enclosing expression without an operand.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     constant-condition:

--- a/docs/rules/bugs/deprecated-builtin.md
+++ b/docs/rules/bugs/deprecated-builtin.md
@@ -125,9 +125,9 @@ a {
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     deprecated-builtin:

--- a/docs/rules/bugs/duplicate-rule.md
+++ b/docs/rules/bugs/duplicate-rule.md
@@ -40,9 +40,9 @@ files, there could still be duplicates across those files. This will be addresse
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     duplicate-rule:

--- a/docs/rules/bugs/if-empty-object.md
+++ b/docs/rules/bugs/if-empty-object.md
@@ -24,9 +24,9 @@ avoided.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     if-empty-object:

--- a/docs/rules/bugs/if-object-literal.md
+++ b/docs/rules/bugs/if-object-literal.md
@@ -26,9 +26,9 @@ a rule body in its place. This isn't too common, but can happen when either an e
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     if-object-literal:

--- a/docs/rules/bugs/import-shadows-rule.md
+++ b/docs/rules/bugs/import-shadows-rule.md
@@ -49,9 +49,9 @@ Avoid shadowing either by renaming your rule or by using an alias for the import
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     import-shadows-rule:

--- a/docs/rules/bugs/impossible-not.md
+++ b/docs/rules/bugs/impossible-not.md
@@ -56,9 +56,9 @@ items, use the built-in `count` function instead.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     impossible-not:

--- a/docs/rules/bugs/inconsistent-args.md
+++ b/docs/rules/bugs/inconsistent-args.md
@@ -56,9 +56,9 @@ also allowed.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     inconsistent-args:

--- a/docs/rules/bugs/internal-entrypoint.md
+++ b/docs/rules/bugs/internal-entrypoint.md
@@ -36,9 +36,9 @@ or use another public rule as an entrypoint, which may reference the internal ru
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     internal-entrypoint:

--- a/docs/rules/bugs/invalid-metadata-attribute.md
+++ b/docs/rules/bugs/invalid-metadata-attribute.md
@@ -36,9 +36,9 @@ These tools include built-in functions like
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     invalid-metadata-attribute:

--- a/docs/rules/bugs/invalid-regexp.md
+++ b/docs/rules/bugs/invalid-regexp.md
@@ -30,9 +30,9 @@ directly.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     invalid-regexp:

--- a/docs/rules/bugs/leaked-internal-reference.md
+++ b/docs/rules/bugs/leaked-internal-reference.md
@@ -55,9 +55,9 @@ in your Regal config file.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     leaked-internal-reference:

--- a/docs/rules/bugs/not-equals-in-loop.md
+++ b/docs/rules/bugs/not-equals-in-loop.md
@@ -51,9 +51,9 @@ currently only checks for wildcard iteration (`[_]`).
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     not-equals-in-loop:

--- a/docs/rules/bugs/redundant-existence-check.md
+++ b/docs/rules/bugs/redundant-existence-check.md
@@ -74,9 +74,9 @@ report(user, is_admin) if {
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     redundant-existence-check:

--- a/docs/rules/bugs/redundant-loop-count.md
+++ b/docs/rules/bugs/redundant-loop-count.md
@@ -73,9 +73,9 @@ If you want to have empty collections fail on `every` conditions, do make sure t
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     redundant-loop-count:

--- a/docs/rules/bugs/rule-assigns-default.md
+++ b/docs/rules/bugs/rule-assigns-default.md
@@ -36,9 +36,9 @@ would evaluate to the same value with or without the assignment.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     rule-assigns-default:

--- a/docs/rules/bugs/rule-named-if.md
+++ b/docs/rules/bugs/rule-named-if.md
@@ -55,9 +55,9 @@ it isn't — consider using a better name for your rule!
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     rule-named-if:

--- a/docs/rules/bugs/rule-shadows-builtin.md
+++ b/docs/rules/bugs/rule-shadows-builtin.md
@@ -22,9 +22,9 @@ behavior.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     rule-shadows-builtin:

--- a/docs/rules/bugs/sprintf-arguments-mismatch.md
+++ b/docs/rules/bugs/sprintf-arguments-mismatch.md
@@ -48,9 +48,9 @@ time spent chasing down issues later, and a happier development experience.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     sprintf-arguments-mismatch:

--- a/docs/rules/bugs/time-now-ns-twice.md
+++ b/docs/rules/bugs/time-now-ns-twice.md
@@ -49,9 +49,9 @@ introduction to these tools, as well as advice on how to write performant polici
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     time-now-ns-twice:

--- a/docs/rules/bugs/top-level-iteration.md
+++ b/docs/rules/bugs/top-level-iteration.md
@@ -27,9 +27,9 @@ data.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     top-level-iteration:

--- a/docs/rules/bugs/unassigned-return-value.md
+++ b/docs/rules/bugs/unassigned-return-value.md
@@ -35,9 +35,9 @@ is almost certainly a mistake.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     unassigned-return-value:

--- a/docs/rules/bugs/unused-output-variable.md
+++ b/docs/rules/bugs/unused-output-variable.md
@@ -81,9 +81,9 @@ Neither of these methods however considers an unused output variable as "unused"
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     unused-output-variable:

--- a/docs/rules/bugs/var-shadows-builtin.md
+++ b/docs/rules/bugs/var-shadows-builtin.md
@@ -34,9 +34,9 @@ function in that namespace to be used later in the rule. Avoid this!
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     var-shadows-builtin:

--- a/docs/rules/bugs/zero-arity-function.md
+++ b/docs/rules/bugs/zero-arity-function.md
@@ -41,9 +41,9 @@ is to avoid them and just use rules in their place.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   bugs:
     zero-arity-function:

--- a/docs/rules/custom/chained-rule-body.md
+++ b/docs/rules/custom/chained-rule-body.md
@@ -41,9 +41,9 @@ rule (as it is by default), there's no point in enabling this rule.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   custom:
     chained-rule-body:

--- a/docs/rules/custom/disallow-rego-v1.md
+++ b/docs/rules/custom/disallow-rego-v1.md
@@ -17,6 +17,18 @@ This rule is intended to be enabled for projects that have been configured to ta
 onwards, but Regal does not explicitly check which version of OPA is being targeted for this rule. If working
 with older versions of OPA and Rego, you probably don't want to enable this rule.
 
+## Configuration Options
+
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
+
+```yaml title=".regal/config.yaml or .regal.yaml"
+rules:
+  custom:
+    disallow-rego-v1:
+      # one of "error", "warning", "ignore"
+      level: error
+```
+
 ## Related Resources
 
 - GitHub: [Source Code](https://github.com/open-policy-agent/regal/blob/main/bundle/regal/rules/custom/disallow-rego-v1/disallow_rego_v1.rego)

--- a/docs/rules/custom/forbidden-function-call.md
+++ b/docs/rules/custom/forbidden-function-call.md
@@ -23,9 +23,9 @@ to forbid certain functions as part of your policy development process, there's 
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   custom:
     forbidden-function-call:

--- a/docs/rules/custom/missing-metadata.md
+++ b/docs/rules/custom/missing-metadata.md
@@ -44,9 +44,9 @@ below.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   custom:
     missing-metadata:

--- a/docs/rules/custom/naming-convention.md
+++ b/docs/rules/custom/naming-convention.md
@@ -19,9 +19,9 @@ Regal can enforce naming conventions for:
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   custom:
     naming-convention:

--- a/docs/rules/custom/narrow-argument.md
+++ b/docs/rules/custom/narrow-argument.md
@@ -164,9 +164,9 @@ locations.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   custom:
     narrow-argument:

--- a/docs/rules/custom/one-liner-rule.md
+++ b/docs/rules/custom/one-liner-rule.md
@@ -36,9 +36,9 @@ teams or organizations might want to standardize on. As such, it must be enabled
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   custom:
     one-liner-rule:

--- a/docs/rules/custom/prefer-value-in-head.md
+++ b/docs/rules/custom/prefer-value-in-head.md
@@ -65,9 +65,9 @@ which will have Regal recommend moving them to the head even when `only-scalars`
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   custom:
     prefer-value-in-head:

--- a/docs/rules/idiomatic/ambiguous-scope.md
+++ b/docs/rules/idiomatic/ambiguous-scope.md
@@ -69,9 +69,9 @@ If a single incremental rule definition is annotated as `entrypoint: true`, this
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     ambiguous-scope:

--- a/docs/rules/idiomatic/boolean-assignment.md
+++ b/docs/rules/idiomatic/boolean-assignment.md
@@ -38,9 +38,9 @@ more_than_one_member if count(input.members) > 1
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     boolean-assignment:

--- a/docs/rules/idiomatic/custom-has-key-construct.md
+++ b/docs/rules/idiomatic/custom-has-key-construct.md
@@ -31,9 +31,9 @@ and using the built-in function together with `in` should be preferred.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     custom-has-key-construct:

--- a/docs/rules/idiomatic/custom-in-construct.md
+++ b/docs/rules/idiomatic/custom-in-construct.md
@@ -34,9 +34,9 @@ recommended.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     custom-in-construct:

--- a/docs/rules/idiomatic/directory-package-mismatch.md
+++ b/docs/rules/idiomatic/directory-package-mismatch.md
@@ -113,9 +113,9 @@ will also be moved if required to the `_test` directory for that package.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     directory-package-mismatch:

--- a/docs/rules/idiomatic/equals-pattern-matching.md
+++ b/docs/rules/idiomatic/equals-pattern-matching.md
@@ -80,9 +80,9 @@ will be improved in future releases.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     equals-pattern-matching:

--- a/docs/rules/idiomatic/in-wildcard-key.md
+++ b/docs/rules/idiomatic/in-wildcard-key.md
@@ -57,9 +57,9 @@ some value in object
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     in-wildcard-key:

--- a/docs/rules/idiomatic/no-defined-entrypoint.md
+++ b/docs/rules/idiomatic/no-defined-entrypoint.md
@@ -71,9 +71,9 @@ provides good documentation for others, but also unlocks programmatic possibilit
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     no-defined-entrypoint:

--- a/docs/rules/idiomatic/non-raw-regex-pattern.md
+++ b/docs/rules/idiomatic/non-raw-regex-pattern.md
@@ -44,9 +44,9 @@ allow if regex.match(pattern, "12345")
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     non-raw-regex-pattern:

--- a/docs/rules/idiomatic/prefer-equals-comparison.md
+++ b/docs/rules/idiomatic/prefer-equals-comparison.md
@@ -78,9 +78,9 @@ rule if {
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     prefer-equals-comparison:

--- a/docs/rules/idiomatic/prefer-set-or-object-rule.md
+++ b/docs/rules/idiomatic/prefer-set-or-object-rule.md
@@ -131,9 +131,9 @@ my_set := {item | some item in arr}
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     prefer-set-or-object-rule:

--- a/docs/rules/idiomatic/single-item-in.md
+++ b/docs/rules/idiomatic/single-item-in.md
@@ -26,9 +26,9 @@ whereas `in` checks currently aren't.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     single-item-in:

--- a/docs/rules/idiomatic/superfluous-object-get.md
+++ b/docs/rules/idiomatic/superfluous-object-get.md
@@ -32,9 +32,9 @@ the expression will evaluate the same without using `object.get`. In such cases 
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     superfluous-object-get:

--- a/docs/rules/idiomatic/use-array-flatten.md
+++ b/docs/rules/idiomatic/use-array-flatten.md
@@ -69,9 +69,9 @@ more details.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     use-array-flatten:

--- a/docs/rules/idiomatic/use-contains.md
+++ b/docs/rules/idiomatic/use-contains.md
@@ -62,9 +62,9 @@ automatically at any applicable location by the `opa fmt` tool.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     use-contains:

--- a/docs/rules/idiomatic/use-if.md
+++ b/docs/rules/idiomatic/use-if.md
@@ -60,9 +60,9 @@ automatically at any applicable location by the `opa fmt` tool.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     use-if:

--- a/docs/rules/idiomatic/use-in-operator.md
+++ b/docs/rules/idiomatic/use-in-operator.md
@@ -30,9 +30,9 @@ checking if something is **not** part of a collection.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     use-in-operator:

--- a/docs/rules/idiomatic/use-object-keys.md
+++ b/docs/rules/idiomatic/use-object-keys.md
@@ -32,9 +32,9 @@ This option is both more declarative and better conveys the intent of the code.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     use-object-keys:

--- a/docs/rules/idiomatic/use-object-union-n.md
+++ b/docs/rules/idiomatic/use-object-union-n.md
@@ -32,9 +32,9 @@ to `true` to always recommend replacing `object.union` with `object.union_n`.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     use-object-union-n:

--- a/docs/rules/idiomatic/use-some-for-output-vars.md
+++ b/docs/rules/idiomatic/use-some-for-output-vars.md
@@ -93,9 +93,9 @@ variable in the local scope of the `usernames` rule.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     use-some-for-output-vars:

--- a/docs/rules/idiomatic/use-strings-count.md
+++ b/docs/rules/idiomatic/use-strings-count.md
@@ -25,9 +25,9 @@ is both more readable and efficient compared to using `count(indexof_n(...))` an
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   idiomatic:
     use-strings-count:

--- a/docs/rules/imports/avoid-importing-input.md
+++ b/docs/rules/imports/avoid-importing-input.md
@@ -60,9 +60,9 @@ allow if {
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   imports:
     avoid-importing-input:

--- a/docs/rules/imports/circular-import.md
+++ b/docs/rules/imports/circular-import.md
@@ -110,9 +110,9 @@ This will make your code easier to navigate and maintain.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   imports:
     circular-import:

--- a/docs/rules/imports/confusing-alias.md
+++ b/docs/rules/imports/confusing-alias.md
@@ -43,9 +43,9 @@ Using two different aliases for the same import is also likely a mistake, and is
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   imports:
     confusing-alias:

--- a/docs/rules/imports/ignored-import.md
+++ b/docs/rules/imports/ignored-import.md
@@ -38,9 +38,9 @@ defeats the purpose of the import, and you're better off referring to the import
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   imports:
     ignored-import:

--- a/docs/rules/imports/implicit-future-keywords.md
+++ b/docs/rules/imports/implicit-future-keywords.md
@@ -47,9 +47,9 @@ variable names in your policy.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   imports:
     implicit-future-keywords:

--- a/docs/rules/imports/import-after-rule.md
+++ b/docs/rules/imports/import-after-rule.md
@@ -29,9 +29,9 @@ dependencies imported in the policy simply by looking at the top of the file.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   imports:
     import-after-rule:

--- a/docs/rules/imports/import-shadows-builtin.md
+++ b/docs/rules/imports/import-shadows-builtin.md
@@ -58,9 +58,9 @@ This is obviously not what the policy author intended.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   imports:
     import-shadows-builtin:

--- a/docs/rules/imports/import-shadows-import.md
+++ b/docs/rules/imports/import-shadows-import.md
@@ -39,9 +39,9 @@ Duplicate imports are redundant, and while harmless, should just be removed.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   imports:
     import-shadows-import:

--- a/docs/rules/imports/pointless-import.md
+++ b/docs/rules/imports/pointless-import.md
@@ -33,9 +33,9 @@ without the import.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   imports:
     pointless-import:

--- a/docs/rules/imports/prefer-package-imports.md
+++ b/docs/rules/imports/prefer-package-imports.md
@@ -46,9 +46,9 @@ of external data, or use the various ignore options to ignore entire files.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   imports:
     prefer-package-imports:

--- a/docs/rules/imports/redundant-alias.md
+++ b/docs/rules/imports/redundant-alias.md
@@ -26,9 +26,9 @@ Using an alias with the same name is thus redundant, and should be omitted.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   imports:
     redundant-alias:

--- a/docs/rules/imports/redundant-data-import.md
+++ b/docs/rules/imports/redundant-data-import.md
@@ -17,9 +17,9 @@ Just like `input`, `data` is always globally available and does not need to be i
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   imports:
     redundant-data-import:

--- a/docs/rules/imports/unresolved-import.md
+++ b/docs/rules/imports/unresolved-import.md
@@ -37,9 +37,9 @@ import data.users
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   imports:
     unresolved-import:

--- a/docs/rules/imports/unresolved-reference.md
+++ b/docs/rules/imports/unresolved-reference.md
@@ -21,9 +21,9 @@ _data_ files. If no reference is found, the rule will flag it as unresolved.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   imports:
     unresolved-reference:

--- a/docs/rules/imports/use-rego-v1.md
+++ b/docs/rules/imports/use-rego-v1.md
@@ -91,9 +91,9 @@ $ regal lint bundle
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   imports:
     use-rego-v1:

--- a/docs/rules/performance/defer-assignment.md
+++ b/docs/rules/performance/defer-assignment.md
@@ -54,9 +54,9 @@ It is possible that the rule will be improved to cover more cases in the future.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   performance:
     defer-assignment:

--- a/docs/rules/performance/equals-over-count.md
+++ b/docs/rules/performance/equals-over-count.md
@@ -95,9 +95,9 @@ you may choose to enable it by default. Just keep the caveats described above in
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   performance:
     equals-over-count:

--- a/docs/rules/performance/non-loop-expression.md
+++ b/docs/rules/performance/non-loop-expression.md
@@ -77,9 +77,9 @@ allow if {
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   performance:
     non-loop-expression:

--- a/docs/rules/performance/walk-no-path.md
+++ b/docs/rules/performance/walk-no-path.md
@@ -73,9 +73,9 @@ function.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   performance:
     walk-no-path:

--- a/docs/rules/performance/with-outside-test-context.md
+++ b/docs/rules/performance/with-outside-test-context.md
@@ -72,9 +72,9 @@ are done so outside of the scope of `with` to avoid performance issues.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   performance:
     with-outside-test-context:

--- a/docs/rules/style/avoid-get-and-list-prefix.md
+++ b/docs/rules/style/avoid-get-and-list-prefix.md
@@ -45,9 +45,9 @@ Using `is_`, or `has_` for boolean helper functions, like `is_admin(user)` may b
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     avoid-get-and-list-prefix:

--- a/docs/rules/style/comprehension-term-assignment.md
+++ b/docs/rules/style/comprehension-term-assignment.md
@@ -60,9 +60,9 @@ first_names := [capitalize(user.name.split(" ")[0]) |
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     comprehension-term-assignment:

--- a/docs/rules/style/default-over-else.md
+++ b/docs/rules/style/default-over-else.md
@@ -78,9 +78,9 @@ option is `false`.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     default-over-else:

--- a/docs/rules/style/default-over-not.md
+++ b/docs/rules/style/default-over-not.md
@@ -31,9 +31,9 @@ negated. This is by design, as using `not` and negation may very well be the rig
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     default-over-not:

--- a/docs/rules/style/detached-metadata.md
+++ b/docs/rules/style/detached-metadata.md
@@ -35,9 +35,9 @@ connect the two when reading the policy. Always optimize for readability!
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     detached-metadata:

--- a/docs/rules/style/double-negative.md
+++ b/docs/rules/style/double-negative.md
@@ -43,9 +43,9 @@ considered OK, and the `double-negative` rule is limited to check for a limited 
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     double-negative:

--- a/docs/rules/style/external-reference.md
+++ b/docs/rules/style/external-reference.md
@@ -72,9 +72,9 @@ match your preference.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     external-reference:

--- a/docs/rules/style/file-length.md
+++ b/docs/rules/style/file-length.md
@@ -28,9 +28,9 @@ parallel and thus will be able to handle many smaller files faster than a few la
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     file-length:

--- a/docs/rules/style/function-arg-return.md
+++ b/docs/rules/style/function-arg-return.md
@@ -49,9 +49,9 @@ is arguably more idiomatic than:
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     function-arg-return:

--- a/docs/rules/style/line-length.md
+++ b/docs/rules/style/line-length.md
@@ -24,9 +24,9 @@ should be considered so long that the line length rule should ignore the line en
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     line-length:

--- a/docs/rules/style/messy-rule.md
+++ b/docs/rules/style/messy-rule.md
@@ -42,9 +42,9 @@ follow. While this is mostly a style preference, having incremental rules groupe
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     messy-rule:

--- a/docs/rules/style/mixed-iteration.md
+++ b/docs/rules/style/mixed-iteration.md
@@ -57,9 +57,9 @@ use `some .. in`), but don't mix the two different styles in a single iteration 
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     mixed-iteration:

--- a/docs/rules/style/no-whitespace-comment.md
+++ b/docs/rules/style/no-whitespace-comment.md
@@ -36,9 +36,9 @@ Comments should be preceded by a single space, as this makes them easier to read
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     no-whitespace-comment:

--- a/docs/rules/style/opa-fmt.md
+++ b/docs/rules/style/opa-fmt.md
@@ -49,9 +49,9 @@ for more configuration help for multi version projects.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     opa-fmt:

--- a/docs/rules/style/pointless-reassignment.md
+++ b/docs/rules/style/pointless-reassignment.md
@@ -45,9 +45,9 @@ This rule does not consider such assignments violations.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     pointless-reassignment:

--- a/docs/rules/style/prefer-snake-case.md
+++ b/docs/rules/style/prefer-snake-case.md
@@ -34,9 +34,9 @@ code, etc).
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     prefer-snake-case:

--- a/docs/rules/style/prefer-some-in-iteration.md
+++ b/docs/rules/style/prefer-some-in-iteration.md
@@ -111,9 +111,9 @@ example_users contains user if {
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     prefer-some-in-iteration:

--- a/docs/rules/style/rule-length.md
+++ b/docs/rules/style/rule-length.md
@@ -22,9 +22,9 @@ content inside of it. Neither does it try to analyze the complexity of the code 
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     rule-length:

--- a/docs/rules/style/rule-name-repeats-package.md
+++ b/docs/rules/style/rule-name-repeats-package.md
@@ -34,9 +34,9 @@ This rule was inspired by [Go Code Review Comments](https://github.com/golang/go
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     rule-name-repeats-package:

--- a/docs/rules/style/todo-comment.md
+++ b/docs/rules/style/todo-comment.md
@@ -36,9 +36,9 @@ the code rather than where issues belong — in your issue tracker.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     todo-comment:

--- a/docs/rules/style/trailing-default-rule.md
+++ b/docs/rules/style/trailing-default-rule.md
@@ -35,9 +35,9 @@ conditionally assigning values.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     trailing-default-rule:

--- a/docs/rules/style/unconditional-assignment.md
+++ b/docs/rules/style/unconditional-assignment.md
@@ -39,9 +39,9 @@ body adds unnecessary noise.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     unconditional-assignment:

--- a/docs/rules/style/unnecessary-some.md
+++ b/docs/rules/style/unnecessary-some.md
@@ -40,9 +40,9 @@ developers contains name if {
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     unnecessary-some:

--- a/docs/rules/style/use-assignment-operator.md
+++ b/docs/rules/style/use-assignment-operator.md
@@ -68,9 +68,9 @@ Even when that is the case, using `:=` consistently should be considered a best 
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     use-assignment-operator:

--- a/docs/rules/style/yoda-condition.md
+++ b/docs/rules/style/yoda-condition.md
@@ -32,9 +32,9 @@ authors in the galaxy.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   style:
     yoda-condition:

--- a/docs/rules/testing/dubious-print-sprintf.md
+++ b/docs/rules/testing/dubious-print-sprintf.md
@@ -43,9 +43,9 @@ still wanting to avoid the use of `sprintf` in such cases.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   testing:
     dubious-print-sprintf:

--- a/docs/rules/testing/file-missing-test-suffix.md
+++ b/docs/rules/testing/file-missing-test-suffix.md
@@ -12,9 +12,9 @@ e.g. `policy.rego` and `policy_test.rego`.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   testing:
     file-missing-test-suffix:

--- a/docs/rules/testing/identically-named-tests.md
+++ b/docs/rules/testing/identically-named-tests.md
@@ -42,9 +42,9 @@ test names within the same test package.
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   testing:
     identically-named-tests:

--- a/docs/rules/testing/metasyntactic-variable.md
+++ b/docs/rules/testing/metasyntactic-variable.md
@@ -70,9 +70,9 @@ If you'd rather use your own list of forbidden variable names or patterns, see t
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   testing:
     metasyntactic-variable:

--- a/docs/rules/testing/print-or-trace-call.md
+++ b/docs/rules/testing/print-or-trace-call.md
@@ -27,9 +27,9 @@ The `trace` function serves no real purpose since the introduction of `print`, a
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   testing:
     print-or-trace-call:

--- a/docs/rules/testing/test-outside-test-package.md
+++ b/docs/rules/testing/test-outside-test-package.md
@@ -38,9 +38,9 @@ from production policy. This is easily done by placing tests in a separate packa
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   testing:
     test-outside-test-package:

--- a/docs/rules/testing/todo-test.md
+++ b/docs/rules/testing/todo-test.md
@@ -23,9 +23,9 @@ developing policy. They are however not to be committed, and should be removed b
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   testing:
     todo-test:

--- a/internal/embeds/templates/builtin/builtin.md.tpl
+++ b/internal/embeds/templates/builtin/builtin.md.tpl
@@ -26,9 +26,9 @@ ADD RATIONALE HERE
 
 ## Configuration Options
 
-This linter rule provides the following configuration options:
+This linter rule provides the following [configuration options](https://www.openpolicyagent.org/projects/regal/configuration):
 
-```yaml
+```yaml title=".regal/config.yaml or .regal.yaml"
 rules:
   {{.Category}}:
     {{.NameOriginal}}:


### PR DESCRIPTION
Fixes #533.

## Summary

- link each rule's configuration options to the current configuration documentation
- label configuration examples with `.regal/config.yaml or .regal.yaml`
- add the missing configuration section for `disallow-rego-v1`
- update the built-in rule scaffold and cover its output with a regression test

## Tests

- `go test ./cmd`
- `go run main.go test --timeout 3s bundle` (1077/1077)
- `go test -tags e2e ./e2e -count=1`
- `go test -tags integration ./internal/capabilities`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...`
- `opa check --strict --capabilities build/capabilities.json bundle`
- markdownlint and dprint checks
- README and capabilities generated-file checks

## Local limitation

`go test ./...` still reproduces the same pre-existing local Windows LSP path and URI failures seen on the clean base commit. The changed package and focused regression test pass.
