### PR TITLE
Report constant `and`/`or` operands

### DIFF
--- a/bundle/regal/rules/bugs/constant-condition/constant_condition.rego
+++ b/bundle/regal/rules/bugs/constant-condition/constant_condition.rego
@@ -7,6 +7,7 @@ package regal.rules.bugs["constant-condition"]
 
 import data.regal.ast
 import data.regal.result
+import data.regal.util
 
 # METADATA
 # description: single scalar value or templatestring, like a lone `true` inside a rule body
@@ -16,8 +17,8 @@ report contains violation if {
 
 	expr := ast.found.expressions[rule_index][i]
 
-	# `and`/`or` operands are excluded, as removing the expression would leave
-	# the enclosing expression without an operand
+	# `and`/`or` operands are excluded, as removing the expression would leave the enclosing
+	# expression without an operand — they're reported by the rules below instead
 	not ast.logical_operand_locations[rule_index][expr.location]
 
 	terms := expr.terms
@@ -51,33 +52,47 @@ report contains violation if {
 
 	expr := ast.found.expressions[rule_index][i]
 
-	expr.terms.type in _logical_expr_types
-
-	# only the outermost logical expression is reported, as removing a nested
-	# one would leave its enclosing expression without an operand
+	# only the outermost logical expression is reported here, as a nested one is an
+	# operand of its enclosing expression, and reported as such by the rule below
 	not ast.logical_operand_locations[rule_index][expr.location]
 
-	constant_locations := _constant_expr_locations[rule_index]
-
-	# every `and`/`or` node in the expression contributes its own operands here, so
-	# nested logical expressions have their operands checked as well
-	every operand in [operand |
-		walk(expr.terms, [_, node])
-
-		node.type in _logical_expr_types
-
-		some operand in [node.lhs, node.rhs]
-	] {
-		count(operand) == 1
-		operand[0].location in constant_locations
-	}
+	expr.location in _constant_logical_expr_locations[rule_index]
 
 	violation := result.fail(rego.metadata.chain(), result.location(expr))
+}
+
+# METADATA
+# description: '`and`/`or` expression with a constant operand, like the `1` in `input.a and 1`'
+# scope: rule
+report contains violation if {
+	some rule_index, i
+
+	expr := ast.found.expressions[rule_index][i]
+
+	expr.terms.type in _logical_expr_types
+
+	some side in ["lhs", "rhs"]
+
+	other_side := _other_side[side]
+
+	_constant_operand(rule_index, expr.terms[side])
+
+	# expressions where both operands are constant are reported by the rule above,
+	# as those are removed rather than collapsed
+	not _constant_operand(rule_index, expr.terms[other_side])
+
+	# the expression can only be collapsed to the operand kept if that operand may
+	# stand on its own, so any other constant operand is left alone
+	_stands_alone(expr.terms, other_side)
+
+	violation := result.fail(rego.metadata.chain(), result.location(_collapse_location(expr, side)))
 }
 
 _scalar_expr_types := {"boolean", "null", "number", "string", "templatestring"}
 
 _logical_expr_types := {"and", "or"}
+
+_other_side := {"lhs": "rhs", "rhs": "lhs"}
 
 # METADATA
 # description: |
@@ -97,19 +112,97 @@ _comparison_locations[rule_index] contains expr.location if {
 
 # METADATA
 # description: |
-#   locations of the expressions that are constant on their own, in the rule at rule_index.
-#   `and`/`or` expressions are included, as whether they are constant is determined by their
-#   operands, which are checked separately
+#   locations of the expressions that are constant on their own, in the rule at rule_index
 _constant_expr_locations[rule_index] contains expr.location if {
 	some rule_index, i
 
 	expr := ast.found.expressions[rule_index][i]
 
-	expr.terms.type in (_scalar_expr_types | _logical_expr_types)
+	expr.terms.type in _scalar_expr_types
 }
 
 _constant_expr_locations[rule_index] contains location if {
 	some rule_index, locations in _comparison_locations
 
 	some location in locations
+}
+
+# METADATA
+# description: locations of the `and`/`or` expressions in the rule at rule_index
+_logical_expr_locations[rule_index] contains expr.location if {
+	some rule_index, i
+
+	expr := ast.found.expressions[rule_index][i]
+
+	expr.terms.type in _logical_expr_types
+}
+
+# METADATA
+# description: |
+#   locations of the `and`/`or` expressions where every operand is constant, like `1 or 2`,
+#   in the rule at rule_index. Unlike the rule reporting them, nested expressions are
+#   included here, as an enclosing expression is only constant if they are
+_constant_logical_expr_locations[rule_index] contains expr.location if {
+	some rule_index, i
+
+	expr := ast.found.expressions[rule_index][i]
+
+	expr.terms.type in _logical_expr_types
+
+	# `and`/`or` operands count as constant here, as whether they really are is
+	# determined by their own operands, which the walk below covers as well
+	constant_locations := _constant_expr_locations[rule_index] | _logical_expr_locations[rule_index]
+
+	# every `and`/`or` node in the expression contributes its own operands here, so
+	# nested logical expressions have their operands checked as well
+	every operand in [operand |
+		walk(expr.terms, [_, node])
+
+		node.type in _logical_expr_types
+
+		some operand in [node.lhs, node.rhs]
+	] {
+		count(operand) == 1
+		operand[0].location in constant_locations
+	}
+}
+
+# METADATA
+# description: |
+#   true if the `and`/`or` operand is made up of a single constant expression, like
+#   the `1` in `input.a and 1`, or the `1 or 2` in `input.a and { 1 or 2 }`
+_constant_operand(rule_index, operand) if {
+	count(operand) == 1
+
+	operand[0].location in _constant_expr_locations[rule_index]
+} else if {
+	count(operand) == 1
+
+	operand[0].location in _constant_logical_expr_locations[rule_index]
+}
+
+# METADATA
+# description: |
+#   the location covering both the constant operand on 'side' of the `and`/`or` expression
+#   and the operator, i.e. the range that when removed collapses the expression to the
+#   operand kept
+# scope: document
+_collapse_location(expr, "rhs") := $"{keep.end.row}:{keep.end.col}:{whole.end.row}:{whole.end.col}" if {
+	keep := util.to_location_no_text(expr.terms.lhs[0].location)
+	whole := util.to_location_no_text(expr.location)
+}
+
+_collapse_location(expr, "lhs") := $"{whole.row}:{whole.col}:{keep.row}:{keep.col}" if {
+	keep := util.to_location_no_text(expr.terms.rhs[0].location)
+	whole := util.to_location_no_text(expr.location)
+}
+
+# METADATA
+# description: |
+#   true if the operand on 'side' is a single expression that isn't brace enclosed, and so
+#   can replace the `and`/`or` expression it's part of
+_stands_alone(terms, side) if {
+	count(terms[side]) == 1
+
+	not terms[$"explicit_{side}"]
 }

--- a/bundle/regal/rules/bugs/constant-condition/constant_condition_test.rego
+++ b/bundle/regal/rules/bugs/constant-condition/constant_condition_test.rego
@@ -184,7 +184,7 @@ test_success_adding_constant_to_set if {
 	r == set()
 }
 
-test_success_constant_and_or_operand if {
+test_fail_constant_and_or_operand if {
 	r := rule.report with input as ast.policy(`import future.keywords.and
 	import future.keywords.or
 
@@ -192,6 +192,82 @@ test_success_constant_and_or_operand if {
 		input.a and 1
 		input.b or "str"
 		input.c and 1 == 1
+	}`)
+
+	# the reported range covers the operator as well, as removing it is what
+	# collapses the expression to its remaining operand
+	locations := {[violation.location.row, violation.location.col, violation.location.end.col] | some violation in r}
+
+	locations == {[7, 10, 16], [8, 10, 19], [9, 10, 21]}
+	count(r) == 3
+}
+
+test_fail_constant_operand_reported_with_operator_range if {
+	r := rule.report with input as ast.policy(`import future.keywords.and
+
+	allow if input.a and 1`)
+
+	r == {{
+		"category": "bugs",
+		"description": "Constant condition",
+		"location": {
+			"col": 18,
+			"file": "policy.rego",
+			"row": 5,
+			"text": "\tallow if input.a and 1",
+			"end": {
+				"row": 5,
+				"col": 24,
+			},
+		},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": "https://www.openpolicyagent.org/projects/regal/rules/bugs/constant-condition",
+		}],
+		"title": "constant-condition",
+		"level": "error",
+	}}
+}
+
+test_fail_constant_operand_of_nested_logical_expr if {
+	r := rule.report with input as ast.policy(`import future.keywords.and
+
+	allow if input.a and 1 and input.b`)
+
+	locations := {[violation.location.row, violation.location.col, violation.location.end.col] | some violation in r}
+
+	# only ` and 1` of the nested `input.a and 1` expression is reported
+	locations == {[5, 18, 24]}
+}
+
+test_fail_brace_enclosed_and_nested_constant_operand if {
+	r := rule.report with input as ast.policy(`import future.keywords.and
+	import future.keywords.or
+
+	allow if {
+		input.a and { 1 }
+		{ 1 } or input.b
+		1 and 2 and input.c
+	}`)
+
+	locations := {[violation.location.row, violation.location.col, violation.location.end.col] | some violation in r}
+
+	# the braces of a brace enclosed operand are part of the reported range, and
+	# a nested `and`/`or` expression is reported as one operand when constant
+	locations == {[7, 10, 20], [8, 3, 12], [9, 3, 15]}
+	count(r) == 3
+}
+
+test_success_constant_operand_where_other_operand_cant_stand_alone if {
+	# the `1` is left alone here, as the operand kept can't make up an expression
+	# of its own, and so there's no way of collapsing the expression
+	r := rule.report with input as ast.policy(`import future.keywords.and
+
+	allow if {
+		{
+			input.a
+			input.b
+		} and 1
 	}`)
 
 	r == set()
@@ -230,7 +306,7 @@ test_fail_constant_condition_in_body_of_and_operand if {
 	}}
 }
 
