### PR TITLE
internal/io: drop stale experimental-keywords capability assertion

### DIFF
--- a/internal/io/io_test.go
+++ b/internal/io/io_test.go
@@ -141,13 +141,11 @@ func TestOPACapabilitiesIncludeNoRegalBuiltins(t *testing.T) {
 	}
 }
 
-func TestCapabilitiesIncludeExperimentalKeywords(t *testing.T) {
+func TestCapabilitiesIncludeLogicalKeywords(t *testing.T) {
 	t.Parallel()
 
 	for _, keyword := range []string{"and", "or"} {
 		assert.True(t, slices.Contains(Capabilities().FutureKeywords, keyword))
-		must.Equal(t, false, slices.Contains(OPACapabilities().FutureKeywords, keyword),
-			"experimental keyword %q advertised in OPA capabilities", keyword)
 	}
 }
 


### PR DESCRIPTION
OPA enabled `and`/`or` in default capabilities (open-policy-agent/opa#9054), so asserting they're absent now fails against OPA main and breaks OPA's nightly Regal compatibility job.

nightly job: https://github.com/open-policy-agent/opa/actions/runs/32705813539/job/97366570649