-test_success_logical_expr_with_non_constant_operand if {
+test_fail_constant_operand_variations if {
 	r := rule.report with input as ast.policy(`import future.keywords.and
 	import future.keywords.or
 
@@ -242,6 +318,25 @@ test_success_logical_expr_with_non_constant_operand if {
 			x := 1
 			x == 1
 		} or 2
+	}`)
+
+	locations := {[violation.location.row, violation.location.col, violation.location.end.col] | some violation in r}
+
+	locations == {[7, 3, 8], [8, 10, 20], [9, 15, 20]}
+	count(r) == 3
+}
+
+test_success_logical_expr_without_constant_operand if {
+	r := rule.report with input as ast.policy(`import future.keywords.and
+	import future.keywords.or
+
+	allow if {
+		input.a and input.b
+		input.c or count(input.d) > 1
+		{
+			x := input.e
+			x == input.f
+		} or input.g
 	}`)
 
 	r == set()

--- a/docs/rules/bugs/constant-condition.md
+++ b/docs/rules/bugs/constant-condition.md
@@ -27,9 +27,11 @@ allow := true
 While most often a mistake, constant conditions are sometimes used as placeholders, or "TODO logic". While this is
 harmless, it has no place in production policy, and should be replaced or removed before deployment.
 
-Note that an operand of an `and`/`or` expression is only reported when the *whole* expression is constant, as in
-`1 or 2`. A constant operand of an otherwise meaningful expression — like the `1` in `input.a and 1` — is left alone,
-since removing it would leave the enclosing expression without an operand.
+Constant operands of `and`/`or` expressions are reported as well. An expression that is constant in its entirety,
+like `1 or 2`, is removed when fixed, while one where only a single operand is constant is collapsed to the operand
+kept, so that `input.a and 1` becomes `input.a`. The exception is when the operand kept can't make up an expression
+of its own, as brace enclosed and multi expression operands can't. There's no way of collapsing
+`{ input.a; input.b } and 1`, so the constant operand of an expression like that is left alone.
 
 ## Configuration Options
 

--- a/pkg/fixer/fixes/constantcondition_test.go
+++ b/pkg/fixer/fixes/constantcondition_test.go
@@ -141,6 +141,35 @@ allow if {
 			fixExpected:     true,
 			contentAfterFix: "package test\n\nallow if {\n\t\n\tinput.x\n}",
 		},
+		"collapse logical expression to remaining operand": {
+			fc: &FixCandidate{
+				Filename: "test.rego",
+				Contents: `package test
+
+import future.keywords.and
+
+allow if {
+	input.a and 1
+}`,
+			},
+			runtimeOptions: &RuntimeOptions{
+				Locations: []report.Location{
+					{
+						Row: 6, Column: 9, End: &report.Position{
+							Row: 6, Column: 15,
+						},
+					},
+				},
+			},
+			fixExpected: true,
+			contentAfterFix: `package test
+
+import future.keywords.and
+
+allow if {
+	input.a
+}`,
+		},
 		"many changes": {
 			fc: &FixCandidate{
 				Filename: "test.rego",


### PR DESCRIPTION
fix: #2076

Report the constant operand of an `and`/`or` expression with a range covering the operator too, so that removing it collapses the expression to the operand kept, unless that operand can't stand on its own.